### PR TITLE
Add backup drive repair flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+Always sprinkle comments about things we might forget in a few months, or that might not immediately seem obvious on a first read.
+
+Double check about documentation that might be related to whatever you are implementing, along with the related links to the index.html file. You are encouraged to rewrite and refactor the documentation whenever it does not make sense to match the behavior seen in code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 Always sprinkle comments about things we might forget in a few months, or that might not immediately seem obvious on a first read.
 
+---
+
 Double check about documentation that might be related to whatever you are implementing, along with the related links to the index.html file. You are encouraged to rewrite and refactor the documentation whenever it does not make sense to match the behavior seen in code.
 
 When writing comments and documentation, don't write it assuming the person reading it has seen the previous version of the code or comments. For example don't do something like
@@ -10,3 +12,7 @@ When writing comments and documentation, don't write it assuming the person read
 instead just do
 
 # this does x
+
+---
+
+Prefer refactoring code if the end result will mean that the code will be simpler, more effective, and easier to maintain, rather than sticking to existing conventions, even if it means more work in the short term

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,12 @@
 Always sprinkle comments about things we might forget in a few months, or that might not immediately seem obvious on a first read.
 
 Double check about documentation that might be related to whatever you are implementing, along with the related links to the index.html file. You are encouraged to rewrite and refactor the documentation whenever it does not make sense to match the behavior seen in code.
+
+When writing comments and documentation, don't write it assuming the person reading it has seen the previous version of the code or comments. For example don't do something like
+
+# previously this did x
+# now it does y
+
+instead just do
+
+# this does x

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ curl -fsSL https://sss.chrismin13.com/install.sh | sudo bash
 ```
 
 - This script will install all dependencies, set up the service, and print your Web UI address.
+- The management Web UI is admin-only. The first account created during setup becomes the initial administrator.
 - For more details and documentation, visit the [landing page](https://sss.chrismin13.com).
 - For manual installation, see the [Manual Installation Guide](docs/manual_install.md).
 
@@ -45,6 +46,7 @@ bash install_dev.sh --with-ml
 
 This project includes detailed documentation for each main feature and page. See the following files for step-by-step guides and explanations:
 
+- [access.md](docs/access.md)
 - [manual_install.md](docs/manual_install.md)
 - [setup.md](docs/setup.md)
 - [login.md](docs/login.md)

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import json
 import os
 import queue
 import threading
+from dashboard_messages import build_dashboard_unmount_success_message
 from backup_drive_setup import (
     BackupDriveSetupError,
     apply_backup_drive_configuration,
@@ -562,6 +563,13 @@ def run_task(task_name):
         return jsonify({"success": False, "message": str(e)}), 500
 
 
+def _get_check_mount_next_run():
+    check_mount_task = get_task('Check Mount')
+    if not check_mount_task:
+        return None
+    return check_mount_task.next_run
+
+
 # API route for unmounting storage
 @app.route("/unmount", methods=["POST"])
 @login_required
@@ -571,7 +579,15 @@ def unmount():
         if runtime.is_fake:
             fake_state.set_mount(False)
             fake_state.append_task_log('Check Mount', f'Backup source disconnected from {mount_point}.')
-            return jsonify({"success": True, "message": "Local backup source disconnected."})
+            return jsonify({
+                "success": True,
+                "message": build_dashboard_unmount_success_message(
+                    'Local backup source disconnected.',
+                    _get_check_mount_next_run(),
+                    availability_phrase='stays available',
+                    remount_verb='reconnect',
+                ),
+            })
 
         # 1. Disconnect all SMB users (if possible)
         try:
@@ -604,7 +620,13 @@ def unmount():
             subprocess.run(["sudo", "systemctl", "start", "nmbd"], check=False)
         except Exception:
             pass
-        return jsonify({"success": True, "message": "Drive unmounted and powered down. It is now safe to remove the drive."})
+        return jsonify({
+            "success": True,
+            "message": build_dashboard_unmount_success_message(
+                'Drive unmounted and powered down. It is now safe to remove the drive.',
+                _get_check_mount_next_run(),
+            ),
+        })
     except subprocess.CalledProcessError as e:
         return jsonify({"success": False, "message": f"Failed to unmount drive: {e}"}), 500
     except Exception as e:

--- a/app.py
+++ b/app.py
@@ -1511,7 +1511,7 @@ def api_backup_drive_unmount():
         message = unmount_selected_drive(data.get('drive'), runtime=runtime)
         return jsonify({'success': True, 'message': message})
     except BackupDriveSetupError as e:
-        return jsonify({'success': False, 'error': str(e)})
+        return jsonify({'success': False, 'error': str(e), 'details': e.details})
     except Exception as e:
         current_app.logger.error(f"Error unmounting backup drive: {e}")
         return jsonify({'success': False, 'error': 'Could not unmount the selected drive.'})
@@ -1533,7 +1533,7 @@ def api_backup_drive_configure():
         )
         return jsonify({'success': True, 'result': result})
     except BackupDriveSetupError as e:
-        return jsonify({'success': False, 'error': str(e)})
+        return jsonify({'success': False, 'error': str(e), 'details': e.details})
     except Exception as e:
         current_app.logger.error(f"Error configuring backup drive: {e}")
         return jsonify({'success': False, 'error': 'Could not configure the backup drive.'})

--- a/app.py
+++ b/app.py
@@ -1510,7 +1510,7 @@ def api_tasks_schedule():
 @api_admin_required
 def api_backup_drive_drives():
     try:
-        return jsonify({'success': True, 'drives': list_available_drives(runtime=runtime)})
+        return jsonify({'success': True, 'drives': list_available_drives(runtime=runtime, ntfs_only=True)})
     except Exception as e:
         current_app.logger.error(f"Error listing backup drives: {e}")
         return jsonify({'success': False, 'error': str(e)})

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ from backup_drive_setup import (
     BackupDriveSetupError,
     apply_backup_drive_configuration,
     list_available_drives,
-    unmount_selected_drive,
+    unmount_selected_partition,
 )
 from config_manager import ConfigManager
 from drive_health import (
@@ -1522,7 +1522,7 @@ def api_backup_drive_drives():
 def api_backup_drive_unmount():
     try:
         data = request.get_json() or {}
-        message = unmount_selected_drive(data.get('drive'), runtime=runtime)
+        message = unmount_selected_partition(data.get('partition'), runtime=runtime)
         return jsonify({'success': True, 'message': message})
     except BackupDriveSetupError as e:
         return jsonify({'success': False, 'error': str(e), 'details': e.details})
@@ -1538,7 +1538,7 @@ def api_backup_drive_configure():
     try:
         data = request.get_json() or {}
         result = apply_backup_drive_configuration(
-            data.get('drive'),
+            data.get('partition'),
             data.get('mount_point'),
             # Rerun setup always refreshes the managed fstab entry with the
             # boot-safe defaults,nofail policy. The UI intentionally exposes no

--- a/app.py
+++ b/app.py
@@ -13,6 +13,10 @@ from backup_drive_setup import (
     list_available_drives,
     unmount_selected_partition,
 )
+from backup_drive_unmount import (
+    is_selected_partition_managed_backup_drive,
+    unmount_managed_backup_drive,
+)
 from config_manager import ConfigManager
 from drive_health import (
     SMARTCTL_JSON_UPGRADE_MESSAGE,
@@ -575,6 +579,7 @@ def _get_check_mount_next_run():
 @login_required
 def unmount():
     mount_point = config_manager.get_value('backup', 'mount_point', runtime.default_mount_point)
+    configured_uuid = config_manager.get_value('backup', 'uuid', None)
     try:
         if runtime.is_fake:
             fake_state.set_mount(False)
@@ -589,37 +594,13 @@ def unmount():
                 ),
             })
 
-        # 1. Disconnect all SMB users (if possible)
-        try:
-            subprocess.run(["sudo", "smbcontrol", "all", "close-share", mount_point], check=False)
-        except Exception:
-            pass  # Ignore errors, just try to close sessions
-        # 2. Stop all systemd tasks
-        for service in ["check_mount.service", "check_health.service", "backup_cloud.service"]:
-            subprocess.run(["sudo", "systemctl", "stop", service], check=False)
-        # 3. Stop smbd and nmbd
-        subprocess.run(["sudo", "systemctl", "stop", "smbd"], check=False)
-        subprocess.run(["sudo", "systemctl", "stop", "nmbd"], check=False)
-        # 4. Unmount the drive
-        subprocess.run(["sudo", "umount", mount_point], check=True)
-        # 5. Power down the drive (try hdparm, ignore errors if not supported)
-        try:
-            uuid = config_manager.get_value('backup', 'uuid', None)
-            if uuid:
-                blkid_out = subprocess.run(['blkid', '-t', f'UUID={uuid}', '-o', 'device'], capture_output=True, text=True)
-                partition_device = blkid_out.stdout.strip()
-                if partition_device:
-                    parent_device = system_utils.get_parent_device(partition_device)
-                    if parent_device:
-                        subprocess.run(["sudo", "hdparm", "-y", parent_device], check=False)
-        except Exception:
-            pass
-        # 6. Start smbd and nmbd again so network file sharing is available
-        try:
-            subprocess.run(["sudo", "systemctl", "start", "smbd"], check=False)
-            subprocess.run(["sudo", "systemctl", "start", "nmbd"], check=False)
-        except Exception:
-            pass
+        unmount_managed_backup_drive(
+            mount_point,
+            configured_uuid,
+            system_utils,
+            runtime=runtime,
+            power_down=True,
+        )
         return jsonify({
             "success": True,
             "message": build_dashboard_unmount_success_message(
@@ -627,8 +608,8 @@ def unmount():
                 _get_check_mount_next_run(),
             ),
         })
-    except subprocess.CalledProcessError as e:
-        return jsonify({"success": False, "message": f"Failed to unmount drive: {e}"}), 500
+    except BackupDriveSetupError as e:
+        return jsonify({"success": False, "message": str(e)}), 500
     except Exception as e:
         return jsonify({"success": False, "message": f"Unexpected error: {e}"}), 500
 
@@ -1544,7 +1525,30 @@ def api_backup_drive_drives():
 def api_backup_drive_unmount():
     try:
         data = request.get_json() or {}
-        message = unmount_selected_partition(data.get('partition'), runtime=runtime)
+        partition = data.get('partition')
+        configured_mount_point = config_manager.get_value('backup', 'mount_point', runtime.default_mount_point)
+        configured_uuid = config_manager.get_value('backup', 'uuid', '')
+
+        if is_selected_partition_managed_backup_drive(
+            partition,
+            configured_mount_point,
+            configured_uuid,
+            system_utils,
+            runtime=runtime,
+        ):
+            unmount_managed_backup_drive(
+                configured_mount_point,
+                configured_uuid,
+                system_utils,
+                runtime=runtime,
+                power_down=False,
+            )
+            message = build_dashboard_unmount_success_message(
+                'Configured backup drive unmounted so backup drive setup can continue.',
+                _get_check_mount_next_run(),
+            )
+        else:
+            message = unmount_selected_partition(partition, runtime=runtime)
         return jsonify({'success': True, 'message': message})
     except BackupDriveSetupError as e:
         return jsonify({'success': False, 'error': str(e), 'details': e.details})

--- a/app.py
+++ b/app.py
@@ -6,6 +6,12 @@ import json
 import os
 import queue
 import threading
+from backup_drive_setup import (
+    BackupDriveSetupError,
+    apply_backup_drive_configuration,
+    list_available_drives,
+    unmount_selected_drive,
+)
 from config_manager import ConfigManager
 from drive_health import (
     SMART_FIELDS,
@@ -655,6 +661,7 @@ def drives():
         'uuid': config_manager.get_value('backup', 'uuid', ''),
         'usb_id': config_manager.get_value('backup', 'usb_id', ''),
     }
+    can_manage_backup_drive = user_manager.is_admin(session.get('username'))
 
     if request.method == "POST":
         form_action = request.form.get("form_action", "run_health_check")
@@ -677,28 +684,6 @@ def drives():
                 settings_message = "HDSentinel settings saved successfully."
             except Exception as exc:
                 settings_error = f"Failed to save HDSentinel settings: {exc}"
-        elif form_action == "save_drive_identifiers":
-            mount_point = request.form.get("mount_point", "").strip()
-            uuid = request.form.get("uuid", "").strip()
-            usb_id = request.form.get("usb_id", "").strip()
-
-            if not mount_point:
-                settings_error = "Mount point is required."
-            elif not uuid:
-                settings_error = "Drive UUID is required."
-            else:
-                try:
-                    config_manager.set_value('backup', 'mount_point', mount_point)
-                    config_manager.set_value('backup', 'uuid', uuid)
-                    config_manager.set_value('backup', 'usb_id', usb_id)
-                    drive_config = {
-                        'mount_point': mount_point,
-                        'uuid': uuid,
-                        'usb_id': usb_id,
-                    }
-                    settings_message = "Backup drive identification saved successfully."
-                except Exception as exc:
-                    settings_error = f"Failed to save backup drive identification: {exc}"
         else:
             smart, missing_attrs = get_smart_attributes(
                 config_manager,
@@ -734,6 +719,7 @@ def drives():
         hdsentinel_settings=hdsentinel_settings,
         hdsentinel_snapshot=hdsentinel_snapshot,
         drive_config=drive_config,
+        can_manage_backup_drive=can_manage_backup_drive,
         settings_message=settings_message,
         settings_error=settings_error,
     )
@@ -1503,6 +1489,54 @@ def api_tasks_schedule():
         return jsonify({'tasks': tasks})
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/backup_drive/drives', methods=['GET'])
+@login_required
+@admin_required
+def api_backup_drive_drives():
+    try:
+        return jsonify({'success': True, 'drives': list_available_drives(runtime=runtime)})
+    except Exception as e:
+        current_app.logger.error(f"Error listing backup drives: {e}")
+        return jsonify({'success': False, 'error': str(e)})
+
+
+@app.route('/api/backup_drive/unmount', methods=['POST'])
+@login_required
+@admin_required
+def api_backup_drive_unmount():
+    try:
+        data = request.get_json() or {}
+        message = unmount_selected_drive(data.get('drive'), runtime=runtime)
+        return jsonify({'success': True, 'message': message})
+    except BackupDriveSetupError as e:
+        return jsonify({'success': False, 'error': str(e)})
+    except Exception as e:
+        current_app.logger.error(f"Error unmounting backup drive: {e}")
+        return jsonify({'success': False, 'error': 'Could not unmount the selected drive.'})
+
+
+@app.route('/api/backup_drive/configure', methods=['POST'])
+@login_required
+@admin_required
+def api_backup_drive_configure():
+    try:
+        data = request.get_json() or {}
+        result = apply_backup_drive_configuration(
+            data.get('drive'),
+            data.get('mount_point'),
+            data.get('auto_mount', True),
+            config_manager,
+            smb_manager,
+            runtime=runtime,
+        )
+        return jsonify({'success': True, 'result': result})
+    except BackupDriveSetupError as e:
+        return jsonify({'success': False, 'error': str(e)})
+    except Exception as e:
+        current_app.logger.error(f"Error configuring backup drive: {e}")
+        return jsonify({'success': False, 'error': 'Could not configure the backup drive.'})
 
 @app.route('/api/cloud_backup/config', methods=['GET'])
 @login_required

--- a/app.py
+++ b/app.py
@@ -741,6 +741,8 @@ def drives():
 def download_telemetry():
     if runtime.telemetry_path.exists():
         return send_file(runtime.telemetry_path, as_attachment=True)
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        return jsonify({"success": False, "error": "Telemetry has not been generated yet. Run a health check first."}), 404
     abort(404)
 
 

--- a/app.py
+++ b/app.py
@@ -666,7 +666,6 @@ def drives():
         'uuid': config_manager.get_value('backup', 'uuid', ''),
         'usb_id': config_manager.get_value('backup', 'usb_id', ''),
     }
-    can_manage_backup_drive = user_manager.is_admin(session.get('username'))
 
     smart_support_warning = None
     if not runtime.is_fake:
@@ -722,6 +721,9 @@ def drives():
                     runtime=runtime,
                 )
 
+    # The normal web UI login path is admin-only, and the backup-drive APIs
+    # still enforce admin on every request. Keep this section visible here so
+    # the first post-setup session cannot be tripped up by stale user state.
     return render_template(
         "drive_health.html",
         smart=smart,
@@ -733,7 +735,6 @@ def drives():
         hdsentinel_settings=hdsentinel_settings,
         hdsentinel_snapshot=hdsentinel_snapshot,
         drive_config=drive_config,
-        can_manage_backup_drive=can_manage_backup_drive,
         smart_support_warning=smart_support_warning,
         settings_message=settings_message,
         settings_error=settings_error,

--- a/app.py
+++ b/app.py
@@ -14,12 +14,14 @@ from backup_drive_setup import (
 )
 from config_manager import ConfigManager
 from drive_health import (
+    SMARTCTL_JSON_UPGRADE_MESSAGE,
     SMART_FIELDS,
     append_telemetry,
     collect_hdsentinel_snapshot,
     get_hdsentinel_display_snapshot,
     get_hdsentinel_settings,
     get_optimal_threshold,
+    get_smartctl_json_support,
     get_smart_attributes,
     predict_failure_probability,
     run_scheduled_drive_health_check,
@@ -663,6 +665,11 @@ def drives():
     }
     can_manage_backup_drive = user_manager.is_admin(session.get('username'))
 
+    smart_support_warning = None
+    smartctl_json_supported, smartctl_json_error = get_smartctl_json_support()
+    if not smartctl_json_supported:
+        smart_support_warning = smartctl_json_error
+
     if request.method == "POST":
         form_action = request.form.get("form_action", "run_health_check")
         if form_action == "save_hdsentinel_settings":
@@ -685,13 +692,16 @@ def drives():
             except Exception as exc:
                 settings_error = f"Failed to save HDSentinel settings: {exc}"
         else:
-            smart, missing_attrs = get_smart_attributes(
+            smart, missing_attrs, smart_error = get_smart_attributes(
                 config_manager,
                 system_utils,
                 runtime=runtime,
             )
             if smart is None:
-                error = "Could not retrieve SMART data"
+                if smart_error == SMARTCTL_JSON_UPGRADE_MESSAGE:
+                    smart_support_warning = smart_error
+                else:
+                    error = smart_error or "Could not retrieve SMART data"
             else:
                 prob = predict_failure_probability(smart, runtime=runtime)
                 if prob is not None:
@@ -720,6 +730,7 @@ def drives():
         hdsentinel_snapshot=hdsentinel_snapshot,
         drive_config=drive_config,
         can_manage_backup_drive=can_manage_backup_drive,
+        smart_support_warning=smart_support_warning,
         settings_message=settings_message,
         settings_error=settings_error,
     )
@@ -1380,9 +1391,9 @@ def api_storage_status():
 @login_required
 def api_drive_health_summary():
     try:
-        smart, missing_attrs = get_smart_attributes(config_manager, system_utils, runtime=runtime)
+        smart, missing_attrs, smart_error = get_smart_attributes(config_manager, system_utils, runtime=runtime)
         if smart is None:
-            return jsonify({'status': 'unknown', 'probability': None, 'temperature': None})
+            return jsonify({'status': 'unknown', 'probability': None, 'temperature': None, 'error': smart_error})
         prob = predict_failure_probability(smart, runtime=runtime)
         if prob is not None:
             temperature = smart.get('smart_194_raw', None)

--- a/app.py
+++ b/app.py
@@ -1540,7 +1540,10 @@ def api_backup_drive_configure():
         result = apply_backup_drive_configuration(
             data.get('drive'),
             data.get('mount_point'),
-            data.get('auto_mount', True),
+            # Rerun setup always refreshes the managed fstab entry with the
+            # boot-safe defaults,nofail policy. The UI intentionally exposes no
+            # opt-out here.
+            True,
             config_manager,
             smb_manager,
             runtime=runtime,

--- a/app.py
+++ b/app.py
@@ -666,9 +666,10 @@ def drives():
     can_manage_backup_drive = user_manager.is_admin(session.get('username'))
 
     smart_support_warning = None
-    smartctl_json_supported, smartctl_json_error = get_smartctl_json_support()
-    if not smartctl_json_supported:
-        smart_support_warning = smartctl_json_error
+    if not runtime.is_fake:
+        smartctl_json_supported, smartctl_json_error = get_smartctl_json_support()
+        if not smartctl_json_supported:
+            smart_support_warning = smartctl_json_error
 
     if request.method == "POST":
         form_action = request.form.get("form_action", "run_health_check")

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ from drive_health import (
 )
 from setup_wizard import setup, install_systemd_tasks
 import logging
-from user_manager import UserManager, login_required, admin_required
+from user_manager import UserManager, login_required, admin_required, api_login_required, api_admin_required
 from flask_socketio import SocketIO
 from logging.handlers import RotatingFileHandler
 import sys
@@ -1492,8 +1492,8 @@ def api_tasks_schedule():
 
 
 @app.route('/api/backup_drive/drives', methods=['GET'])
-@login_required
-@admin_required
+@api_login_required
+@api_admin_required
 def api_backup_drive_drives():
     try:
         return jsonify({'success': True, 'drives': list_available_drives(runtime=runtime)})
@@ -1503,8 +1503,8 @@ def api_backup_drive_drives():
 
 
 @app.route('/api/backup_drive/unmount', methods=['POST'])
-@login_required
-@admin_required
+@api_login_required
+@api_admin_required
 def api_backup_drive_unmount():
     try:
         data = request.get_json() or {}
@@ -1518,8 +1518,8 @@ def api_backup_drive_unmount():
 
 
 @app.route('/api/backup_drive/configure', methods=['POST'])
-@login_required
-@admin_required
+@api_login_required
+@api_admin_required
 def api_backup_drive_configure():
     try:
         data = request.get_json() or {}

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -1,4 +1,5 @@
 import logging
+import json
 import os
 import re
 import shutil
@@ -32,7 +33,13 @@ def _is_managed_fstab_line(line):
     stripped = line.strip()
     if not stripped or stripped.startswith('#'):
         return False
-    return LEGACY_FSTAB_MARKER in line
+    if '#' not in line:
+        return False
+    marker = line.split('#', 1)[1].strip()
+    return marker in {
+        FSTAB_MARKER.lstrip('# ').strip(),
+        LEGACY_FSTAB_MARKER,
+    }
 
 
 def _parse_fstab_entry(line):
@@ -207,62 +214,65 @@ def list_available_drives(runtime=None):
         return fake_state.get_virtual_drives()
 
     lsblk_result = subprocess.run(
-        ['lsblk', '-f', '-o', 'NAME,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'],
+        ['lsblk', '-J', '-o', 'PATH,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'],
         capture_output=True,
         text=True,
     )
     if lsblk_result.returncode != 0:
         raise BackupDriveSetupError('Failed to list drives.')
 
-    root_mount = subprocess.run(['mount | grep "on / "'], shell=True, capture_output=True, text=True)
-    system_drive = root_mount.stdout.split()[0] if root_mount.returncode == 0 and root_mount.stdout.split() else None
+    try:
+        lsblk_data = json.loads(lsblk_result.stdout)
+    except Exception as exc:
+        raise BackupDriveSetupError('Failed to parse drive list.') from exc
+
+    root_mount = subprocess.run(['findmnt', '-n', '-o', 'SOURCE', '/'], capture_output=True, text=True)
+    system_drive = root_mount.stdout.strip() if root_mount.returncode == 0 else None
 
     drives = []
-    current_drive = None
-    for line in lsblk_result.stdout.splitlines()[1:]:
-        parts = line.split()
-        if not parts:
+    for block in lsblk_data.get('blockdevices', []):
+        if block.get('type') != 'disk':
             continue
 
-        name = parts[0]
-        if name.startswith('├─') or name.startswith('└─'):
-            if current_drive:
-                current_drive['partitions'].append({
-                    'path': '/dev/{}'.format(name[2:]),
-                    'type': parts[1] if len(parts) > 1 else 'unknown',
-                    'label': parts[2] if len(parts) > 2 else '',
-                    'size': parts[3] if len(parts) > 3 else '',
-                    'mountpoint': parts[4] if len(parts) > 4 else '',
-                })
+        disk_path = block.get('path')
+        if not disk_path:
             continue
 
-        if current_drive and current_drive['type'] in ['disk', 'usb'] and current_drive['path'] != system_drive:
-            drives.append(current_drive)
+        if system_drive and system_drive.startswith(disk_path):
+            continue
 
-        udev_result = subprocess.run(
-            ['udevadm', 'info', '--query=property', '/dev/{}'.format(name)],
-            capture_output=True,
-            text=True,
-        )
-        model = 'Unknown Drive'
-        drive_type = 'unknown'
-        if udev_result.returncode == 0:
-            for udev_line in udev_result.stdout.splitlines():
-                if udev_line.startswith('ID_MODEL='):
-                    model = udev_line.split('=', 1)[1].strip()
-                elif udev_line.startswith('ID_TYPE='):
-                    drive_type = udev_line.split('=', 1)[1].strip()
+        partitions = []
+        for child in block.get('children', []) or []:
+            child_path = child.get('path')
+            if not child_path:
+                continue
+            partitions.append({
+                'path': child_path,
+                'type': child.get('fstype') or child.get('type') or 'unknown',
+                'label': child.get('label') or '',
+                'size': child.get('size') or '',
+                'mountpoint': child.get('mountpoint') or '',
+            })
 
-        current_drive = {
-            'path': '/dev/{}'.format(name),
-            'model': model,
-            'size': parts[3] if len(parts) > 3 else '',
-            'type': drive_type,
-            'partitions': [],
-        }
+        if not partitions and (block.get('fstype') or block.get('mountpoint')):
+            partitions.append({
+                'path': disk_path,
+                'type': block.get('fstype') or block.get('type') or 'unknown',
+                'label': block.get('label') or '',
+                'size': block.get('size') or '',
+                'mountpoint': block.get('mountpoint') or '',
+            })
 
-    if current_drive and current_drive['type'] in ['disk', 'usb'] and current_drive['path'] != system_drive:
-        drives.append(current_drive)
+        if not partitions:
+            continue
+
+        drives.append({
+            'path': disk_path,
+            'model': (block.get('model') or 'Unknown Drive').strip() or 'Unknown Drive',
+            'size': block.get('size') or '',
+            'type': block.get('type') or 'unknown',
+            'partitions': partitions,
+        })
 
     return drives
 

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -77,6 +77,30 @@ def _is_ntfs_filesystem(filesystem_type):
     return (filesystem_type or '').strip().lower() in NTFS_FILESYSTEM_TYPES
 
 
+def _get_blkid_filesystem_type(device_path):
+    # lsblk can report a mounted ntfs-3g partition as "fuseblk", which tells
+    # us how it is mounted right now rather than what is on disk. For the
+    # NTFS-only picker we verify that narrower case with blkid so we do not
+    # accidentally treat every FUSE-backed block device as NTFS months later.
+    result = subprocess.run(
+        ['blkid', '-o', 'value', '-s', 'TYPE', device_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ''
+    return result.stdout.strip().lower()
+
+
+def _is_ntfs_scan_candidate(device_path, filesystem_type):
+    normalized_type = (filesystem_type or '').strip().lower()
+    if _is_ntfs_filesystem(normalized_type):
+        return True
+    if normalized_type != 'fuseblk':
+        return False
+    return _get_blkid_filesystem_type(device_path) == 'ntfs'
+
+
 def _normalize_device_path(device_path):
     device_path = (device_path or '').strip()
     if not device_path:
@@ -367,7 +391,7 @@ def list_available_drives(runtime=None, ntfs_only=False):
             if not child_path:
                 continue
             filesystem_type = child.get('fstype') or ''
-            if ntfs_only and not _is_ntfs_filesystem(filesystem_type):
+            if ntfs_only and not _is_ntfs_scan_candidate(child_path, filesystem_type):
                 continue
             partitions.append({
                 'path': child_path,
@@ -378,7 +402,7 @@ def list_available_drives(runtime=None, ntfs_only=False):
             })
 
         block_filesystem_type = block.get('fstype') or ''
-        if not partitions and _is_ntfs_filesystem(block_filesystem_type):
+        if not partitions and _is_ntfs_scan_candidate(disk_path, block_filesystem_type):
             partitions.append({
                 'path': disk_path,
                 'type': block_filesystem_type or block.get('type') or 'unknown',

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -1,0 +1,438 @@
+import logging
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from runtime import get_fake_state, get_runtime
+
+
+LOGGER = logging.getLogger(__name__)
+FSTAB_MARKER = "# SimpleSaferServer managed backup drive"
+LEGACY_FSTAB_MARKER = "SimpleSaferServer"
+
+
+class BackupDriveSetupError(Exception):
+    pass
+
+
+def _get_fstab_path(runtime=None, fstab_path=None):
+    runtime = runtime or get_runtime()
+    if fstab_path is not None:
+        return Path(fstab_path)
+    if runtime.is_fake:
+        return runtime.data_dir / 'fstab'
+    return Path('/etc/fstab')
+
+
+def _is_managed_fstab_line(line):
+    stripped = line.strip()
+    if not stripped or stripped.startswith('#'):
+        return False
+    return LEGACY_FSTAB_MARKER in line
+
+
+def _parse_fstab_entry(line):
+    stripped = line.strip()
+    if not stripped or stripped.startswith('#'):
+        return None
+
+    content = stripped.split('#', 1)[0].strip()
+    if not content:
+        return None
+
+    parts = re.split(r'\s+', content)
+    if len(parts) < 2:
+        return None
+
+    return {
+        'spec': parts[0],
+        'mount_point': parts[1],
+    }
+
+
+def _backup_file(path, runtime, prefix):
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    backup_dir = runtime.config_dir / 'backups'
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = backup_dir / '{}.{}'.format(prefix, timestamp)
+    shutil.copy2(path, backup_path)
+    return backup_path
+
+
+def _validate_fstab_file(path):
+    if shutil.which('findmnt'):
+        result = subprocess.run(
+            ['findmnt', '--verify', '--tab-file', str(path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, None
+        message = (result.stderr or result.stdout or 'findmnt validation failed').strip()
+        return False, message
+
+    if shutil.which('mount'):
+        result = subprocess.run(
+            ['mount', '-fav', '-T', str(path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, None
+        message = (result.stderr or result.stdout or 'mount validation failed').strip()
+        return False, message
+
+    return True, None
+
+
+def _render_managed_fstab_entry(uuid, mount_point):
+    return 'UUID={}\t\t{}\tntfs-3g\tdefaults,nofail\t0\t0 {}\n'.format(uuid, mount_point, FSTAB_MARKER)
+
+
+def update_managed_fstab(uuid, mount_point, auto_mount, runtime=None, fstab_path=None):
+    runtime = runtime or get_runtime()
+    path = _get_fstab_path(runtime, fstab_path=fstab_path)
+
+    if runtime.is_fake:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing = path.read_text().splitlines(True) if path.exists() else []
+    else:
+        existing = path.read_text().splitlines(True)
+
+    managed_lines = [line for line in existing if _is_managed_fstab_line(line)]
+    if len(managed_lines) > 1:
+        raise BackupDriveSetupError(
+            'Multiple SimpleSaferServer-managed /etc/fstab entries were found. Clean them up manually before rerunning drive setup.'
+        )
+
+    desired_spec = 'UUID={}'.format(uuid)
+    if auto_mount:
+        conflicts = []
+        for line in existing:
+            if _is_managed_fstab_line(line):
+                continue
+            entry = _parse_fstab_entry(line)
+            if not entry:
+                continue
+            if entry['mount_point'] == mount_point:
+                conflicts.append('mount point {}'.format(mount_point))
+            if entry['spec'] == desired_spec:
+                conflicts.append('UUID {}'.format(uuid))
+
+        if conflicts:
+            raise BackupDriveSetupError(
+                'An existing non-SimpleSaferServer /etc/fstab entry already uses {}. Resolve it manually before rerunning drive setup.'.format(
+                    ', '.join(sorted(set(conflicts)))
+                )
+            )
+
+    new_lines = []
+    managed_written = False
+    for line in existing:
+        if _is_managed_fstab_line(line):
+            if auto_mount:
+                new_lines.append(_render_managed_fstab_entry(uuid, mount_point))
+                managed_written = True
+            continue
+        new_lines.append(line)
+
+    if auto_mount and not managed_written:
+        if new_lines and not new_lines[-1].endswith('\n'):
+            new_lines[-1] = new_lines[-1] + '\n'
+        new_lines.append(_render_managed_fstab_entry(uuid, mount_point))
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile('w', delete=False, dir=str(path.parent), prefix='fstab-', suffix='.tmp') as handle:
+        handle.writelines(new_lines)
+        temp_path = Path(handle.name)
+
+    valid, validation_error = _validate_fstab_file(temp_path)
+    if not valid:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise BackupDriveSetupError('/etc/fstab validation failed: {}'.format(validation_error))
+
+    backup_path = None
+    if path.exists():
+        backup_path = _backup_file(path, runtime, 'fstab')
+    shutil.move(str(temp_path), str(path))
+    if not runtime.is_fake:
+        path.chmod(0o644)
+    return backup_path
+
+
+def restore_fstab_backup(backup_path, runtime=None, fstab_path=None):
+    runtime = runtime or get_runtime()
+    if not backup_path:
+        return
+    path = _get_fstab_path(runtime, fstab_path=fstab_path)
+    shutil.copy2(backup_path, path)
+
+
+def get_drive_uuid(drive):
+    result = subprocess.run(['blkid', '-s', 'UUID', '-o', 'value', drive], capture_output=True, text=True)
+    if result.returncode != 0 or not result.stdout.strip():
+        raise BackupDriveSetupError('Could not determine the UUID for {}.'.format(drive))
+    return result.stdout.strip()
+
+
+def get_drive_usb_id(drive):
+    try:
+        sys_block_path = '/sys/class/block/{}/device'.format(os.path.basename(drive))
+        parent = os.path.realpath(sys_block_path)
+        while parent != '/':
+            id_vendor_path = os.path.join(parent, 'idVendor')
+            id_product_path = os.path.join(parent, 'idProduct')
+            if os.path.isfile(id_vendor_path) and os.path.isfile(id_product_path):
+                with open(id_vendor_path) as vendor_file:
+                    vendor = vendor_file.read().strip()
+                with open(id_product_path) as product_file:
+                    product = product_file.read().strip()
+                return '{}:{}'.format(vendor, product)
+            parent = os.path.dirname(parent)
+    except Exception as exc:
+        LOGGER.warning('Failed to determine USB ID for %s: %s', drive, exc)
+    return ''
+
+
+def list_available_drives(runtime=None):
+    runtime = runtime or get_runtime()
+    fake_state = get_fake_state() if runtime.is_fake else None
+
+    if runtime.is_fake:
+        return fake_state.get_virtual_drives()
+
+    lsblk_result = subprocess.run(
+        ['lsblk', '-f', '-o', 'NAME,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'],
+        capture_output=True,
+        text=True,
+    )
+    if lsblk_result.returncode != 0:
+        raise BackupDriveSetupError('Failed to list drives.')
+
+    root_mount = subprocess.run(['mount | grep "on / "'], shell=True, capture_output=True, text=True)
+    system_drive = root_mount.stdout.split()[0] if root_mount.returncode == 0 and root_mount.stdout.split() else None
+
+    drives = []
+    current_drive = None
+    for line in lsblk_result.stdout.splitlines()[1:]:
+        parts = line.split()
+        if not parts:
+            continue
+
+        name = parts[0]
+        if name.startswith('├─') or name.startswith('└─'):
+            if current_drive:
+                current_drive['partitions'].append({
+                    'path': '/dev/{}'.format(name[2:]),
+                    'type': parts[1] if len(parts) > 1 else 'unknown',
+                    'label': parts[2] if len(parts) > 2 else '',
+                    'size': parts[3] if len(parts) > 3 else '',
+                    'mountpoint': parts[4] if len(parts) > 4 else '',
+                })
+            continue
+
+        if current_drive and current_drive['type'] in ['disk', 'usb'] and current_drive['path'] != system_drive:
+            drives.append(current_drive)
+
+        udev_result = subprocess.run(
+            ['udevadm', 'info', '--query=property', '/dev/{}'.format(name)],
+            capture_output=True,
+            text=True,
+        )
+        model = 'Unknown Drive'
+        drive_type = 'unknown'
+        if udev_result.returncode == 0:
+            for udev_line in udev_result.stdout.splitlines():
+                if udev_line.startswith('ID_MODEL='):
+                    model = udev_line.split('=', 1)[1].strip()
+                elif udev_line.startswith('ID_TYPE='):
+                    drive_type = udev_line.split('=', 1)[1].strip()
+
+        current_drive = {
+            'path': '/dev/{}'.format(name),
+            'model': model,
+            'size': parts[3] if len(parts) > 3 else '',
+            'type': drive_type,
+            'partitions': [],
+        }
+
+    if current_drive and current_drive['type'] in ['disk', 'usb'] and current_drive['path'] != system_drive:
+        drives.append(current_drive)
+
+    return drives
+
+
+def unmount_selected_drive(drive, runtime=None):
+    runtime = runtime or get_runtime()
+    fake_state = get_fake_state() if runtime.is_fake else None
+
+    if runtime.is_fake:
+        fake_state.set_mount(False)
+        return 'Fake backup source disconnected.'
+
+    if not drive:
+        raise BackupDriveSetupError('No drive selected.')
+
+    mount_check = subprocess.run(['mount'], capture_output=True, text=True)
+    mounted_partitions = []
+    for line in mount_check.stdout.splitlines():
+        if drive in line:
+            parts = line.split()
+            if len(parts) >= 3:
+                mounted_partitions.append({'device': parts[0], 'mount_point': parts[2]})
+
+    if not mounted_partitions:
+        raise BackupDriveSetupError('The selected drive is not currently mounted.')
+
+    failures = []
+    for partition in mounted_partitions:
+        result = subprocess.run(['umount', partition['device']], capture_output=True, text=True)
+        if result.returncode != 0:
+            failures.append('{}: {}'.format(
+                partition['device'],
+                result.stderr.strip() if result.stderr else 'unknown error',
+            ))
+
+    if failures:
+        raise BackupDriveSetupError('Failed to unmount partitions: {}'.format('; '.join(failures)))
+
+    return 'Successfully unmounted {} partition(s).'.format(len(mounted_partitions))
+
+
+def _sync_backup_share_path(smb_manager, new_path):
+    for share in smb_manager.get_shares():
+        if share.get('name') != 'backup':
+            continue
+        smb_manager.update_share(
+            old_name='backup',
+            new_name='backup',
+            path=new_path,
+            writable=share.get('writable', True),
+            comment=share.get('comment', ''),
+            valid_users=share.get('valid_users', []),
+        )
+        return True
+    return False
+
+
+def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_manager, smb_manager, runtime=None):
+    runtime = runtime or get_runtime()
+    fake_state = get_fake_state() if runtime.is_fake else None
+
+    mount_point = (mount_point or '').strip()
+    if not mount_point or not mount_point.startswith('/'):
+        raise BackupDriveSetupError('Mount point must be an absolute path.')
+
+    if runtime.is_fake:
+        selected_path = Path(os.path.abspath(mount_point or runtime.default_mount_point))
+        if not selected_path.exists():
+            try:
+                selected_path.relative_to(runtime.data_dir)
+                selected_path.mkdir(parents=True, exist_ok=True)
+            except ValueError:
+                raise BackupDriveSetupError(
+                    'In fake mode, choose an existing folder on this machine or a path inside .dev-data.'
+                )
+        if not selected_path.is_dir():
+            raise BackupDriveSetupError('Source path must be a directory.')
+
+        config_manager.set_value('backup', 'mount_point', str(selected_path))
+        config_manager.set_value('backup', 'uuid', 'FAKE-UUID-0001')
+        config_manager.set_value('backup', 'usb_id', 'FAKE:0001')
+        fake_state.set_mount(True, mount_point=str(selected_path), drive=drive or '/dev/fakebackup1')
+        return {
+            'message': 'Successfully selected local backup source at {}'.format(selected_path),
+            'uuid': 'FAKE-UUID-0001',
+            'usb_id': 'FAKE:0001',
+            'mount_point': str(selected_path),
+        }
+
+    if not drive:
+        raise BackupDriveSetupError('No drive selected.')
+
+    mount_check = subprocess.run(['mount'], capture_output=True, text=True)
+    for line in mount_check.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[0] == drive:
+            raise BackupDriveSetupError(
+                'The selected drive is already mounted at {}. Unmount it first before rerunning drive setup.'.format(parts[2])
+            )
+
+    uuid = get_drive_uuid(drive)
+    usb_id = get_drive_usb_id(drive)
+
+    previous_mount_point = config_manager.get_value('backup', 'mount_point', runtime.default_mount_point)
+    previous_uuid = config_manager.get_value('backup', 'uuid', '')
+    previous_usb_id = config_manager.get_value('backup', 'usb_id', '')
+
+    os.makedirs(mount_point, exist_ok=True)
+
+    mounted = False
+    fstab_backup = None
+    share_backup = None
+    config_updated = False
+
+    try:
+        fstab_backup = update_managed_fstab(uuid, mount_point, bool(auto_mount), runtime=runtime)
+
+        mount_result = subprocess.run(
+            ['ntfs-3g', drive, mount_point, '-o', 'rw,uid=1000,gid=1000'],
+            capture_output=True,
+            text=True,
+        )
+        if mount_result.returncode != 0:
+            error_msg = mount_result.stderr.strip() if mount_result.stderr else 'Unknown error occurred'
+            raise BackupDriveSetupError('Error mounting drive: {}'.format(error_msg))
+        mounted = True
+
+        backup_share = None
+        for share in smb_manager.get_shares():
+            if share.get('name') == 'backup':
+                backup_share = share
+                break
+
+        if backup_share and backup_share.get('path') != mount_point:
+            share_backup = backup_share
+            _sync_backup_share_path(smb_manager, mount_point)
+
+        config_manager.set_value('backup', 'mount_point', mount_point)
+        config_manager.set_value('backup', 'uuid', uuid)
+        config_manager.set_value('backup', 'usb_id', usb_id)
+        config_updated = True
+
+        return {
+            'message': 'Successfully configured {} at {}'.format(drive, mount_point),
+            'uuid': uuid,
+            'usb_id': usb_id,
+            'mount_point': mount_point,
+        }
+    except Exception:
+        if mounted:
+            subprocess.run(['umount', drive], check=False)
+        if fstab_backup:
+            restore_fstab_backup(fstab_backup, runtime=runtime)
+        if share_backup:
+            try:
+                smb_manager.update_share(
+                    old_name='backup',
+                    new_name='backup',
+                    path=share_backup.get('path', previous_mount_point),
+                    writable=share_backup.get('writable', True),
+                    comment=share_backup.get('comment', ''),
+                    valid_users=share_backup.get('valid_users', []),
+                )
+            except Exception as share_exc:
+                LOGGER.error('Failed to restore backup share after drive setup error: %s', share_exc)
+        if config_updated:
+            try:
+                config_manager.set_value('backup', 'mount_point', previous_mount_point)
+                config_manager.set_value('backup', 'uuid', previous_uuid)
+                config_manager.set_value('backup', 'usb_id', previous_usb_id)
+            except Exception as config_exc:
+                LOGGER.error('Failed to restore backup config after drive setup error: %s', config_exc)
+        raise

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -214,7 +214,7 @@ def list_available_drives(runtime=None):
         return fake_state.get_virtual_drives()
 
     lsblk_result = subprocess.run(
-        ['lsblk', '-J', '-o', 'PATH,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'],
+        ['lsblk', '-J', '-o', 'NAME,PATH,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'],
         capture_output=True,
         text=True,
     )

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -351,6 +351,10 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
     if not mount_point or not mount_point.startswith('/'):
         raise BackupDriveSetupError('Mount point must be an absolute path.')
 
+    previous_mount_point = config_manager.get_value('backup', 'mount_point', runtime.default_mount_point)
+    previous_uuid = config_manager.get_value('backup', 'uuid', '')
+    previous_usb_id = config_manager.get_value('backup', 'usb_id', '')
+
     if runtime.is_fake:
         selected_path = Path(os.path.abspath(mount_point or runtime.default_mount_point))
         if not selected_path.exists():
@@ -364,16 +368,60 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
         if not selected_path.is_dir():
             raise BackupDriveSetupError('Source path must be a directory.')
 
-        config_manager.set_value('backup', 'mount_point', str(selected_path))
-        config_manager.set_value('backup', 'uuid', 'FAKE-UUID-0001')
-        config_manager.set_value('backup', 'usb_id', 'FAKE:0001')
-        fake_state.set_mount(True, mount_point=str(selected_path), drive=drive or '/dev/fakebackup1')
-        return {
-            'message': 'Successfully selected local backup source at {}'.format(selected_path),
-            'uuid': 'FAKE-UUID-0001',
-            'usb_id': 'FAKE:0001',
-            'mount_point': str(selected_path),
-        }
+        uuid = 'FAKE-UUID-0001'
+        usb_id = 'FAKE:0001'
+        selected_path_str = str(selected_path)
+        fstab_backup = None
+        share_backup = None
+        config_updated = False
+
+        try:
+            fstab_backup = update_managed_fstab(uuid, selected_path_str, bool(auto_mount), runtime=runtime)
+
+            backup_share = None
+            for share in smb_manager.get_shares():
+                if share.get('name') == 'backup':
+                    backup_share = share
+                    break
+
+            if backup_share and backup_share.get('path') != selected_path_str:
+                share_backup = backup_share
+                _sync_backup_share_path(smb_manager, selected_path_str)
+
+            config_manager.set_value('backup', 'mount_point', selected_path_str)
+            config_manager.set_value('backup', 'uuid', uuid)
+            config_manager.set_value('backup', 'usb_id', usb_id)
+            config_updated = True
+            fake_state.set_mount(True, mount_point=selected_path_str, drive=drive or '/dev/fakebackup1')
+            return {
+                'message': 'Successfully selected local backup source at {}'.format(selected_path),
+                'uuid': uuid,
+                'usb_id': usb_id,
+                'mount_point': selected_path_str,
+            }
+        except Exception:
+            if fstab_backup:
+                restore_fstab_backup(fstab_backup, runtime=runtime)
+            if share_backup:
+                try:
+                    smb_manager.update_share(
+                        old_name='backup',
+                        new_name='backup',
+                        path=share_backup.get('path', previous_mount_point),
+                        writable=share_backup.get('writable', True),
+                        comment=share_backup.get('comment', ''),
+                        valid_users=share_backup.get('valid_users', []),
+                    )
+                except Exception as share_exc:
+                    LOGGER.error('Failed to restore fake backup share after drive setup error: %s', share_exc)
+            if config_updated:
+                try:
+                    config_manager.set_value('backup', 'mount_point', previous_mount_point)
+                    config_manager.set_value('backup', 'uuid', previous_uuid)
+                    config_manager.set_value('backup', 'usb_id', previous_usb_id)
+                except Exception as config_exc:
+                    LOGGER.error('Failed to restore fake backup config after drive setup error: %s', config_exc)
+            raise
 
     if not drive:
         raise BackupDriveSetupError('No drive selected.')
@@ -388,10 +436,6 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
 
     uuid = get_drive_uuid(drive)
     usb_id = get_drive_usb_id(drive)
-
-    previous_mount_point = config_manager.get_value('backup', 'mount_point', runtime.default_mount_point)
-    previous_uuid = config_manager.get_value('backup', 'uuid', '')
-    previous_usb_id = config_manager.get_value('backup', 'usb_id', '')
 
     os.makedirs(mount_point, exist_ok=True)
 

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -14,6 +14,7 @@ from runtime import get_fake_state, get_runtime
 LOGGER = logging.getLogger(__name__)
 FSTAB_MARKER = "# SimpleSaferServer managed backup drive"
 LEGACY_FSTAB_MARKER = "SimpleSaferServer"
+NTFS_FILESYSTEM_TYPES = {'ntfs', 'ntfs3', 'ntfs-3g'}
 
 
 class BackupDriveSetupError(Exception):
@@ -70,6 +71,22 @@ def _backup_file(path, runtime, prefix):
     backup_path = backup_dir / '{}.{}'.format(prefix, timestamp)
     shutil.copy2(path, backup_path)
     return backup_path
+
+
+def _is_ntfs_filesystem(filesystem_type):
+    return (filesystem_type or '').strip().lower() in NTFS_FILESYSTEM_TYPES
+
+
+def _get_partition_filesystem_type(drive):
+    lsblk_result = subprocess.run(
+        ['lsblk', '-no', 'FSTYPE', drive],
+        capture_output=True,
+        text=True,
+    )
+    if lsblk_result.returncode != 0:
+        error_msg = lsblk_result.stderr.strip() if lsblk_result.stderr else 'Unknown error occurred'
+        raise BackupDriveSetupError('Failed to determine the selected partition filesystem: {}'.format(error_msg))
+    return lsblk_result.stdout.strip()
 
 
 def _validate_fstab_file(path):
@@ -259,18 +276,22 @@ def list_available_drives(runtime=None):
             child_path = child.get('path')
             if not child_path:
                 continue
+            filesystem_type = child.get('fstype') or ''
+            if not _is_ntfs_filesystem(filesystem_type):
+                continue
             partitions.append({
                 'path': child_path,
-                'type': child.get('fstype') or child.get('type') or 'unknown',
+                'type': filesystem_type or child.get('type') or 'unknown',
                 'label': child.get('label') or '',
                 'size': child.get('size') or '',
                 'mountpoint': child.get('mountpoint') or '',
             })
 
-        if not partitions and (block.get('fstype') or block.get('mountpoint')):
+        block_filesystem_type = block.get('fstype') or ''
+        if not partitions and _is_ntfs_filesystem(block_filesystem_type):
             partitions.append({
                 'path': disk_path,
-                'type': block.get('fstype') or block.get('type') or 'unknown',
+                'type': block_filesystem_type or block.get('type') or 'unknown',
                 'label': block.get('label') or '',
                 'size': block.get('size') or '',
                 'mountpoint': block.get('mountpoint') or '',
@@ -304,10 +325,9 @@ def unmount_selected_drive(drive, runtime=None):
     mount_check = subprocess.run(['mount'], capture_output=True, text=True)
     mounted_partitions = []
     for line in mount_check.stdout.splitlines():
-        if drive in line:
-            parts = line.split()
-            if len(parts) >= 3:
-                mounted_partitions.append({'device': parts[0], 'mount_point': parts[2]})
+        parts = line.split()
+        if len(parts) >= 3 and parts[0] == drive:
+            mounted_partitions.append({'device': parts[0], 'mount_point': parts[2]})
 
     if not mounted_partitions:
         raise BackupDriveSetupError('The selected drive is not currently mounted.')
@@ -436,6 +456,9 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
 
     uuid = get_drive_uuid(drive)
     usb_id = get_drive_usb_id(drive)
+    filesystem_type = _get_partition_filesystem_type(drive)
+    if not _is_ntfs_filesystem(filesystem_type):
+        raise BackupDriveSetupError('The selected drive must be formatted as NTFS.')
 
     os.makedirs(mount_point, exist_ok=True)
 

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -73,18 +73,6 @@ def _backup_file(path, runtime, prefix):
 
 
 def _validate_fstab_file(path):
-    if shutil.which('findmnt'):
-        result = subprocess.run(
-            ['findmnt', '--verify', '--tab-file', str(path)],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            return True, None, None
-        summary = (result.stderr or result.stdout or 'findmnt validation failed').strip().splitlines()[0]
-        details = '\n'.join(part for part in [result.stdout.strip(), result.stderr.strip()] if part).strip()
-        return False, summary, details
-
     if shutil.which('mount'):
         result = subprocess.run(
             ['mount', '-fav', '-T', str(path)],
@@ -94,6 +82,18 @@ def _validate_fstab_file(path):
         if result.returncode == 0:
             return True, None, None
         summary = (result.stderr or result.stdout or 'mount validation failed').strip().splitlines()[0]
+        details = '\n'.join(part for part in [result.stdout.strip(), result.stderr.strip()] if part).strip()
+        return False, summary, details
+
+    if shutil.which('findmnt'):
+        result = subprocess.run(
+            ['findmnt', '--verify', '--tab-file', str(path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, None, None
+        summary = (result.stderr or result.stdout or 'findmnt validation failed').strip().splitlines()[0]
         details = '\n'.join(part for part in [result.stdout.strip(), result.stderr.strip()] if part).strip()
         return False, summary, details
 

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -77,24 +77,116 @@ def _is_ntfs_filesystem(filesystem_type):
     return (filesystem_type or '').strip().lower() in NTFS_FILESYSTEM_TYPES
 
 
-def _mount_belongs_to_drive(selected_drive, mounted_device):
-    selected_drive = (selected_drive or '').strip()
-    mounted_device = (mounted_device or '').strip()
-    if not selected_drive or not mounted_device:
-        return False
-    # The rerun flow selects a partition path, not a whole disk. Match the
-    # mounted source exactly so names like /dev/sdb1 never catch /dev/sdb11.
-    return os.path.realpath(mounted_device) == os.path.realpath(selected_drive)
+def _normalize_device_path(device_path):
+    device_path = (device_path or '').strip()
+    if not device_path:
+        return ''
+    return os.path.realpath(device_path)
 
 
-def _get_mounted_partitions_for_drive(drive):
+def _get_current_mounts():
+    # Use the live mount table for operation safety checks instead of lsblk's
+    # mountpoint field so we always act on what the kernel currently reports.
     mount_check = subprocess.run(['mount'], capture_output=True, text=True)
-    mounted_partitions = []
+    mounts = []
     for line in mount_check.stdout.splitlines():
         parts = line.split()
-        if len(parts) >= 3 and _mount_belongs_to_drive(drive, parts[0]):
-            mounted_partitions.append({'device': parts[0], 'mount_point': parts[2]})
+        if len(parts) >= 3:
+            mounts.append({'device': parts[0], 'mount_point': parts[2]})
+    return mounts
+
+
+def _load_lsblk_devices():
+    # Keep one shared inventory source for both setup and rerun flows. The
+    # flows differ in target semantics, not in how we discover block devices.
+    lsblk_result = subprocess.run(
+        ['lsblk', '-J', '-o', 'NAME,PATH,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'],
+        capture_output=True,
+        text=True,
+    )
+    if lsblk_result.returncode != 0:
+        raise BackupDriveSetupError('Failed to list drives.')
+
+    try:
+        lsblk_data = json.loads(lsblk_result.stdout)
+    except Exception as exc:
+        raise BackupDriveSetupError('Failed to parse drive list.') from exc
+
+    return lsblk_data.get('blockdevices', [])
+
+
+def _get_system_drive_path():
+    root_mount = subprocess.run(['findmnt', '-n', '-o', 'SOURCE', '/'], capture_output=True, text=True)
+    return root_mount.stdout.strip() if root_mount.returncode == 0 else None
+
+
+def _iter_non_system_disks(blockdevices, system_drive=None):
+    for block in blockdevices:
+        if block.get('type') != 'disk':
+            continue
+        disk_path = block.get('path')
+        if not disk_path:
+            continue
+        if system_drive and system_drive.startswith(disk_path):
+            continue
+        yield block
+
+
+def _find_disk_device(disk_path, blockdevices):
+    normalized_disk = _normalize_device_path(disk_path)
+    for block in blockdevices:
+        if block.get('type') != 'disk':
+            continue
+        if _normalize_device_path(block.get('path')) == normalized_disk:
+            return block
+    return None
+
+
+def _get_disk_member_devices(disk_path, blockdevices):
+    # Setup step 2 operates on a whole disk, so it must consider every child
+    # partition that belongs to that disk before unmounting or formatting.
+    disk = _find_disk_device(disk_path, blockdevices)
+    if not disk:
+        return set()
+
+    device_paths = set()
+    for child in disk.get('children', []) or []:
+        child_path = child.get('path')
+        if child_path:
+            device_paths.add(_normalize_device_path(child_path))
+
+    # Some removable media expose a filesystem directly on the disk path.
+    if not device_paths and disk.get('fstype'):
+        device_paths.add(_normalize_device_path(disk.get('path')))
+
+    return device_paths
+
+
+def _get_mounted_partitions_for_disk(disk_path, blockdevices=None, mounts=None):
+    # Disk operations intentionally match child partitions; partition-oriented
+    # flows use _get_mount_for_partition() instead.
+    blockdevices = blockdevices if blockdevices is not None else _load_lsblk_devices()
+    mounts = mounts if mounts is not None else _get_current_mounts()
+    member_devices = _get_disk_member_devices(disk_path, blockdevices)
+    if not member_devices:
+        return []
+
+    mounted_partitions = []
+    for mount in mounts:
+        if _normalize_device_path(mount['device']) in member_devices:
+            mounted_partitions.append(mount)
     return mounted_partitions
+
+
+def _get_mount_for_partition(partition_path, mounts=None):
+    # Rerun/setup-mount flows select an exact partition path, so this lookup
+    # must never treat /dev/sdb1 and /dev/sdb11 as interchangeable.
+    mounts = mounts if mounts is not None else _get_current_mounts()
+    normalized_partition = _normalize_device_path(partition_path)
+    for mount in mounts:
+        if _normalize_device_path(mount['device']) == normalized_partition:
+            return mount
+    return None
 
 
 def _get_partition_filesystem_type(drive):
@@ -263,34 +355,12 @@ def list_available_drives(runtime=None, ntfs_only=False):
     if runtime.is_fake:
         return fake_state.get_virtual_drives()
 
-    lsblk_result = subprocess.run(
-        ['lsblk', '-J', '-o', 'NAME,PATH,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'],
-        capture_output=True,
-        text=True,
-    )
-    if lsblk_result.returncode != 0:
-        raise BackupDriveSetupError('Failed to list drives.')
-
-    try:
-        lsblk_data = json.loads(lsblk_result.stdout)
-    except Exception as exc:
-        raise BackupDriveSetupError('Failed to parse drive list.') from exc
-
-    root_mount = subprocess.run(['findmnt', '-n', '-o', 'SOURCE', '/'], capture_output=True, text=True)
-    system_drive = root_mount.stdout.strip() if root_mount.returncode == 0 else None
+    blockdevices = _load_lsblk_devices()
+    system_drive = _get_system_drive_path()
 
     drives = []
-    for block in lsblk_data.get('blockdevices', []):
-        if block.get('type') != 'disk':
-            continue
-
+    for block in _iter_non_system_disks(blockdevices, system_drive=system_drive):
         disk_path = block.get('path')
-        if not disk_path:
-            continue
-
-        if system_drive and system_drive.startswith(disk_path):
-            continue
-
         partitions = []
         for child in block.get('children', []) or []:
             child_path = child.get('path')
@@ -331,7 +401,7 @@ def list_available_drives(runtime=None, ntfs_only=False):
     return drives
 
 
-def unmount_selected_drive(drive, runtime=None):
+def unmount_disk_partitions(disk_path, runtime=None):
     runtime = runtime or get_runtime()
     fake_state = get_fake_state() if runtime.is_fake else None
 
@@ -339,13 +409,15 @@ def unmount_selected_drive(drive, runtime=None):
         fake_state.set_mount(False)
         return 'Fake backup source disconnected.'
 
-    if not drive:
-        raise BackupDriveSetupError('No drive selected.')
+    if not disk_path:
+        raise BackupDriveSetupError('No disk selected.')
 
-    mounted_partitions = _get_mounted_partitions_for_drive(drive)
+    # The format flow needs to clear every mounted child partition on the
+    # selected disk, not just one exact device path.
+    mounted_partitions = _get_mounted_partitions_for_disk(disk_path)
 
     if not mounted_partitions:
-        raise BackupDriveSetupError('The selected drive is not currently mounted.')
+        raise BackupDriveSetupError('The selected disk has no mounted partitions.')
 
     failures = []
     for partition in mounted_partitions:
@@ -360,6 +432,33 @@ def unmount_selected_drive(drive, runtime=None):
         raise BackupDriveSetupError('Failed to unmount partitions: {}'.format('; '.join(failures)))
 
     return 'Successfully unmounted {} partition(s).'.format(len(mounted_partitions))
+
+
+def unmount_selected_partition(partition_path, runtime=None):
+    runtime = runtime or get_runtime()
+    fake_state = get_fake_state() if runtime.is_fake else None
+
+    if runtime.is_fake:
+        fake_state.set_mount(False)
+        return 'Fake backup source disconnected.'
+
+    if not partition_path:
+        raise BackupDriveSetupError('No partition selected.')
+
+    # The rerun flow should only unmount the exact partition the user chose.
+    mount = _get_mount_for_partition(partition_path)
+    if not mount:
+        raise BackupDriveSetupError('The selected partition is not currently mounted.')
+
+    result = subprocess.run(['umount', mount['device']], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise BackupDriveSetupError(
+            'Failed to unmount partition: {}'.format(
+                result.stderr.strip() if result.stderr else 'unknown error'
+            )
+        )
+
+    return 'Successfully unmounted {}.'.format(mount['device'])
 
 
 def _sync_backup_share_path(smb_manager, new_path):
@@ -378,7 +477,7 @@ def _sync_backup_share_path(smb_manager, new_path):
     return False
 
 
-def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_manager, smb_manager, runtime=None):
+def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_manager, smb_manager, runtime=None):
     runtime = runtime or get_runtime()
     fake_state = get_fake_state() if runtime.is_fake else None
 
@@ -427,7 +526,7 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
             config_manager.set_value('backup', 'uuid', uuid)
             config_manager.set_value('backup', 'usb_id', usb_id)
             config_updated = True
-            fake_state.set_mount(True, mount_point=selected_path_str, drive=drive or '/dev/fakebackup1')
+            fake_state.set_mount(True, mount_point=selected_path_str, drive=partition or '/dev/fakebackup1')
             return {
                 'message': 'Successfully selected local backup source at {}'.format(selected_path),
                 'uuid': uuid,
@@ -458,22 +557,24 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
                     LOGGER.error('Failed to restore fake backup config after drive setup error: %s', config_exc)
             raise
 
-    if not drive:
-        raise BackupDriveSetupError('No drive selected.')
+    if not partition:
+        raise BackupDriveSetupError('No partition selected.')
 
-    mounted_partitions = _get_mounted_partitions_for_drive(drive)
-    if mounted_partitions:
+    # This flow is partition-oriented by design. If the user selected /dev/sdb1,
+    # we should not block on or touch unrelated devices on the same disk.
+    mounted_partition = _get_mount_for_partition(partition)
+    if mounted_partition:
         raise BackupDriveSetupError(
-            'The selected drive is already mounted at {}. Unmount it first before rerunning drive setup.'.format(
-                mounted_partitions[0]['mount_point']
+            'The selected partition is already mounted at {}. Unmount it first before rerunning drive setup.'.format(
+                mounted_partition['mount_point']
             )
         )
 
-    uuid = get_drive_uuid(drive)
-    usb_id = get_drive_usb_id(drive)
-    filesystem_type = _get_partition_filesystem_type(drive)
+    uuid = get_drive_uuid(partition)
+    usb_id = get_drive_usb_id(partition)
+    filesystem_type = _get_partition_filesystem_type(partition)
     if not _is_ntfs_filesystem(filesystem_type):
-        raise BackupDriveSetupError('The selected drive must be formatted as NTFS.')
+        raise BackupDriveSetupError('The selected partition must be formatted as NTFS.')
 
     os.makedirs(mount_point, exist_ok=True)
 
@@ -486,7 +587,7 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
         fstab_backup = update_managed_fstab(uuid, mount_point, bool(auto_mount), runtime=runtime)
 
         mount_result = subprocess.run(
-            ['ntfs-3g', drive, mount_point, '-o', 'rw,uid=1000,gid=1000'],
+            ['ntfs-3g', partition, mount_point, '-o', 'rw,uid=1000,gid=1000'],
             capture_output=True,
             text=True,
         )
@@ -511,14 +612,14 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
         config_updated = True
 
         return {
-            'message': 'Successfully configured {} at {}'.format(drive, mount_point),
+            'message': 'Successfully configured {} at {}'.format(partition, mount_point),
             'uuid': uuid,
             'usb_id': usb_id,
             'mount_point': mount_point,
         }
     except Exception:
         if mounted:
-            subprocess.run(['umount', drive], check=False)
+            subprocess.run(['umount', partition], check=False)
         if fstab_backup:
             restore_fstab_backup(fstab_backup, runtime=runtime)
         if share_backup:

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -73,29 +73,33 @@ def _backup_file(path, runtime, prefix):
 
 
 def _validate_fstab_file(path):
-    if shutil.which('mount'):
-        result = subprocess.run(
-            ['mount', '-fav', '-T', str(path)],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            return True, None, None
-        summary = (result.stderr or result.stdout or 'mount validation failed').strip().splitlines()[0]
-        details = '\n'.join(part for part in [result.stdout.strip(), result.stderr.strip()] if part).strip()
-        return False, summary, details
+    issues = []
+    for line_number, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
 
-    if shutil.which('findmnt'):
-        result = subprocess.run(
-            ['findmnt', '--verify', '--tab-file', str(path)],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            return True, None, None
-        summary = (result.stderr or result.stdout or 'findmnt validation failed').strip().splitlines()[0]
-        details = '\n'.join(part for part in [result.stdout.strip(), result.stderr.strip()] if part).strip()
-        return False, summary, details
+        content = stripped.split('#', 1)[0].strip()
+        if not content:
+            continue
+
+        parts = re.split(r'\s+', content)
+        if len(parts) < 6:
+            issues.append('line {} does not have 6 fstab fields: {}'.format(line_number, raw_line.strip()))
+            continue
+
+        spec, mount_point, fstype = parts[0], parts[1], parts[2]
+        if not mount_point.startswith('/'):
+            issues.append('line {} has a non-absolute mount point: {}'.format(line_number, mount_point))
+        if _is_managed_fstab_line(raw_line):
+            if not spec.startswith('UUID='):
+                issues.append('line {} has an invalid managed UUID spec: {}'.format(line_number, spec))
+            if fstype != 'ntfs-3g':
+                issues.append('line {} has unexpected managed filesystem type: {}'.format(line_number, fstype))
+
+    if issues:
+        details = '\n'.join(issues)
+        return False, issues[0], details
 
     return True, None, None
 

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -355,6 +355,27 @@ def restore_fstab_backup(backup_path, runtime=None, fstab_path=None):
     shutil.copy2(backup_path, path)
 
 
+def _reload_systemd_mount_units(runtime=None):
+    runtime = runtime or get_runtime()
+    if runtime.is_fake:
+        return
+
+    # Keep daemon-reload outside update_managed_fstab() so callers can treat
+    # "rewrite /etc/fstab" and "refresh systemd's generated mount units" as
+    # one rollback-aware transaction.
+    result = subprocess.run(
+        ['systemctl', 'daemon-reload'],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise BackupDriveSetupError(
+            'Failed to reload systemd after updating /etc/fstab: {}'.format(
+                result.stderr.strip() if result.stderr else 'unknown error'
+            )
+        )
+
+
 def get_drive_uuid(drive):
     result = subprocess.run(['blkid', '-s', 'UUID', '-o', 'value', drive], capture_output=True, text=True)
     if result.returncode != 0 or not result.stdout.strip():
@@ -561,6 +582,7 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
 
         try:
             fstab_backup = update_managed_fstab(uuid, selected_path_str, bool(auto_mount), runtime=runtime)
+            _reload_systemd_mount_units(runtime=runtime)
 
             backup_share = None
             for share in smb_manager.get_shares():
@@ -586,6 +608,7 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
         except Exception:
             if fstab_backup:
                 restore_fstab_backup(fstab_backup, runtime=runtime)
+                _reload_systemd_mount_units(runtime=runtime)
             if share_backup:
                 try:
                     smb_manager.update_share(
@@ -635,6 +658,7 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
 
     try:
         fstab_backup = update_managed_fstab(uuid, mount_point, bool(auto_mount), runtime=runtime)
+        _reload_systemd_mount_units(runtime=runtime)
 
         mount_result = subprocess.run(
             ['ntfs-3g', partition, mount_point, '-o', 'rw,uid=1000,gid=1000'],
@@ -672,6 +696,7 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
             subprocess.run(['umount', partition], check=False)
         if fstab_backup:
             restore_fstab_backup(fstab_backup, runtime=runtime)
+            _reload_systemd_mount_units(runtime=runtime)
         if share_backup:
             try:
                 smb_manager.update_share(

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -117,6 +117,28 @@ def _normalize_device_path(device_path):
     return os.path.realpath(device_path)
 
 
+def _lsblk_flag_is_true(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    return str(value).strip().lower() in {'1', 'true', 'yes', 'y', 'on'}
+
+
+def _get_drive_connection_type(block):
+    transport = (block.get('tran') or '').strip().lower()
+    if transport == 'usb':
+        return 'usb'
+
+    # External-drive enclosures are not perfectly consistent across kernels
+    # and bridge chipsets, so keep a fallback for hotplug/removable signals
+    # rather than assuming every non-USB transport is an internal disk.
+    if _lsblk_flag_is_true(block.get('hotplug')) or _lsblk_flag_is_true(block.get('rm')):
+        return 'removable'
+
+    return 'internal'
+
+
 def _get_current_mounts():
     # Use the live mount table for operation safety checks instead of lsblk's
     # mountpoint field so we always act on what the kernel currently reports.
@@ -133,7 +155,7 @@ def _load_lsblk_devices():
     # Keep one shared inventory source for both setup and rerun flows. The
     # flows differ in target semantics, not in how we discover block devices.
     lsblk_result = subprocess.run(
-        ['lsblk', '-J', '-o', 'NAME,PATH,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'],
+        ['lsblk', '-J', '-o', 'NAME,PATH,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE,TRAN,RM,HOTPLUG'],
         capture_output=True,
         text=True,
     )
@@ -465,7 +487,10 @@ def list_available_drives(runtime=None, ntfs_only=False):
             'path': disk_path,
             'model': (block.get('model') or 'Unknown Drive').strip() or 'Unknown Drive',
             'size': block.get('size') or '',
-            'type': block.get('type') or 'unknown',
+            # The setup UI expects a connection hint here so operators can
+            # distinguish likely external backup targets from internal disks.
+            'type': _get_drive_connection_type(block),
+            'device_type': block.get('type') or 'unknown',
             'partitions': partitions,
         })
 

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -92,13 +92,22 @@ def _get_blkid_filesystem_type(device_path):
     return result.stdout.strip().lower()
 
 
-def _is_ntfs_scan_candidate(device_path, filesystem_type):
+def _get_partition_type_for_scan(device_path, filesystem_type, fallback_type='', ntfs_only=False):
     normalized_type = (filesystem_type or '').strip().lower()
+    if not ntfs_only:
+        return filesystem_type or fallback_type or 'unknown'
+
     if _is_ntfs_filesystem(normalized_type):
-        return True
-    if normalized_type != 'fuseblk':
-        return False
-    return _get_blkid_filesystem_type(device_path) == 'ntfs'
+        # The NTFS-only pickers care about "mountable backup target" rather
+        # than which exact driver spelling lsblk reported today.
+        return 'ntfs'
+
+    if normalized_type == 'fuseblk' and _get_blkid_filesystem_type(device_path) == 'ntfs':
+        # This is an API contract for UI consumers, not a claim that the volume
+        # is mounted with the in-kernel NTFS driver.
+        return 'ntfs'
+
+    return None
 
 
 def _normalize_device_path(device_path):
@@ -391,21 +400,38 @@ def list_available_drives(runtime=None, ntfs_only=False):
             if not child_path:
                 continue
             filesystem_type = child.get('fstype') or ''
-            if ntfs_only and not _is_ntfs_scan_candidate(child_path, filesystem_type):
+            partition_type = _get_partition_type_for_scan(
+                child_path,
+                filesystem_type,
+                fallback_type=child.get('type') or 'unknown',
+                ntfs_only=ntfs_only,
+            )
+            if partition_type is None:
                 continue
             partitions.append({
                 'path': child_path,
-                'type': filesystem_type or child.get('type') or 'unknown',
+                'type': partition_type,
                 'label': child.get('label') or '',
                 'size': child.get('size') or '',
                 'mountpoint': child.get('mountpoint') or '',
             })
 
         block_filesystem_type = block.get('fstype') or ''
-        if not partitions and _is_ntfs_scan_candidate(disk_path, block_filesystem_type):
+        should_include_whole_disk_target = ntfs_only or bool(
+            block_filesystem_type or block.get('mountpoint')
+        )
+        block_partition_type = None
+        if should_include_whole_disk_target:
+            block_partition_type = _get_partition_type_for_scan(
+                disk_path,
+                block_filesystem_type,
+                fallback_type=block.get('type') or 'unknown',
+                ntfs_only=ntfs_only,
+            )
+        if not partitions and block_partition_type is not None:
             partitions.append({
                 'path': disk_path,
-                'type': block_filesystem_type or block.get('type') or 'unknown',
+                'type': block_partition_type,
                 'label': block.get('label') or '',
                 'size': block.get('size') or '',
                 'mountpoint': block.get('mountpoint') or '',

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -619,10 +619,10 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
                 share_backup = backup_share
                 _sync_backup_share_path(smb_manager, selected_path_str)
 
+            config_updated = True
             config_manager.set_value('backup', 'mount_point', selected_path_str)
             config_manager.set_value('backup', 'uuid', uuid)
             config_manager.set_value('backup', 'usb_id', usb_id)
-            config_updated = True
             fake_state.set_mount(True, mount_point=selected_path_str, drive=partition or '/dev/fakebackup1')
             return {
                 'message': 'Successfully selected local backup source at {}'.format(selected_path),
@@ -705,10 +705,10 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
             share_backup = backup_share
             _sync_backup_share_path(smb_manager, mount_point)
 
+        config_updated = True
         config_manager.set_value('backup', 'mount_point', mount_point)
         config_manager.set_value('backup', 'uuid', uuid)
         config_manager.set_value('backup', 'usb_id', usb_id)
-        config_updated = True
 
         return {
             'message': 'Successfully configured {} at {}'.format(partition, mount_point),

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -82,15 +82,9 @@ def _mount_belongs_to_drive(selected_drive, mounted_device):
     mounted_device = (mounted_device or '').strip()
     if not selected_drive or not mounted_device:
         return False
-    if mounted_device == selected_drive:
-        return True
-
-    base_name = os.path.basename(selected_drive)
-    mounted_name = os.path.basename(mounted_device)
-
-    if re.match(r'^{}p\d+$'.format(re.escape(base_name)), mounted_name):
-        return True
-    return re.match(r'^{}\d+$'.format(re.escape(base_name)), mounted_name) is not None
+    # The rerun flow selects a partition path, not a whole disk. Match the
+    # mounted source exactly so names like /dev/sdb1 never catch /dev/sdb11.
+    return os.path.realpath(mounted_device) == os.path.realpath(selected_drive)
 
 
 def _get_mounted_partitions_for_drive(drive):

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -77,6 +77,32 @@ def _is_ntfs_filesystem(filesystem_type):
     return (filesystem_type or '').strip().lower() in NTFS_FILESYSTEM_TYPES
 
 
+def _mount_belongs_to_drive(selected_drive, mounted_device):
+    selected_drive = (selected_drive or '').strip()
+    mounted_device = (mounted_device or '').strip()
+    if not selected_drive or not mounted_device:
+        return False
+    if mounted_device == selected_drive:
+        return True
+
+    base_name = os.path.basename(selected_drive)
+    mounted_name = os.path.basename(mounted_device)
+
+    if re.match(r'^{}p\d+$'.format(re.escape(base_name)), mounted_name):
+        return True
+    return re.match(r'^{}\d+$'.format(re.escape(base_name)), mounted_name) is not None
+
+
+def _get_mounted_partitions_for_drive(drive):
+    mount_check = subprocess.run(['mount'], capture_output=True, text=True)
+    mounted_partitions = []
+    for line in mount_check.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and _mount_belongs_to_drive(drive, parts[0]):
+            mounted_partitions.append({'device': parts[0], 'mount_point': parts[2]})
+    return mounted_partitions
+
+
 def _get_partition_filesystem_type(drive):
     lsblk_result = subprocess.run(
         ['lsblk', '-no', 'FSTYPE', drive],
@@ -106,9 +132,9 @@ def _validate_fstab_file(path):
             continue
 
         spec, mount_point, fstype = parts[0], parts[1], parts[2]
-        if not mount_point.startswith('/'):
-            issues.append('line {} has a non-absolute mount point: {}'.format(line_number, mount_point))
         if _is_managed_fstab_line(raw_line):
+            if not mount_point.startswith('/'):
+                issues.append('line {} has a non-absolute managed mount point: {}'.format(line_number, mount_point))
             if not spec.startswith('UUID='):
                 issues.append('line {} has an invalid managed UUID spec: {}'.format(line_number, spec))
             if fstype != 'ntfs-3g':
@@ -236,7 +262,7 @@ def get_drive_usb_id(drive):
     return ''
 
 
-def list_available_drives(runtime=None):
+def list_available_drives(runtime=None, ntfs_only=False):
     runtime = runtime or get_runtime()
     fake_state = get_fake_state() if runtime.is_fake else None
 
@@ -277,7 +303,7 @@ def list_available_drives(runtime=None):
             if not child_path:
                 continue
             filesystem_type = child.get('fstype') or ''
-            if not _is_ntfs_filesystem(filesystem_type):
+            if ntfs_only and not _is_ntfs_filesystem(filesystem_type):
                 continue
             partitions.append({
                 'path': child_path,
@@ -297,7 +323,7 @@ def list_available_drives(runtime=None):
                 'mountpoint': block.get('mountpoint') or '',
             })
 
-        if not partitions:
+        if ntfs_only and not partitions:
             continue
 
         drives.append({
@@ -322,12 +348,7 @@ def unmount_selected_drive(drive, runtime=None):
     if not drive:
         raise BackupDriveSetupError('No drive selected.')
 
-    mount_check = subprocess.run(['mount'], capture_output=True, text=True)
-    mounted_partitions = []
-    for line in mount_check.stdout.splitlines():
-        parts = line.split()
-        if len(parts) >= 3 and parts[0] == drive:
-            mounted_partitions.append({'device': parts[0], 'mount_point': parts[2]})
+    mounted_partitions = _get_mounted_partitions_for_drive(drive)
 
     if not mounted_partitions:
         raise BackupDriveSetupError('The selected drive is not currently mounted.')
@@ -446,13 +467,13 @@ def apply_backup_drive_configuration(drive, mount_point, auto_mount, config_mana
     if not drive:
         raise BackupDriveSetupError('No drive selected.')
 
-    mount_check = subprocess.run(['mount'], capture_output=True, text=True)
-    for line in mount_check.stdout.splitlines():
-        parts = line.split()
-        if len(parts) >= 3 and parts[0] == drive:
-            raise BackupDriveSetupError(
-                'The selected drive is already mounted at {}. Unmount it first before rerunning drive setup.'.format(parts[2])
+    mounted_partitions = _get_mounted_partitions_for_drive(drive)
+    if mounted_partitions:
+        raise BackupDriveSetupError(
+            'The selected drive is already mounted at {}. Unmount it first before rerunning drive setup.'.format(
+                mounted_partitions[0]['mount_point']
             )
+        )
 
     uuid = get_drive_uuid(drive)
     usb_id = get_drive_usb_id(drive)

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -17,7 +17,9 @@ LEGACY_FSTAB_MARKER = "SimpleSaferServer"
 
 
 class BackupDriveSetupError(Exception):
-    pass
+    def __init__(self, message, details=None):
+        super().__init__(message)
+        self.details = details
 
 
 def _get_fstab_path(runtime=None, fstab_path=None):
@@ -78,9 +80,10 @@ def _validate_fstab_file(path):
             text=True,
         )
         if result.returncode == 0:
-            return True, None
-        message = (result.stderr or result.stdout or 'findmnt validation failed').strip()
-        return False, message
+            return True, None, None
+        summary = (result.stderr or result.stdout or 'findmnt validation failed').strip().splitlines()[0]
+        details = '\n'.join(part for part in [result.stdout.strip(), result.stderr.strip()] if part).strip()
+        return False, summary, details
 
     if shutil.which('mount'):
         result = subprocess.run(
@@ -89,11 +92,12 @@ def _validate_fstab_file(path):
             text=True,
         )
         if result.returncode == 0:
-            return True, None
-        message = (result.stderr or result.stdout or 'mount validation failed').strip()
-        return False, message
+            return True, None, None
+        summary = (result.stderr or result.stdout or 'mount validation failed').strip().splitlines()[0]
+        details = '\n'.join(part for part in [result.stdout.strip(), result.stderr.strip()] if part).strip()
+        return False, summary, details
 
-    return True, None
+    return True, None, None
 
 
 def _render_managed_fstab_entry(uuid, mount_point):
@@ -157,11 +161,16 @@ def update_managed_fstab(uuid, mount_point, auto_mount, runtime=None, fstab_path
         handle.writelines(new_lines)
         temp_path = Path(handle.name)
 
-    valid, validation_error = _validate_fstab_file(temp_path)
+    valid, validation_error, validation_details = _validate_fstab_file(temp_path)
     if not valid:
         if temp_path.exists():
             temp_path.unlink()
-        raise BackupDriveSetupError('/etc/fstab validation failed: {}'.format(validation_error))
+        if validation_details:
+            LOGGER.error('Backup drive fstab validation failed for %s:\n%s', temp_path, validation_details)
+        raise BackupDriveSetupError(
+            '/etc/fstab validation failed: {}'.format(validation_error),
+            details=validation_details,
+        )
 
     backup_path = None
     if path.exists():

--- a/backup_drive_unmount.py
+++ b/backup_drive_unmount.py
@@ -1,0 +1,122 @@
+import logging
+import os
+import subprocess
+
+from backup_drive_setup import BackupDriveSetupError, _get_mount_for_partition, get_drive_uuid
+from runtime import get_fake_state, get_runtime
+
+
+LOGGER = logging.getLogger(__name__)
+MANAGED_BACKUP_UNMOUNT_TASKS = (
+    'check_mount.service',
+    'check_health.service',
+    'backup_cloud.service',
+)
+
+
+def is_selected_partition_managed_backup_drive(
+    partition_path,
+    configured_mount_point,
+    configured_uuid,
+    system_utils,
+    runtime=None,
+):
+    runtime = runtime or get_runtime()
+    configured_mount_point = (configured_mount_point or '').strip()
+    if not partition_path or not configured_mount_point:
+        return False
+
+    if runtime.is_fake:
+        return system_utils.is_mounted(configured_mount_point)
+
+    mount = _get_mount_for_partition(partition_path)
+    if mount and os.path.realpath(mount['mount_point']) == os.path.realpath(configured_mount_point):
+        return True
+
+    # Months from now it will be easy to forget why UUID matching is gated on
+    # the configured mount being active: without that guard, an unmounted old
+    # backup disk would incorrectly trigger the broader SMB-safe flow.
+    if not configured_uuid or not system_utils.is_mounted(configured_mount_point):
+        return False
+
+    try:
+        return get_drive_uuid(partition_path) == configured_uuid
+    except BackupDriveSetupError as exc:
+        LOGGER.warning('Could not compare backup partition UUID for %s: %s', partition_path, exc)
+        return False
+
+
+def _power_down_managed_backup_drive(configured_uuid, system_utils):
+    if not configured_uuid:
+        return
+
+    try:
+        blkid_out = subprocess.run(
+            ['blkid', '-t', f'UUID={configured_uuid}', '-o', 'device'],
+            capture_output=True,
+            text=True,
+        )
+        partition_device = blkid_out.stdout.strip()
+        if not partition_device:
+            return
+
+        parent_device = system_utils.get_parent_device(partition_device)
+        if parent_device:
+            subprocess.run(['sudo', 'hdparm', '-y', parent_device], check=False)
+    except Exception as exc:
+        LOGGER.warning('Failed to power down configured backup drive: %s', exc)
+
+
+def unmount_managed_backup_drive(
+    configured_mount_point,
+    configured_uuid,
+    system_utils,
+    *,
+    runtime=None,
+    power_down=False,
+):
+    runtime = runtime or get_runtime()
+    fake_state = get_fake_state() if runtime.is_fake else None
+
+    if runtime.is_fake:
+        fake_state.set_mount(False)
+        return
+
+    configured_mount_point = (configured_mount_point or '').strip()
+    if not configured_mount_point:
+        raise BackupDriveSetupError('Configured backup mount point is missing.')
+
+    # The managed backup-drive path is intentionally broader than an exact
+    # partition umount because Samba and background jobs can keep busy handles
+    # on the share even when the user only asked to unmount one partition.
+    try:
+        subprocess.run(['sudo', 'smbcontrol', 'all', 'close-share', configured_mount_point], check=False)
+    except Exception:
+        pass
+
+    for service in MANAGED_BACKUP_UNMOUNT_TASKS:
+        subprocess.run(['sudo', 'systemctl', 'stop', service], check=False)
+    subprocess.run(['sudo', 'systemctl', 'stop', 'smbd'], check=False)
+    subprocess.run(['sudo', 'systemctl', 'stop', 'nmbd'], check=False)
+
+    try:
+        result = subprocess.run(
+            ['sudo', 'umount', configured_mount_point],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise BackupDriveSetupError(
+                'Failed to unmount drive: {}'.format(
+                    result.stderr.strip() if result.stderr else 'unknown error'
+                )
+            )
+
+        if power_down:
+            _power_down_managed_backup_drive(configured_uuid, system_utils)
+    finally:
+        try:
+            subprocess.run(['sudo', 'systemctl', 'start', 'smbd'], check=False)
+            subprocess.run(['sudo', 'systemctl', 'start', 'nmbd'], check=False)
+        except Exception:
+            pass

--- a/backup_drive_unmount.py
+++ b/backup_drive_unmount.py
@@ -2,7 +2,7 @@ import logging
 import os
 import subprocess
 
-from backup_drive_setup import BackupDriveSetupError, _get_mount_for_partition, get_drive_uuid
+from backup_drive_setup import BackupDriveSetupError, _get_mount_for_partition
 from runtime import get_fake_state, get_runtime
 
 
@@ -30,20 +30,14 @@ def is_selected_partition_managed_backup_drive(
         return system_utils.is_mounted(configured_mount_point)
 
     mount = _get_mount_for_partition(partition_path)
-    if mount and os.path.realpath(mount['mount_point']) == os.path.realpath(configured_mount_point):
-        return True
-
-    # Months from now it will be easy to forget why UUID matching is gated on
-    # the configured mount being active: without that guard, an unmounted old
-    # backup disk would incorrectly trigger the broader SMB-safe flow.
-    if not configured_uuid or not system_utils.is_mounted(configured_mount_point):
+    if not mount:
         return False
 
-    try:
-        return get_drive_uuid(partition_path) == configured_uuid
-    except BackupDriveSetupError as exc:
-        LOGGER.warning('Could not compare backup partition UUID for %s: %s', partition_path, exc)
-        return False
+    # Keep the SMB-safe path tied to the partition that is actually mounted at
+    # the managed backup mount point. UUID-only matching sounds convenient, but
+    # cloned replacement disks can legitimately share a filesystem UUID and
+    # would make us stop SMB for the wrong physical device.
+    return os.path.realpath(mount['mount_point']) == os.path.realpath(configured_mount_point)
 
 
 def _power_down_managed_backup_drive(configured_uuid, system_utils):

--- a/dashboard_messages.py
+++ b/dashboard_messages.py
@@ -1,0 +1,101 @@
+import re
+from datetime import datetime
+from typing import Optional
+
+
+_IGNORED_TIME_VALUES = {
+    '',
+    '-',
+    'never',
+    'unknown',
+    'not run yet',
+    'not scheduled',
+    'retrieval error',
+}
+
+
+def parse_server_datetime(value: Optional[str]) -> Optional[datetime]:
+    """Parse the mixed timestamp formats the dashboard already shows for task times."""
+    trimmed = (value or '').strip()
+    if not trimmed or trimmed.lower() in _IGNORED_TIME_VALUES:
+        return None
+
+    try:
+        return datetime.fromisoformat(trimmed)
+    except ValueError:
+        pass
+
+    # systemd-style values often include a weekday prefix and timezone suffix
+    # that datetime.fromisoformat does not accept directly.
+    normalized = re.sub(r'^[A-Za-z]{3}\s+', '', trimmed)
+    normalized = re.sub(r'\s+[A-Z]{2,5}$', '', normalized)
+
+    try:
+        return datetime.fromisoformat(normalized.replace(' ', 'T'))
+    except ValueError:
+        pass
+
+    match = re.match(r'^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$', normalized)
+    if not match:
+        return None
+
+    year, month, day, hour, minute, second = (int(part) for part in match.groups())
+    return datetime(year, month, day, hour, minute, second)
+
+
+def format_future_delay(value: Optional[str], now: Optional[datetime] = None) -> Optional[str]:
+    """Return a short human-readable countdown such as 'in about 2h 13m'."""
+    target_time = parse_server_datetime(value)
+    if not target_time:
+        return None
+
+    now = now or datetime.now()
+    diff_seconds = int((target_time - now).total_seconds())
+    if diff_seconds <= 0:
+        return None
+
+    if diff_seconds < 60:
+        return 'in about a few seconds'
+
+    remaining_minutes = diff_seconds // 60
+    units = [
+        ('w', 10080),
+        ('d', 1440),
+        ('h', 60),
+        ('m', 1),
+    ]
+
+    parts = []
+    for suffix, size in units:
+        if len(parts) >= 3:
+            break
+        amount = remaining_minutes // size
+        if amount > 0:
+            parts.append(f'{amount}{suffix}')
+            remaining_minutes -= amount * size
+
+    if not parts:
+        parts.append('0m')
+
+    return 'in about {}'.format(' '.join(parts))
+
+
+def build_dashboard_unmount_success_message(
+    base_message: str,
+    next_check_mount_run: Optional[str],
+    *,
+    availability_phrase: str = 'stays connected',
+    remount_verb: str = 'remount',
+) -> str:
+    """Describe that dashboard unmount is temporary because the drive stays managed."""
+    delay = format_future_delay(next_check_mount_run)
+    if delay:
+        return (
+            f'{base_message} If it {availability_phrase}, SimpleSaferServer may '
+            f'{remount_verb} it automatically during the next Check Mount run, {delay}.'
+        )
+
+    return (
+        f'{base_message} If it {availability_phrase}, SimpleSaferServer may '
+        f'{remount_verb} it automatically during the next scheduled Check Mount run.'
+    )

--- a/docs/access.md
+++ b/docs/access.md
@@ -1,0 +1,28 @@
+# Access and Permissions
+
+SimpleSaferServer separates management access from file-share access.
+
+## Management Web UI
+
+- The SimpleSaferServer web UI is for administrators only.
+- The first account created during setup is an administrator.
+- Any later account must also have the admin flag enabled before it can sign in to the web UI.
+- A valid username and password are not enough for web UI access by themselves. The account must also be marked as an administrator.
+
+## Non-Admin Accounts
+
+- Non-admin accounts can exist for file sharing and related system access.
+- Non-admin accounts cannot sign in to the SimpleSaferServer management interface.
+- If a user only needs access to the backup share over the network, that user does not need web UI access.
+
+## Why This Matters
+
+- The web UI can change backup settings, schedules, alerts, cloud destinations, and managed storage configuration.
+- Some actions also trigger privileged system changes such as service restarts, Samba updates, and managed `/etc/fstab` changes.
+- Keeping the management interface admin-only avoids mixing day-to-day file access with system administration privileges.
+
+## Related Documentation
+
+- [Setup Wizard](setup.md)
+- [Login Page](login.md)
+- [Users](users.md)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -15,13 +15,16 @@ Four cards display real-time status:
 - **Refresh**: Button to reload the task schedule.
 
 ## System Actions
-- **Unmount Storage**: Opens a modal to confirm and unmount the storage drive.
+- **Unmount Storage**: Opens a modal to confirm a temporary unmount of the configured backup drive.
+- If the backup drive stays connected, SimpleSaferServer may remount it automatically during the next scheduled `Check Mount` run.
+- When the next `Check Mount` run is available, the confirmation dialog explains the remount timing as a relative countdown so the user knows how long they have to remove or swap the drive.
 - **Mount Storage**: Opens a modal to mount the storage drive.
 - **Restart System**: Opens a modal to confirm and restart the system.
 - **Shutdown System**: Opens a modal to confirm and shut down the system.
 
 ## Modals
-- **Unmount, Mount, Restart, Shutdown**: Each action temporarily disables its button and uses existing completion/error messaging.
+- **Unmount, Mount, Restart, Shutdown**: Each action temporarily disables its button and uses completion/error messaging.
+- The unmount success message repeats that the dashboard action is temporary. That reminder matters because the app still manages the configured backup drive through its mount checks and `/etc/fstab` entry.
 
 ## Live Updates
 - Status cards and system resources update live using background API calls.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -16,6 +16,7 @@ Four cards display real-time status:
 
 ## System Actions
 - **Unmount Storage**: Opens a modal to confirm a temporary unmount of the configured backup drive.
+- Before unmounting, the app best-effort closes SMB sessions and stops the related background tasks so Samba does not keep the backup share busy.
 - If the backup drive stays connected, SimpleSaferServer may remount it automatically during the next scheduled `Check Mount` run.
 - When the next `Check Mount` run is available, the confirmation dialog explains the remount timing as a relative countdown so the user knows how long they have to remove or swap the drive.
 - **Mount Storage**: Opens a modal to mount the storage drive.

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -50,6 +50,12 @@ This flow is partition-oriented.
 
 This is different from setup wizard step 2, which is disk-oriented for formatting.
 
+It is also different from the main Dashboard `Unmount Drive` action.
+
+- Dashboard unmount is temporary for the configured backup drive.
+- If that drive stays connected, SimpleSaferServer may remount it automatically during the next scheduled `Check Mount` run.
+- The Drive Health unmount button exists to clear the selected partition so the rerun flow can mount and validate the exact partition you picked.
+
 ## What the Rerun Flow Updates
 
 - the stored backup `mount_point`

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -47,6 +47,7 @@ This flow is partition-oriented.
 - Partitions reported as `ntfs3`, `ntfs-3g`, or confirmed-NTFS `fuseblk` are treated as NTFS backup targets by the picker.
 - The unmount action unmounts only the exact selected partition.
 - That unmount action only clears the live mount so the selected partition can be validated and configured again.
+- If the selected partition is still the configured backup drive and it is currently mounted at the managed backup mount point, the app first disconnects SMB access and stops the related background tasks so the unmount is not blocked by busy share handles.
 - The configure action mounts only the exact selected partition.
 
 This is different from setup wizard step 2, which is disk-oriented for formatting.
@@ -56,6 +57,7 @@ It is also different from the main Dashboard `Unmount Drive` action.
 - Dashboard unmount is temporary for the configured backup drive.
 - If that drive stays connected, SimpleSaferServer may remount it automatically during the next scheduled `Check Mount` run.
 - The Drive Health unmount button exists to clear the selected partition so the rerun flow can mount and validate the exact partition you picked.
+- When the selected partition is the live configured backup share, Drive Health uses the same SMB-safe unmount sequence as Dashboard, but it does not power the disk down because the next step is usually to mount and validate it again.
 - The Drive Health unmount button does not clear the stored backup `mount_point`, `uuid`, `usb_id`, or managed `/etc/fstab` entry by itself.
 
 ## What the Rerun Flow Updates
@@ -67,6 +69,7 @@ It is also different from the main Dashboard `Unmount Drive` action.
 - the Samba backup share path if the mount point changed
 
 The rerun flow always refreshes the managed `/etc/fstab` entry with `defaults,nofail`.
+After rewriting the managed `/etc/fstab` entry, the app also runs `systemctl daemon-reload` so the next `Check Mount` run sees the updated systemd-generated mount units immediately.
 
 Persistent backup-drive state changes happen only when the rerun configure step succeeds.
 That separation is intentional because a failed replacement attempt should still be able to fall back to the previously configured backup drive.
@@ -106,6 +109,7 @@ Manual recovery rules:
 
 - Update `/etc/SimpleSaferServer/config.conf` only if you know the correct `mount_point`, `uuid`, and `usb_id`.
 - Update only the SimpleSaferServer-managed `/etc/fstab` entry.
+- Run `sudo systemctl daemon-reload` after manually changing `/etc/fstab` so systemd forgets the old generated mount unit state.
 - If the mount point changes, also check `/etc/samba/smb.conf`.
 - Do not modify unrelated `/etc/fstab` entries.
 - Back up `/etc/fstab` before editing it manually.
@@ -127,6 +131,7 @@ After manual changes, verify the result:
 ```bash
 sudo findmnt --verify
 sudo mkdir -p /media/backup
+sudo systemctl daemon-reload
 sudo mount -a
 sudo systemctl restart smbd nmbd simple_safer_server_web.service
 ```

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -22,6 +22,7 @@ The Drive Health page combines two views of the configured backup drive:
 - Use the advanced section on the Drive Health page only if the backup drive changed or the original identifiers were detected incorrectly.
 - The flow is designed to re-run the backup drive mount setup safely instead of editing UUID or USB ID fields directly.
 - It updates only the SimpleSaferServer-managed backup mount entry in `/etc/fstab`.
+- The rerun flow always refreshes the managed entry with the boot-safe `defaults,nofail` mount options.
 - If the app finds multiple managed entries or a conflicting non-SimpleSaferServer entry using the same UUID or mount point, it stops and asks for manual cleanup.
 
 What "SimpleSaferServer-managed" means:

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -24,6 +24,10 @@ The Drive Health page combines two views of the configured backup drive:
 - It updates only the SimpleSaferServer-managed backup mount entry in `/etc/fstab`.
 - If the app finds multiple managed entries or a conflicting non-SimpleSaferServer entry using the same UUID or mount point, it stops and asks for manual cleanup.
 
+What "SimpleSaferServer-managed" means:
+- It refers to the backup drive line in `/etc/fstab` that ends with the marker comment `# SimpleSaferServer managed backup drive`.
+- The app does not treat unrelated `/etc/fstab` lines as its own unless they carry that backup-drive marker (or the older legacy marker).
+
 ## Manual Recovery
 If you need to inspect or repair the backup drive configuration manually, start here:
 
@@ -44,8 +48,14 @@ sudo findmnt --verify
 Manual recovery rules:
 - Update `/etc/SimpleSaferServer/config.conf` only if you know the correct `mount_point`, `uuid`, and `usb_id` values.
 - Update only the SimpleSaferServer-managed line in `/etc/fstab`.
+- If the mount point changes, also check the backup share path in `/etc/samba/smb.conf`.
 - Do not modify unrelated `/etc/fstab` entries.
 - Create a backup of `/etc/fstab` before editing it.
+
+Important file locations:
+- App config: `/etc/SimpleSaferServer/config.conf`
+- Managed mount entry: `/etc/fstab`
+- Samba share config: `/etc/samba/smb.conf`
 
 Example managed `/etc/fstab` entry:
 

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -46,6 +46,7 @@ This flow is partition-oriented.
 - If `lsblk` reports a mounted `ntfs-3g` partition as `fuseblk`, the app double-checks the on-disk type with `blkid` before showing it.
 - Partitions reported as `ntfs3`, `ntfs-3g`, or confirmed-NTFS `fuseblk` are treated as NTFS backup targets by the picker.
 - The unmount action unmounts only the exact selected partition.
+- That unmount action only clears the live mount so the selected partition can be validated and configured again.
 - The configure action mounts only the exact selected partition.
 
 This is different from setup wizard step 2, which is disk-oriented for formatting.
@@ -55,6 +56,7 @@ It is also different from the main Dashboard `Unmount Drive` action.
 - Dashboard unmount is temporary for the configured backup drive.
 - If that drive stays connected, SimpleSaferServer may remount it automatically during the next scheduled `Check Mount` run.
 - The Drive Health unmount button exists to clear the selected partition so the rerun flow can mount and validate the exact partition you picked.
+- The Drive Health unmount button does not clear the stored backup `mount_point`, `uuid`, `usb_id`, or managed `/etc/fstab` entry by itself.
 
 ## What the Rerun Flow Updates
 
@@ -65,6 +67,9 @@ It is also different from the main Dashboard `Unmount Drive` action.
 - the Samba backup share path if the mount point changed
 
 The rerun flow always refreshes the managed `/etc/fstab` entry with `defaults,nofail`.
+
+Persistent backup-drive state changes happen only when the rerun configure step succeeds.
+That separation is intentional because a failed replacement attempt should still be able to fall back to the previously configured backup drive.
 
 ## What "SimpleSaferServer-managed" Means
 

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -48,6 +48,7 @@ This flow is partition-oriented.
 - The unmount action unmounts only the exact selected partition.
 - That unmount action only clears the live mount so the selected partition can be validated and configured again.
 - If the selected partition is still the configured backup drive and it is currently mounted at the managed backup mount point, the app first disconnects SMB access and stops the related background tasks so the unmount is not blocked by busy share handles.
+- The app intentionally does not escalate to that broader SMB-safe path based on UUID alone, because cloned replacement disks can legitimately share a filesystem UUID and would make the selected physical device ambiguous.
 - The configure action mounts only the exact selected partition.
 
 This is different from setup wizard step 2, which is disk-oriented for formatting.

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -42,7 +42,9 @@ Use the advanced backup-drive section only when:
 This flow is partition-oriented.
 
 - The selector shows NTFS partitions.
+- The selector uses the same NTFS-partition scan as setup wizard step 3.
 - If `lsblk` reports a mounted `ntfs-3g` partition as `fuseblk`, the app double-checks the on-disk type with `blkid` before showing it.
+- Partitions reported as `ntfs3`, `ntfs-3g`, or confirmed-NTFS `fuseblk` are treated as NTFS backup targets by the picker.
 - The unmount action unmounts only the exact selected partition.
 - The configure action mounts only the exact selected partition.
 

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -18,6 +18,50 @@ The Drive Health page combines two views of the configured backup drive:
 - HDSentinel alerts only trigger on health changes between scheduled checks.
 - Temperature is displayed but does not currently trigger alerts.
 
+## Re-running Backup Drive Setup
+- Use the advanced section on the Drive Health page only if the backup drive changed or the original identifiers were detected incorrectly.
+- The flow is designed to re-run the backup drive mount setup safely instead of editing UUID or USB ID fields directly.
+- It updates only the SimpleSaferServer-managed backup mount entry in `/etc/fstab`.
+- If the app finds multiple managed entries or a conflicting non-SimpleSaferServer entry using the same UUID or mount point, it stops and asks for manual cleanup.
+
+## Manual Recovery
+If you need to inspect or repair the backup drive configuration manually, start here:
+
+```bash
+sudo awk '1' /etc/SimpleSaferServer/config.conf
+sudo grep -n 'SimpleSaferServer' /etc/fstab
+```
+
+Useful commands:
+
+```bash
+lsblk -f
+sudo blkid -s UUID -o value /dev/sdX1
+lsusb
+sudo findmnt --verify
+```
+
+Manual recovery rules:
+- Update `/etc/SimpleSaferServer/config.conf` only if you know the correct `mount_point`, `uuid`, and `usb_id` values.
+- Update only the SimpleSaferServer-managed line in `/etc/fstab`.
+- Do not modify unrelated `/etc/fstab` entries.
+- Create a backup of `/etc/fstab` before editing it.
+
+Example managed `/etc/fstab` entry:
+
+```fstab
+UUID=2CD49023D48FED80    /media/backup    ntfs-3g    defaults,nofail    0    0 # SimpleSaferServer managed backup drive
+```
+
+After manual changes, verify the result:
+
+```bash
+sudo findmnt --verify
+sudo mkdir -p /media/backup
+sudo mount -a
+sudo systemctl restart smbd nmbd simple_safer_server_web.service
+```
+
 ---
 
 This page is the main place to inspect the backup drive's current SMART and HDSentinel health data.

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -16,6 +16,21 @@ It combines:
 - Enable or disable HDSentinel monitoring and change alert settings.
 - Download SMART telemetry as CSV.
 
+## SMART Error Reporting
+
+The SMART prediction path uses `smartctl` JSON output when the installed
+`smartctl` version supports `-j`.
+
+- The "upgrade smartmontools" warning is reserved for the explicit case where
+  `smartctl -h` shows that JSON output is unavailable.
+- If `smartctl` advertises JSON support but the actual SMART read still fails,
+  the app preserves the original `smartctl` error instead. This matters because
+  USB bridges, controller quirks, and device read failures can all break SMART
+  collection even on newer smartmontools versions.
+
+That split is easy to forget later because both cases may surface during the
+same troubleshooting session, but they need different remediation.
+
 ## Re-running Backup Drive Setup
 
 Use the advanced backup-drive section only when:

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -1,45 +1,71 @@
 # Drive Health
 
-The Drive Health page combines two views of the configured backup drive:
+The Drive Health page is the main place to inspect the configured backup drive and to rerun backup-drive configuration if the physical backup device changes.
 
-- SMART data plus the local machine-learning failure prediction
+It combines:
+
+- SMART data and the local failure-prediction result
 - HDSentinel health and performance reporting
 
 ## Features
-- **Run Health Check**: Runs a manual SMART and HDSentinel refresh from the page.
-- **Prediction Result**: Shows whether the SMART model predicts failure, with probability percentage.
-- **Missing Attributes**: Lists SMART attributes that fell back to defaults.
-- **HDSentinel Status**: Shows install state, device, model, serial, health, performance, temperature, size, and last checked time.
-- **HDSentinel Settings**: Lets users enable or disable HDSentinel monitoring and toggle health-change alerts.
-- **SMART Data Table**: Lists SMART attributes, descriptions, raw values, and status.
-- **Download Telemetry**: Downloads the SMART telemetry CSV.
 
-## Alerting
-- HDSentinel alerts only trigger on health changes between scheduled checks.
-- Temperature is displayed but does not currently trigger alerts.
+- Run a manual health refresh from the page.
+- View the SMART prediction result and probability.
+- View missing SMART attributes that fell back to defaults.
+- View the HDSentinel device snapshot.
+- Enable or disable HDSentinel monitoring and change alert settings.
+- Download SMART telemetry as CSV.
 
 ## Re-running Backup Drive Setup
-- Use the advanced section on the Drive Health page only if the backup drive changed or the original identifiers were detected incorrectly.
-- The flow is designed to re-run the backup drive mount setup safely instead of editing UUID or USB ID fields directly.
-- It updates only the SimpleSaferServer-managed backup mount entry in `/etc/fstab`.
-- The rerun flow always refreshes the managed entry with the boot-safe `defaults,nofail` mount options.
-- If the app finds multiple managed entries or a conflicting non-SimpleSaferServer entry using the same UUID or mount point, it stops and asks for manual cleanup.
 
-What "SimpleSaferServer-managed" means:
-- It refers to the backup drive line in `/etc/fstab` that ends with the marker comment `# SimpleSaferServer managed backup drive`.
-- The app does not treat unrelated `/etc/fstab` lines as its own unless they carry that backup-drive marker (or the older legacy marker).
+Use the advanced backup-drive section only when:
+
+- the backup drive was replaced
+- the original UUID or USB ID was detected incorrectly
+- the app needs to be pointed at the correct backup partition again
+
+This flow is partition-oriented.
+
+- The selector shows NTFS partitions.
+- The unmount action unmounts only the exact selected partition.
+- The configure action mounts only the exact selected partition.
+
+This is different from setup wizard step 2, which is disk-oriented for formatting.
+
+## What the Rerun Flow Updates
+
+- the stored backup `mount_point`
+- the stored backup `uuid`
+- the stored backup `usb_id`
+- the SimpleSaferServer-managed `/etc/fstab` entry for the backup drive
+- the Samba backup share path if the mount point changed
+
+The rerun flow always refreshes the managed `/etc/fstab` entry with `defaults,nofail`.
+
+## What "SimpleSaferServer-managed" Means
+
+The app only manages the `/etc/fstab` line for the backup drive that ends with:
+
+```text
+# SimpleSaferServer managed backup drive
+```
+
+The app does not treat unrelated `/etc/fstab` lines as its own unless they use that marker or the older legacy marker.
+
+## Safety Rules
+
+- The rerun flow does not edit unrelated `/etc/fstab` entries.
+- If the app finds multiple managed entries, it stops and asks for manual cleanup.
+- If a non-SimpleSaferServer entry already uses the same UUID or mount point, it stops and asks for manual cleanup.
+- If the selected partition is already mounted, it stops and asks the user to unmount it first.
 
 ## Manual Recovery
-If you need to inspect or repair the backup drive configuration manually, start here:
+
+If you need to inspect or repair the backup-drive configuration manually, start here:
 
 ```bash
 sudo awk '1' /etc/SimpleSaferServer/config.conf
 sudo grep -n 'SimpleSaferServer' /etc/fstab
-```
-
-Useful commands:
-
-```bash
 lsblk -f
 sudo blkid -s UUID -o value /dev/sdX1
 lsusb
@@ -47,13 +73,15 @@ sudo findmnt --verify
 ```
 
 Manual recovery rules:
-- Update `/etc/SimpleSaferServer/config.conf` only if you know the correct `mount_point`, `uuid`, and `usb_id` values.
-- Update only the SimpleSaferServer-managed line in `/etc/fstab`.
-- If the mount point changes, also check the backup share path in `/etc/samba/smb.conf`.
+
+- Update `/etc/SimpleSaferServer/config.conf` only if you know the correct `mount_point`, `uuid`, and `usb_id`.
+- Update only the SimpleSaferServer-managed `/etc/fstab` entry.
+- If the mount point changes, also check `/etc/samba/smb.conf`.
 - Do not modify unrelated `/etc/fstab` entries.
-- Create a backup of `/etc/fstab` before editing it.
+- Back up `/etc/fstab` before editing it manually.
 
 Important file locations:
+
 - App config: `/etc/SimpleSaferServer/config.conf`
 - Managed mount entry: `/etc/fstab`
 - Samba share config: `/etc/samba/smb.conf`
@@ -72,7 +100,3 @@ sudo mkdir -p /media/backup
 sudo mount -a
 sudo systemctl restart smbd nmbd simple_safer_server_web.service
 ```
-
----
-
-This page is the main place to inspect the backup drive's current SMART and HDSentinel health data.

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -27,6 +27,7 @@ Use the advanced backup-drive section only when:
 This flow is partition-oriented.
 
 - The selector shows NTFS partitions.
+- If `lsblk` reports a mounted `ntfs-3g` partition as `fuseblk`, the app double-checks the on-disk type with `blkid` before showing it.
 - The unmount action unmounts only the exact selected partition.
 - The configure action mounts only the exact selected partition.
 
@@ -67,6 +68,7 @@ If you need to inspect or repair the backup-drive configuration manually, start 
 sudo awk '1' /etc/SimpleSaferServer/config.conf
 sudo grep -n 'SimpleSaferServer' /etc/fstab
 lsblk -f
+sudo blkid -s TYPE -o value /dev/sdX1
 sudo blkid -s UUID -o value /dev/sdX1
 lsusb
 sudo findmnt --verify

--- a/docs/login.md
+++ b/docs/login.md
@@ -2,6 +2,8 @@
 
 The Login page allows administrators to sign in to the SimpleSaferServer management interface.
 
+The broader access model is documented in [Access and Permissions](access.md).
+
 ## Fields
 - **Username**: Enter your admin username.
 - **Password**: Enter your password.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,7 @@ The Setup Wizard guides you through the initial configuration of your backup sys
 - **Async Buttons**: Buttons disable while work is in progress.
 
 ## Step 1: Create Admin Account
-- **Username**: Enter a username (3-32 characters, letters, numbers, underscores, hyphens).
+- **Username**: Enter a username using letters, numbers, underscores, or hyphens.
 - **Server Name**: Name your server (required).
 - **Password**: Enter a password (minimum 4 characters).
 - **Confirm Password**: Re-enter the password to confirm.
@@ -30,6 +30,7 @@ The Setup Wizard guides you through the initial configuration of your backup sys
 - **Auto Mount**: Checkbox to mount automatically at boot.
 - **Unmount/Mount Buttons**: Unmount or mount the selected drive.
 - **Status/Error Areas**: Inline feedback for actions.
+- **Later Changes**: If the backup drive changes after setup, use the advanced section on the Drive Health page to re-run this part of the setup flow.
 
 ## Step 4: Backup Configuration
 - **Backup Mode**: Choose between:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,69 +1,89 @@
 # Setup Wizard
 
-The Setup Wizard guides you through the initial configuration of your backup system. It consists of six main steps, each with its own section and options.
+The Setup Wizard walks through the first-time configuration of the system. The backup-drive portion has two different target types on purpose:
+
+- Step 2 works on a whole disk when the user wants to prepare or erase a drive.
+- Step 3 works on an NTFS partition when the user wants to mount and configure the backup destination.
+
+That split is important because the safety checks are different.
 
 ## Navigation and Progress
-- **Progress Bar**: Shows current step and allows navigation between steps.
-- **Validation**: Inline feedback for all fields.
-- **Async Buttons**: Buttons disable while work is in progress.
+
+- The progress bar shows the current step and allows moving between steps.
+- Validation is inline for the form fields.
+- Async buttons disable themselves while work is in progress.
 
 ## Step 1: Create Admin Account
-- **Username**: Enter a username using letters, numbers, underscores, or hyphens.
-- **Server Name**: Name your server (required).
-- **Password**: Enter a password (minimum 4 characters).
-- **Confirm Password**: Re-enter the password to confirm.
-- **Validation**: Inline feedback is provided for all fields.
-- **Button**: `Create Admin Account` (proceeds to next step on success).
+
+- Enter the admin username.
+- Enter the server name.
+- Enter and confirm the password.
+- On success, the wizard logs the user in and moves to the next step.
 
 ## Step 2: Drive Format (Optional)
-- **Drive Selection**: Choose a drive to format from a dropdown (shows model, size, type, and mount status).
-- **Unmount Drive**: Button to unmount the selected drive (required before formatting).
-- **Format Drive**: Button to format the selected drive (erases all data).
-- **Status Area**: Shows messages about formatting/unmounting.
-- **Warning**: Formatting erases all data on the drive.
-- **Skip Formatting**: Button to proceed without formatting.
+
+This step is disk-oriented.
+
+- The selector shows disks, not partitions.
+- The unmount button unmounts every currently mounted partition that belongs to the selected disk.
+- The format button creates a single partition if needed and formats that partition as NTFS.
+- Formatting erases all existing data on the selected disk.
+
+Why it works this way:
+
+- Formatting is a whole-disk preparation step.
+- Desktop automounters often mount child partitions such as `/dev/sdb1`, so the wizard checks for mounted child partitions before allowing formatting.
 
 ## Step 3: Drive Mount
-- **Drive Selection**: Choose an NTFS partition to mount.
-- **Advanced Options**: Toggle to show mount point and auto-mount at boot.
-- **Mount Point**: Set the mount directory (default: `/media/backup`).
-- **Auto Mount**: Checkbox to mount automatically at boot.
-- **Boot Behavior**: The managed `/etc/fstab` entry uses `nofail`, so the system should still boot if the backup drive is disconnected.
-- **Unmount/Mount Buttons**: Unmount or mount the selected drive.
-- **Status/Error Areas**: Inline feedback for actions.
-- **Later Changes**: If the backup drive changes after setup, use the advanced section on the Drive Health page to re-run this part of the setup flow.
+
+This step is partition-oriented.
+
+- The selector shows NTFS partitions, not whole disks.
+- The unmount button unmounts only the exact selected partition.
+- The mount button mounts that selected NTFS partition at the chosen mount point.
+- Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.
+
+Boot behavior:
+
+- The managed `/etc/fstab` entry uses `defaults,nofail`.
+- That means the system should still boot if the backup drive is disconnected.
 
 ## Step 4: Backup Configuration
-- **Backup Mode**: Choose between:
-  - Easy MEGA Cloud Backup
-  - Advanced (Paste rclone config)
 
-### MEGA Easy Mode
-- **MEGA Email/Password**: Enter MEGA credentials.
-- **Connect & Choose Folder**: Button to connect and select a MEGA folder.
-- **Folder Path**: Shows selected MEGA folder.
-- **Modal**: MEGA folder picker modal for cloud backup setup.
-- **Warning**: All files in the selected MEGA folder will be overwritten during backup.
+Choose one cloud-backup mode:
 
-### Advanced rclone Config
-- **Rclone Configuration**: Paste rclone config.
-- **Remote Name and Path**: Enter in the format `remotename:/path`.
-- **Warning**: rclone will synchronize the remote path to match the local backup directory.
+- Easy MEGA Cloud Backup
+- Advanced rclone configuration
 
-- **Save Backup Configuration**: Button to save settings.
+MEGA mode:
+
+- Enter MEGA credentials.
+- Connect and choose the target folder.
+- The selected remote folder is shown before saving.
+
+Advanced mode:
+
+- Paste the rclone config.
+- Enter the remote in `remote:/path` form.
 
 ## Step 5: Email Setup
-- **Email Address**: Enter the address for alerts.
-- **From Address**: Enter the address that will appear in the From field of alert emails. This must be a valid, verified sender for your SMTP service (e.g., the authenticated SMTP user or a domain-verified address). Some SMTP providers will only deliver mail if the From address matches the authenticated user or a verified sender.
-- **SMTP Configuration**: Enter SMTP server, port, username, and password.
-- **Save Email Configuration**: Button to save settings.
+
+- Enter the destination alert email address.
+- Enter the From address used by the SMTP provider.
+- Enter SMTP host, port, username, and password.
 
 ## Step 6: Schedule
-- **Backup Time**: Set the daily backup time.
-- **Bandwidth Limit**: (Optional) Limit backup bandwidth (e.g., 4M for 4 MB/s).
-- **Save Schedule**: Button to save and complete setup.
 
+- Set the backup time.
+- Optionally set a bandwidth limit.
+- Save to complete setup.
 
----
+## Later Changes
 
-After completing all steps, the system is ready for use and redirects to the main interface. 
+If the backup drive changes after setup:
+
+- use the advanced backup-drive section on the Drive Health page
+- select the correct NTFS partition there
+- rerun only the backup-drive configuration portion
+
+That rerun flow is intentionally partition-oriented and does not behave like the whole-disk format step.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,6 +27,8 @@ This step is disk-oriented.
 - The selector shows disks, not partitions.
 - The selector intentionally detects eligible non-system disks whether they are blank, already formatted, or currently formatted with the wrong filesystem.
 - The unmount button unmounts every currently mounted partition that belongs to the selected disk.
+- That unmount action only clears live mounts so the format step can proceed safely.
+- It does not clear the saved backup-drive config and it does not remove the SimpleSaferServer-managed `/etc/fstab` entry.
 - The format button creates a single partition if needed and formats that partition as NTFS.
 - Formatting erases all existing data on the selected disk.
 
@@ -45,8 +47,15 @@ This step is partition-oriented.
 - If a mounted `ntfs-3g` partition shows up from `lsblk` as `fuseblk`, the wizard verifies the underlying on-disk type with `blkid` before treating it as NTFS.
 - Partitions reported as `ntfs3`, `ntfs-3g`, or confirmed-NTFS `fuseblk` are all exposed to the wizard as NTFS mount targets.
 - The unmount button unmounts only the exact selected partition.
+- That unmount action is temporary preparation for this step. It does not deconfigure the old backup drive by itself.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
 - Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.
+
+Persistent backup-drive state changes only when the mount/configure step succeeds:
+
+- `backup.mount_point`, `backup.uuid`, and `backup.usb_id` stay unchanged until a new backup-drive setup is applied successfully.
+- The SimpleSaferServer-managed `/etc/fstab` entry is updated only when the new setup is applied.
+- If the old backup drive is still the configured backup source and it remains connected, `Check Mount` may mount it again after an unmount-only step.
 
 That NTFS-only scan is shared with the backup-drive rerun flow on Drive Health.
 This is worth calling out because the setup wizard and the rerun flow need to

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -25,6 +25,7 @@ That split is important because the safety checks are different.
 This step is disk-oriented.
 
 - The selector shows disks, not partitions.
+- The selector intentionally detects eligible non-system disks whether they are blank, already formatted, or currently formatted with the wrong filesystem.
 - The unmount button unmounts every currently mounted partition that belongs to the selected disk.
 - The format button creates a single partition if needed and formats that partition as NTFS.
 - Formatting erases all existing data on the selected disk.
@@ -33,13 +34,16 @@ Why it works this way:
 
 - Formatting is a whole-disk preparation step.
 - Desktop automounters often mount child partitions such as `/dev/sdb1`, so the wizard checks for mounted child partitions before allowing formatting.
+- This is a simple destructive preparation flow. It is not a partition resizer and it does not try to preserve or rearrange an existing multi-partition layout.
 
 ## Step 3: Drive Mount
 
 This step is partition-oriented.
 
 - The selector shows NTFS partitions, not whole disks.
+- The selector uses a dedicated NTFS-partition scan instead of the broader step-2 disk scan.
 - If a mounted `ntfs-3g` partition shows up from `lsblk` as `fuseblk`, the wizard verifies the underlying on-disk type with `blkid` before treating it as NTFS.
+- Partitions reported as `ntfs3`, `ntfs-3g`, or confirmed-NTFS `fuseblk` are all exposed to the wizard as NTFS mount targets.
 - The unmount button unmounts only the exact selected partition.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
 - Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,6 +39,7 @@ Why it works this way:
 This step is partition-oriented.
 
 - The selector shows NTFS partitions, not whole disks.
+- If a mounted `ntfs-3g` partition shows up from `lsblk` as `fuseblk`, the wizard verifies the underlying on-disk type with `blkid` before treating it as NTFS.
 - The unmount button unmounts only the exact selected partition.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
 - Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,6 +48,7 @@ This step is partition-oriented.
 - Partitions reported as `ntfs3`, `ntfs-3g`, or confirmed-NTFS `fuseblk` are all exposed to the wizard as NTFS mount targets.
 - The unmount button unmounts only the exact selected partition.
 - That unmount action is temporary preparation for this step. It does not deconfigure the old backup drive by itself.
+- If the selected partition is also the currently configured backup drive and it is live at the managed backup mount point, the same SMB-safe unmount sequence used on Dashboard is needed to clear sharing handles before the partition can be reused.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
 - Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.
 
@@ -55,6 +56,7 @@ Persistent backup-drive state changes only when the mount/configure step succeed
 
 - `backup.mount_point`, `backup.uuid`, and `backup.usb_id` stay unchanged until a new backup-drive setup is applied successfully.
 - The SimpleSaferServer-managed `/etc/fstab` entry is updated only when the new setup is applied.
+- After the managed `/etc/fstab` entry changes, the app runs `systemctl daemon-reload` so `Check Mount` and the generated mount units immediately follow the new backup-drive definition.
 - If the old backup drive is still the configured backup source and it remains connected, `Check Mount` may mount it again after an unmount-only step.
 
 That NTFS-only scan is shared with the backup-drive rerun flow on Drive Health.
@@ -106,3 +108,4 @@ If the backup drive changes after setup:
 - rerun only the backup-drive configuration portion
 
 That rerun flow is intentionally partition-oriented and does not behave like the whole-disk format step.
+If the selected partition is still the live configured backup share, the rerun flow temporarily disconnects SMB access before unmounting it.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,6 +28,7 @@ The Setup Wizard guides you through the initial configuration of your backup sys
 - **Advanced Options**: Toggle to show mount point and auto-mount at boot.
 - **Mount Point**: Set the mount directory (default: `/media/backup`).
 - **Auto Mount**: Checkbox to mount automatically at boot.
+- **Boot Behavior**: The managed `/etc/fstab` entry uses `nofail`, so the system should still boot if the backup drive is disconnected.
 - **Unmount/Mount Buttons**: Unmount or mount the selected drive.
 - **Status/Error Areas**: Inline feedback for actions.
 - **Later Changes**: If the backup drive changes after setup, use the advanced section on the Drive Health page to re-run this part of the setup flow.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,9 +46,10 @@ This step is partition-oriented.
 - The selector uses a dedicated NTFS-partition scan instead of the broader step-2 disk scan.
 - If a mounted `ntfs-3g` partition shows up from `lsblk` as `fuseblk`, the wizard verifies the underlying on-disk type with `blkid` before treating it as NTFS.
 - Partitions reported as `ntfs3`, `ntfs-3g`, or confirmed-NTFS `fuseblk` are all exposed to the wizard as NTFS mount targets.
+- Drive labels prefer `lsblk` transport data such as `TRAN=usb`, with `RM` and `HOTPLUG` as fallbacks, so removable backup targets are not mislabeled as internal disks.
 - The unmount button unmounts only the exact selected partition.
 - That unmount action is temporary preparation for this step. It does not deconfigure the old backup drive by itself.
-- If the selected partition is also the currently configured backup drive and it is live at the managed backup mount point, the same SMB-safe unmount sequence used on Dashboard is needed to clear sharing handles before the partition can be reused.
+- If the exact unmount fails and the selected partition still appears to be the currently configured backup drive, the wizard offers a second explicit SMB-safe retry that may temporarily stop SMB access and the related background backup tasks before retrying the unmount.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
 - Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.
 
@@ -108,4 +109,4 @@ If the backup drive changes after setup:
 - rerun only the backup-drive configuration portion
 
 That rerun flow is intentionally partition-oriented and does not behave like the whole-disk format step.
-If the selected partition is still the live configured backup share, the rerun flow temporarily disconnects SMB access before unmounting it.
+If the selected partition is still the live configured backup share, the rerun flow can temporarily disconnect SMB access before unmounting it.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,6 +19,8 @@ That split is important because the safety checks are different.
 - Enter the server name.
 - Enter and confirm the password.
 - On success, the wizard logs the user in and moves to the next step.
+- That first account becomes the initial administrator for the web UI.
+- Only administrator accounts can sign in to the management interface after setup.
 
 ## Step 2: Drive Format (Optional)
 
@@ -49,7 +51,8 @@ This step is partition-oriented.
 - Drive labels prefer `lsblk` transport data such as `TRAN=usb`, with `RM` and `HOTPLUG` as fallbacks, so removable backup targets are not mislabeled as internal disks.
 - The unmount button unmounts only the exact selected partition.
 - That unmount action is temporary preparation for this step. It does not deconfigure the old backup drive by itself.
-- If the exact unmount fails and the selected partition still appears to be the currently configured backup drive, the wizard offers a second explicit SMB-safe retry that may temporarily stop SMB access and the related background backup tasks before retrying the unmount.
+- If the exact unmount fails and the selected partition is still the live configured backup drive mounted at the managed backup mount point, the wizard offers a second explicit SMB-safe retry that may temporarily stop SMB access and the related background backup tasks before retrying the unmount.
+- The wizard intentionally does not offer that broader retry based on UUID alone, because cloned replacement disks can legitimately share a filesystem UUID and would make the safety check ambiguous.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
 - Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -44,6 +44,11 @@ This step is partition-oriented.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
 - Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.
 
+That NTFS-only scan is shared with the backup-drive rerun flow on Drive Health.
+This is worth calling out because the setup wizard and the rerun flow need to
+agree about which partitions are selectable, especially for already-mounted
+`ntfs-3g` volumes that appear as `fuseblk`.
+
 Boot behavior:
 
 - The managed `/etc/fstab` entry uses `defaults,nofail`.

--- a/drive_health.py
+++ b/drive_health.py
@@ -563,7 +563,8 @@ def collect_hdsentinel_snapshot(config_manager, system_utils, runtime=None, devi
             report_text = report_path.read_text(errors="replace")
             report_data = parse_hdsentinel_report(report_text)
     finally:
-        report_path.unlink(missing_ok=True)
+        if report_path.exists():
+            report_path.unlink()
 
     snapshot.update(solid_data)
     for key, value in report_data.items():

--- a/drive_health.py
+++ b/drive_health.py
@@ -23,6 +23,10 @@ except (ImportError, OSError):
 
 
 LOGGER = logging.getLogger(__name__)
+SMARTCTL_JSON_UPGRADE_MESSAGE = (
+    "The installed smartctl version does not support JSON output required for SMART-based health prediction. "
+    "Upgrade smartmontools on this machine to enable SMART prediction."
+)
 
 SMART_FIELDS = {
     "smart_1_raw": {
@@ -121,6 +125,18 @@ def get_fake_smart_attributes():
 
 
 @lru_cache(maxsize=1)
+def get_smartctl_json_support():
+    if not shutil.which("smartctl"):
+        return False, "smartctl is not installed on this machine."
+
+    result = subprocess.run(["smartctl", "-h"], capture_output=True, text=True)
+    help_output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+    if "-j" in help_output or "--json" in help_output:
+        return True, None
+    return False, SMARTCTL_JSON_UPGRADE_MESSAGE
+
+
+@lru_cache(maxsize=1)
 def _load_model_and_threshold(model_path: str, threshold_path: str):
     if XGBClassifier is None or joblib is None:
         return None, 0.5
@@ -208,63 +224,35 @@ def resolve_backup_parent_device(config_manager, system_utils, runtime=None):
 def get_smart_attributes(config_manager, system_utils, device=None, runtime=None):
     runtime = runtime or get_runtime()
     if runtime.is_fake:
-        return get_fake_smart_attributes()
+        attrs, missing = get_fake_smart_attributes()
+        return attrs, missing, None
 
     try:
+        smartctl_json_supported, smartctl_json_error = get_smartctl_json_support()
+        if not smartctl_json_supported:
+            LOGGER.warning(smartctl_json_error)
+            return None, None, smartctl_json_error
+
         if device is None:
-            device, partition_device, error = resolve_backup_parent_device(config_manager, system_utils, runtime=runtime)
+            device, _, error = resolve_backup_parent_device(config_manager, system_utils, runtime=runtime)
             if error:
                 LOGGER.warning(error)
-                return None, None
-        else:
-            partition_device = None
+                return None, None, error
 
-        candidate_devices = [device]
-        if partition_device and partition_device not in candidate_devices:
-            candidate_devices.append(partition_device)
+        command = ["smartctl", "-A", "-j", device]
+        if os.geteuid() != 0 and shutil.which("sudo"):
+            command.insert(0, "sudo")
 
-        transport_attempts = [
-            [],
-            ["-d", "sat"],
-            ["-d", "sat,12"],
-            ["-d", "sat,16"],
-            ["-d", "scsi"],
-        ]
+        result = subprocess.run(command, capture_output=True, text=True)
+        stdout = (result.stdout or "").strip()
+        stderr = (result.stderr or "").strip()
 
-        data = None
-        attempt_errors = []
-        for candidate_device in candidate_devices:
-            for transport_args in transport_attempts:
-                command = ["smartctl", "-A", "-j"] + transport_args + [candidate_device]
-                if os.geteuid() != 0 and shutil.which("sudo"):
-                    command.insert(0, "sudo")
+        if not stdout:
+            error_message = stderr or "smartctl returned no JSON output"
+            LOGGER.warning("Failed to retrieve SMART JSON: %s", error_message)
+            return None, None, error_message
 
-                result = subprocess.run(command, capture_output=True, text=True)
-                stdout = (result.stdout or "").strip()
-                stderr = (result.stderr or "").strip()
-
-                if stdout:
-                    try:
-                        parsed = json.loads(stdout)
-                        data = parsed
-                        device = candidate_device
-                        break
-                    except json.JSONDecodeError as exc:
-                        attempt_errors.append(
-                            "{}: invalid JSON output ({})".format(" ".join(command), exc)
-                        )
-                        continue
-
-                error_text = stderr or "smartctl returned no JSON output"
-                attempt_errors.append("{}: {}".format(" ".join(command), error_text))
-
-            if data is not None:
-                break
-
-        if data is None:
-            if attempt_errors:
-                LOGGER.warning("Failed to retrieve SMART JSON:\n%s", "\n".join(attempt_errors))
-            return None, None
+        data = json.loads(stdout)
 
         attrs = {field: info["default"] for field, info in SMART_FIELDS.items()}
         missing_attrs = set(SMART_FIELDS.keys())
@@ -282,13 +270,13 @@ def get_smart_attributes(config_manager, system_utils, device=None, runtime=None
             except (ValueError, KeyError, TypeError):
                 LOGGER.warning("Could not parse SMART value for %s", field_name)
 
-        return attrs, list(missing_attrs)
+        return attrs, list(missing_attrs), None
     except json.JSONDecodeError as exc:
         LOGGER.warning("Failed to parse smartctl JSON output: %s", exc)
-        return None, None
+        return None, None, SMARTCTL_JSON_UPGRADE_MESSAGE
     except Exception as exc:
         LOGGER.warning("Unexpected SMART read error: %s", exc)
-        return None, None
+        return None, None, str(exc)
 
 
 def append_telemetry(data_dict, prediction, runtime=None):

--- a/drive_health.py
+++ b/drive_health.py
@@ -743,14 +743,7 @@ def run_scheduled_drive_health_check(config_manager, system_utils, runtime=None)
             }
 
         message = smart_error or f"Could not retrieve SMART data from {device}."
-        _log_and_email_alert(
-            config_manager,
-            runtime,
-            "Drive Health Check Failed - No SMART Data",
-            message,
-            alert_type="error",
-            source="check_health",
-        )
+        LOGGER.warning("Drive health check could not retrieve SMART data: %s", message)
         raise RuntimeError(message)
 
     probability = predict_failure_probability(smart, runtime=runtime)

--- a/drive_health.py
+++ b/drive_health.py
@@ -286,7 +286,16 @@ def get_smart_attributes(config_manager, system_utils, device=None, runtime=None
         return attrs, list(missing_attrs), None
     except json.JSONDecodeError as exc:
         LOGGER.warning("Failed to parse smartctl JSON output: %s", exc)
-        return None, None, SMARTCTL_JSON_UPGRADE_MESSAGE
+        # We only surface the upgrade warning from the explicit capability
+        # check above. If `-j` is advertised but this invocation still emits
+        # malformed or plain-text output, that usually points to a device,
+        # bridge, or transport problem rather than an outdated binary.
+        error_message = (
+            locals().get("stderr")
+            or locals().get("stdout")
+            or f"Failed to parse smartctl JSON output: {exc}"
+        )
+        return None, None, error_message
     except Exception as exc:
         LOGGER.warning("Unexpected SMART read error: %s", exc)
         return None, None, str(exc)

--- a/drive_health.py
+++ b/drive_health.py
@@ -124,8 +124,10 @@ def get_fake_smart_attributes():
     return attrs, []
 
 
-@lru_cache(maxsize=1)
 def get_smartctl_json_support():
+    # Do not cache this result across the whole process. Operators can install
+    # or upgrade smartmontools while the web service keeps running, and a stale
+    # negative result would keep blocking SMART reads until restart.
     if not shutil.which("smartctl"):
         return False, "smartctl is not installed on this machine."
 

--- a/drive_health.py
+++ b/drive_health.py
@@ -744,6 +744,14 @@ def run_scheduled_drive_health_check(config_manager, system_utils, runtime=None)
 
         message = smart_error or f"Could not retrieve SMART data from {device}."
         LOGGER.warning("Drive health check could not retrieve SMART data: %s", message)
+        _log_and_email_alert(
+            config_manager,
+            runtime,
+            "Drive Health Check Failed - SMART Read Error",
+            message,
+            alert_type="error",
+            source="check_health",
+        )
         raise RuntimeError(message)
 
     probability = predict_failure_probability(smart, runtime=runtime)

--- a/drive_health.py
+++ b/drive_health.py
@@ -212,16 +212,59 @@ def get_smart_attributes(config_manager, system_utils, device=None, runtime=None
 
     try:
         if device is None:
-            device, _, error = resolve_backup_parent_device(config_manager, system_utils, runtime=runtime)
+            device, partition_device, error = resolve_backup_parent_device(config_manager, system_utils, runtime=runtime)
             if error:
                 LOGGER.warning(error)
                 return None, None
+        else:
+            partition_device = None
 
-        command = ["smartctl", "-A", "-j", device]
-        if os.geteuid() != 0 and shutil.which("sudo"):
-            command.insert(0, "sudo")
-        result = subprocess.run(command, capture_output=True, text=True, check=True)
-        data = json.loads(result.stdout)
+        candidate_devices = [device]
+        if partition_device and partition_device not in candidate_devices:
+            candidate_devices.append(partition_device)
+
+        transport_attempts = [
+            [],
+            ["-d", "sat"],
+            ["-d", "sat,12"],
+            ["-d", "sat,16"],
+            ["-d", "scsi"],
+        ]
+
+        data = None
+        attempt_errors = []
+        for candidate_device in candidate_devices:
+            for transport_args in transport_attempts:
+                command = ["smartctl", "-A", "-j"] + transport_args + [candidate_device]
+                if os.geteuid() != 0 and shutil.which("sudo"):
+                    command.insert(0, "sudo")
+
+                result = subprocess.run(command, capture_output=True, text=True)
+                stdout = (result.stdout or "").strip()
+                stderr = (result.stderr or "").strip()
+
+                if stdout:
+                    try:
+                        parsed = json.loads(stdout)
+                        data = parsed
+                        device = candidate_device
+                        break
+                    except json.JSONDecodeError as exc:
+                        attempt_errors.append(
+                            "{}: invalid JSON output ({})".format(" ".join(command), exc)
+                        )
+                        continue
+
+                error_text = stderr or "smartctl returned no JSON output"
+                attempt_errors.append("{}: {}".format(" ".join(command), error_text))
+
+            if data is not None:
+                break
+
+        if data is None:
+            if attempt_errors:
+                LOGGER.warning("Failed to retrieve SMART JSON:\n%s", "\n".join(attempt_errors))
+            return None, None
 
         attrs = {field: info["default"] for field, info in SMART_FIELDS.items()}
         missing_attrs = set(SMART_FIELDS.keys())
@@ -240,9 +283,6 @@ def get_smart_attributes(config_manager, system_utils, device=None, runtime=None
                 LOGGER.warning("Could not parse SMART value for %s", field_name)
 
         return attrs, list(missing_attrs)
-    except subprocess.CalledProcessError as exc:
-        LOGGER.warning("Failed to execute smartctl: %s", exc)
-        return None, None
     except json.JSONDecodeError as exc:
         LOGGER.warning("Failed to parse smartctl JSON output: %s", exc)
         return None, None

--- a/drive_health.py
+++ b/drive_health.py
@@ -254,10 +254,23 @@ def get_smart_attributes(config_manager, system_utils, device=None, runtime=None
 
         data = json.loads(stdout)
 
+        smart_table = data.get("ata_smart_attributes", {}).get("table")
+        if result.returncode != 0 and not smart_table:
+            # Some smartctl failures still emit valid JSON, but without the ATA
+            # SMART table we need for prediction. Treat that as a read failure
+            # instead of silently falling back to model defaults.
+            error_message = (
+                stderr
+                or data.get("smartctl", {}).get("messages", [{}])[0].get("string")
+                or "smartctl could not retrieve SMART attributes"
+            )
+            LOGGER.warning("Failed to retrieve SMART JSON: %s", error_message)
+            return None, None, error_message
+
         attrs = {field: info["default"] for field, info in SMART_FIELDS.items()}
         missing_attrs = set(SMART_FIELDS.keys())
 
-        for item in data.get("ata_smart_attributes", {}).get("table", []):
+        for item in smart_table or []:
             field_name = f"smart_{item['id']}_raw"
             if field_name not in SMART_FIELDS:
                 continue

--- a/drive_health.py
+++ b/drive_health.py
@@ -733,14 +733,28 @@ def run_scheduled_drive_health_check(config_manager, system_utils, runtime=None)
         )
         raise RuntimeError(error)
 
-    smart, missing_attrs = get_smart_attributes(
+    smart, missing_attrs, smart_error = get_smart_attributes(
         config_manager,
         system_utils,
         device=device,
         runtime=runtime,
     )
     if smart is None:
-        message = f"Could not retrieve SMART data from {device}."
+        hdsentinel_result = run_hdsentinel_health_monitor(config_manager, system_utils, runtime=runtime)
+        if smart_error == SMARTCTL_JSON_UPGRADE_MESSAGE and hdsentinel_result.get("snapshot", {}).get("available"):
+            LOGGER.warning(smart_error)
+            return {
+                "device": device,
+                "smart": None,
+                "missing_attrs": None,
+                "probability": None,
+                "prediction": None,
+                "threshold": get_optimal_threshold(runtime),
+                "hdsentinel": hdsentinel_result,
+                "smart_warning": smart_error,
+            }
+
+        message = smart_error or f"Could not retrieve SMART data from {device}."
         _log_and_email_alert(
             config_manager,
             runtime,

--- a/drive_health.py
+++ b/drive_health.py
@@ -563,8 +563,10 @@ def collect_hdsentinel_snapshot(config_manager, system_utils, runtime=None, devi
             report_text = report_path.read_text(errors="replace")
             report_data = parse_hdsentinel_report(report_text)
     finally:
-        if report_path.exists():
+        try:
             report_path.unlink()
+        except FileNotFoundError:
+            pass
 
     snapshot.update(solid_data)
     for key, value in report_data.items():

--- a/index.html
+++ b/index.html
@@ -88,12 +88,14 @@
         </div>
         <div class="note">
             <i class="fa-solid fa-circle-info"></i> <strong>Note:</strong> Run as <code>root</code> or with <code>sudo</code> on a clean Debian-based system.<br>
-            The script will install all dependencies, set up the service, and print your Web UI address.
+            The script will install all dependencies, set up the service, and print your Web UI address.<br>
+            The management Web UI is admin-only, and the first account created during setup becomes the initial administrator.
         </div>
         <hr>
         <h2 class="mb-3"><i class="fa-solid fa-book"></i> Documentation</h2>
         <ul class="doc-list list-unstyled">
             <li><i class="fa-brands fa-github"></i> <a href="https://github.com/chrismin13/SimpleSaferServer" target="_blank">GitHub Repository</a></li>
+            <li><i class="fa-solid fa-user-shield"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/access.md" target="_blank">Access &amp; Permissions</a></li>
             <li><i class="fa-solid fa-gear"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/setup.md" target="_blank">Setup Guide</a></li>
             <li><i class="fa-solid fa-right-to-bracket"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/login.md" target="_blank">Login &amp; User Management</a></li>
             <li><i class="fa-solid fa-gauge-high"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/dashboard.md" target="_blank">Dashboard</a></li>
@@ -129,4 +131,3 @@
     </script>
 </body>
 </html>
-

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,7 @@ set -e
 
 APP_DIR="/opt/SimpleSaferServer"
 SCRIPTS_DIR="$APP_DIR/scripts"
+BIN_DIR="/usr/local/bin"
 MODEL_DIR="/opt/SimpleSaferServer/harddrive_model"
 VENV_DIR="$APP_DIR/venv"
 SERVICE_FILE="/etc/systemd/system/simple_safer_server_web.service"
@@ -164,14 +165,17 @@ if ! "$VENV_DIR/bin/pip" install -r "$APP_DIR/requirements-ml.txt"; then
 fi
 echo -e "${GREEN}✔ Python virtualenv ready at $VENV_DIR.${NC}\n"
 
-# 7. Copy scripts to /opt/SimpleSaferServer/scripts and set permissions
+# 7. Copy scripts to /opt/SimpleSaferServer/scripts and /usr/local/bin
 echo -e "${YELLOW}Step 7: Installing scripts...${NC}"
 mkdir -p "$SCRIPTS_DIR"
+mkdir -p "$BIN_DIR"
 for script in scripts/*.sh scripts/*.py; do
   cp "$script" "$SCRIPTS_DIR/"
   chmod +x "$SCRIPTS_DIR/$(basename $script)"
+  cp "$script" "$BIN_DIR/"
+  chmod +x "$BIN_DIR/$(basename $script)"
 done
-echo -e "${GREEN}✔ Scripts installed to $SCRIPTS_DIR.${NC}\n"
+echo -e "${GREEN}✔ Scripts installed to $SCRIPTS_DIR and $BIN_DIR.${NC}\n"
 
 # 8. Copy model files
 echo -e "${YELLOW}Step 8: Copying model files...${NC}"

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -3,8 +3,9 @@ from backup_drive_setup import (
     BackupDriveSetupError,
     apply_backup_drive_configuration,
     list_available_drives as get_available_backup_drives,
-    _get_mounted_partitions_for_drive,
-    unmount_selected_drive,
+    _get_mounted_partitions_for_disk,
+    unmount_disk_partitions,
+    unmount_selected_partition,
 )
 from config_manager import ConfigManager
 from system_utils import SystemUtils
@@ -111,12 +112,14 @@ def format_drive():
             })
 
         data = request.get_json()
-        drive = data.get('drive')
-        
-        if not drive:
-            return jsonify({'success': False, 'error': 'No drive selected'})
+        # Step 2 is intentionally disk-oriented because formatting and partition
+        # creation are destructive whole-disk operations.
+        disk = data.get('disk')
 
-        mounted_partitions = _get_mounted_partitions_for_drive(drive)
+        if not disk:
+            return jsonify({'success': False, 'error': 'No disk selected'})
+
+        mounted_partitions = _get_mounted_partitions_for_disk(disk)
 
         if mounted_partitions:
             partition_info = '\n'.join([f"- {p['device']} at {p['mount_point']}" for p in mounted_partitions])
@@ -128,11 +131,11 @@ def format_drive():
             })
 
         # Create a single partition if none exists
-        partition = f"{drive}1"
+        partition = f"{disk}1"
         if not os.path.exists(partition):
             # Create partition using fdisk
             fdisk_input = f"n\np\n1\n\n\nw\n"
-            result = subprocess.run(['fdisk', drive], input=fdisk_input.encode(), capture_output=True)
+            result = subprocess.run(['fdisk', disk], input=fdisk_input.encode(), capture_output=True)
             if result.returncode != 0:
                 return jsonify({
                     'success': False,
@@ -166,8 +169,15 @@ def unmount_drive():
     """Unmount the selected drive"""
     try:
         data = request.get_json()
-        drive = data.get('drive')
-        message = unmount_selected_drive(drive, runtime=runtime)
+        # The setup wizard uses this route for two different UI controls:
+        # whole-disk unmount before formatting, and exact-partition unmount
+        # before mounting an NTFS partition in step 3.
+        disk = data.get('disk')
+        partition = data.get('partition')
+        if disk:
+            message = unmount_disk_partitions(disk, runtime=runtime)
+        else:
+            message = unmount_selected_partition(partition, runtime=runtime)
         return jsonify({'success': True, 'message': message})
     except BackupDriveSetupError as e:
         return jsonify({'success': False, 'error': str(e)})
@@ -184,11 +194,13 @@ def mount_drive():
     """Mount the selected drive"""
     try:
         data = request.get_json()
-        drive = data.get('drive')
+        # Step 3 always selects a filesystem-bearing partition, never a whole
+        # disk. That aligns it with the rerun flow on Drive Health.
+        partition = data.get('partition')
         mount_point = data.get('mount_point') or (runtime.default_mount_point if runtime.is_fake else '/media/backup')
         auto_mount = data.get('auto_mount', True)
         result = apply_backup_drive_configuration(
-            drive,
+            partition,
             mount_point,
             auto_mount,
             config_manager,

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -3,6 +3,7 @@ from backup_drive_setup import (
     BackupDriveSetupError,
     apply_backup_drive_configuration,
     list_available_drives as get_available_backup_drives,
+    _get_mounted_partitions_for_drive,
     unmount_selected_drive,
 )
 from config_manager import ConfigManager
@@ -92,7 +93,7 @@ def create_user():
 def list_drives():
     """List available drives with detailed information"""
     try:
-        drives = get_available_backup_drives(runtime=runtime)
+        drives = get_available_backup_drives(runtime=runtime, ntfs_only=False)
         return jsonify({'success': True, 'drives': drives})
     except Exception as e:
         logger.error(f"Error listing drives: {str(e)}")
@@ -115,20 +116,7 @@ def format_drive():
         if not drive:
             return jsonify({'success': False, 'error': 'No drive selected'})
 
-        # Check if drive is mounted
-        mount_check = subprocess.run(['mount'], capture_output=True, text=True)
-        mounted_partitions = []
-        
-        # Find all mounted partitions for this drive
-        for line in mount_check.stdout.splitlines():
-            parts = line.split()
-            if len(parts) >= 3 and parts[0] == drive:
-                device = parts[0]
-                mount_point = parts[2]
-                mounted_partitions.append({
-                    'device': device,
-                    'mount_point': mount_point
-                })
+        mounted_partitions = _get_mounted_partitions_for_drive(drive)
 
         if mounted_partitions:
             partition_info = '\n'.join([f"- {p['device']} at {p['mount_point']}" for p in mounted_partitions])

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -47,6 +47,8 @@ def setup_api_access_required(route_handler):
         if 'username' not in session:
             return jsonify({'success': False, 'error': 'Please log in again.'}), 401
 
+        # Reload user data to ensure we have the latest
+        user_manager.users = user_manager._load_users()
         if not user_manager.is_admin(session['username']):
             return jsonify({'success': False, 'error': 'Admin privileges required.'}), 403
 
@@ -350,7 +352,7 @@ def mount_drive():
         logger.info(f"Current config after mounting: {config_manager.get_all_config()}")
         return jsonify({'success': True, 'message': result['message']})
     except BackupDriveSetupError as e:
-        return jsonify({'success': False, 'error': str(e)})
+        return jsonify({'success': False, 'error': str(e), 'details': e.details})
     except Exception as e:
         logger.error(f"Error mounting drive: {str(e)}")
         return jsonify({

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -94,7 +94,11 @@ def create_user():
 def list_drives():
     """List available drives with detailed information"""
     try:
-        drives = get_available_backup_drives(runtime=runtime, ntfs_only=False)
+        # Step 3 is partition-oriented and only accepts NTFS backup targets, so
+        # it must reuse the same NTFS scan as the Drive Health rerun flow. That
+        # includes the blkid fallback when lsblk reports ntfs-3g mounts as
+        # fuseblk, which is easy to miss if this route ever gets "simplified".
+        drives = get_available_backup_drives(runtime=runtime, ntfs_only=True)
         return jsonify({'success': True, 'drives': drives})
     except Exception as e:
         logger.error(f"Error listing drives: {str(e)}")

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -7,6 +7,10 @@ from backup_drive_setup import (
     unmount_disk_partitions,
     unmount_selected_partition,
 )
+from backup_drive_unmount import (
+    is_selected_partition_managed_backup_drive,
+    unmount_managed_backup_drive,
+)
 from config_manager import ConfigManager
 from system_utils import SystemUtils
 from user_manager import UserManager
@@ -28,6 +32,88 @@ system_utils = SystemUtils(runtime=runtime)
 user_manager = UserManager(runtime=runtime)
 smb_manager = SMBManager(runtime=runtime)
 logger = logging.getLogger(__name__)
+MANAGED_UNMOUNT_RETRY_ERROR = (
+    'The selected partition is busy. If it is still serving the backup share over SMB, '
+    'retry with the SMB-safe unmount path.'
+)
+MANAGED_UNMOUNT_RETRY_DETAILS = (
+    'This retry may temporarily stop SMB access and related background backup tasks, '
+    'unmount the configured backup share, and then restart SMB.'
+)
+
+
+def _get_configured_backup_drive_identity():
+    default_mount_point = getattr(runtime, 'default_mount_point', '/media/backup')
+    return (
+        config_manager.get_value('backup', 'mount_point', default_mount_point),
+        config_manager.get_value('backup', 'uuid', ''),
+    )
+
+
+def _is_busy_unmount_error(error):
+    return 'busy' in str(error).lower()
+
+
+def _build_managed_unmount_retry_response(partition, configured_mount_point, configured_uuid):
+    if not is_selected_partition_managed_backup_drive(
+        partition,
+        configured_mount_point,
+        configured_uuid,
+        system_utils,
+        runtime=runtime,
+    ):
+        return None
+
+    # This response only appears after the exact-partition unmount already
+    # failed, so power users can make an explicit choice about stopping SMB.
+    return {
+        'success': False,
+        'error': MANAGED_UNMOUNT_RETRY_ERROR,
+        'details': MANAGED_UNMOUNT_RETRY_DETAILS,
+        'can_retry_managed_unmount': True,
+    }
+
+
+def _unmount_selected_partition_with_managed_retry(partition, force_managed=False):
+    if force_managed:
+        configured_mount_point, configured_uuid = _get_configured_backup_drive_identity()
+        if not is_selected_partition_managed_backup_drive(
+            partition,
+            configured_mount_point,
+            configured_uuid,
+            system_utils,
+            runtime=runtime,
+        ):
+            raise BackupDriveSetupError(
+                'The selected partition is no longer the active configured backup drive.'
+            )
+        unmount_managed_backup_drive(
+            configured_mount_point,
+            configured_uuid,
+            system_utils,
+            runtime=runtime,
+            power_down=False,
+        )
+        return (
+            'Drive unmounted after the SMB-safe retry temporarily stopped SMB access '
+            'and related background backup tasks.'
+        )
+
+    try:
+        return unmount_selected_partition(partition, runtime=runtime)
+    except BackupDriveSetupError as exc:
+        if not _is_busy_unmount_error(exc):
+            raise
+
+        configured_mount_point, configured_uuid = _get_configured_backup_drive_identity()
+        retry_response = _build_managed_unmount_retry_response(
+            partition,
+            configured_mount_point,
+            configured_uuid,
+        )
+        if retry_response is not None:
+            return retry_response
+        raise
 
 @setup.route('/setup')
 def setup_page():
@@ -186,19 +272,26 @@ def format_drive():
 def unmount_drive():
     """Unmount the selected drive"""
     try:
-        data = request.get_json()
+        data = request.get_json() or {}
         # The setup wizard uses this route for two different UI controls:
         # whole-disk unmount before formatting, and exact-partition unmount
         # before mounting an NTFS partition in step 3.
         disk = data.get('disk')
         partition = data.get('partition')
+        force_managed = bool(data.get('force_managed'))
         if disk:
             message = unmount_disk_partitions(disk, runtime=runtime)
         else:
-            message = unmount_selected_partition(partition, runtime=runtime)
+            message = _unmount_selected_partition_with_managed_retry(
+                partition,
+                force_managed=force_managed,
+            )
+
+        if isinstance(message, dict):
+            return jsonify(message)
         return jsonify({'success': True, 'message': message})
     except BackupDriveSetupError as e:
-        return jsonify({'success': False, 'error': str(e)})
+        return jsonify({'success': False, 'error': str(e), 'details': e.details})
     except Exception as e:
         logger.error(f"Error unmounting drive: {str(e)}")
         return jsonify({

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -20,6 +20,7 @@ import subprocess
 import os
 import re
 from datetime import datetime
+from functools import wraps
 from tempfile import NamedTemporaryFile
 from pathlib import Path
 from runtime import get_runtime, get_fake_state
@@ -32,6 +33,28 @@ system_utils = SystemUtils(runtime=runtime)
 user_manager = UserManager(runtime=runtime)
 smb_manager = SMBManager(runtime=runtime)
 logger = logging.getLogger(__name__)
+
+
+def setup_api_access_required(route_handler):
+    """Allow anonymous setup API access only during first-time onboarding."""
+    @wraps(route_handler)
+    def wrapped(*args, **kwargs):
+        # Once setup is complete these routes become admin maintenance tools,
+        # so old bookmarked setup URLs must not keep working anonymously.
+        if not config_manager.is_setup_complete():
+            return route_handler(*args, **kwargs)
+
+        if 'username' not in session:
+            return jsonify({'success': False, 'error': 'Please log in again.'}), 401
+
+        if not user_manager.is_admin(session['username']):
+            return jsonify({'success': False, 'error': 'Admin privileges required.'}), 403
+
+        return route_handler(*args, **kwargs)
+
+    return wrapped
+
+
 MANAGED_UNMOUNT_RETRY_ERROR = (
     'The selected partition is busy. If it is still serving the backup share over SMB, '
     'retry with the SMB-safe unmount path.'
@@ -156,6 +179,7 @@ def setup_page():
         return render_template('setup.html')
 
 @setup.route('/api/setup/user', methods=['POST'])
+@setup_api_access_required
 def create_user():
     """Create the initial admin user"""
     try:
@@ -177,6 +201,7 @@ def create_user():
         return jsonify({'success': False, 'error': str(e)})
 
 @setup.route('/api/setup/format-drives', methods=['GET'])
+@setup_api_access_required
 def list_format_drives():
     """List disks for the destructive format step."""
     try:
@@ -191,6 +216,7 @@ def list_format_drives():
 
 
 @setup.route('/api/setup/mount-drives', methods=['GET'])
+@setup_api_access_required
 def list_mount_drives():
     """List NTFS partitions for the mount step."""
     try:
@@ -205,6 +231,7 @@ def list_mount_drives():
         return jsonify({'success': False, 'error': str(e)})
 
 @setup.route('/api/setup/format', methods=['POST'])
+@setup_api_access_required
 def format_drive():
     """Format the selected drive"""
     try:
@@ -269,6 +296,7 @@ def format_drive():
         })
 
 @setup.route('/api/setup/unmount', methods=['POST'])
+@setup_api_access_required
 def unmount_drive():
     """Unmount the selected drive"""
     try:
@@ -301,6 +329,7 @@ def unmount_drive():
         })
 
 @setup.route('/api/setup/mount', methods=['POST'])
+@setup_api_access_required
 def mount_drive():
     """Mount the selected drive"""
     try:
@@ -331,6 +360,7 @@ def mount_drive():
         })
 
 @setup.route('/api/setup/rclone', methods=['POST'])
+@setup_api_access_required
 def setup_rclone():
     """Set up rclone configuration"""
     try:
@@ -354,6 +384,7 @@ def setup_rclone():
         return jsonify({'success': False, 'error': str(e)})
 
 @setup.route('/api/setup/email', methods=['POST'])
+@setup_api_access_required
 def setup_email():
     """Set up email configuration"""
     try:
@@ -388,6 +419,7 @@ def setup_email():
         return jsonify({'success': False, 'error': str(e)})
 
 @setup.route('/api/setup/schedule', methods=['POST'])
+@setup_api_access_required
 def save_schedule():
     """Save the backup schedule configuration"""
     try:
@@ -539,6 +571,7 @@ def setup_smb_share(config):
         return False, str(e)
 
 @setup.route('/api/setup/complete', methods=['POST'])
+@setup_api_access_required
 def complete_setup():
     """Complete the setup process"""
     try:
@@ -606,6 +639,7 @@ def complete_setup():
         })
 
 @setup.route('/api/setup/system', methods=['POST'])
+@setup_api_access_required
 def setup_system_info():
     """Save system-level info such as username and server name"""
     try:
@@ -624,6 +658,7 @@ def setup_system_info():
         return jsonify({'success': False, 'error': str(e)}) 
 
 @setup.route('/api/setup/mega/connect', methods=['POST'])
+@setup_api_access_required
 def mega_connect():
     """Authenticate with MEGA and list folders using rclone."""
     try:
@@ -662,6 +697,7 @@ pass = {obscured_pw}
         return jsonify({'success': False, 'error': f'Error connecting to MEGA: {str(e)}'})
 
 @setup.route('/api/setup/mega/list_folders', methods=['POST'])
+@setup_api_access_required
 def mega_list_folders():
     """List folders at a given MEGA path using rclone."""
     try:
@@ -701,6 +737,7 @@ pass = {obscured_pw}
         return jsonify({'error': f'Error listing MEGA folders: {str(e)}'})
 
 @setup.route('/api/setup/mega/create_folder', methods=['POST'])
+@setup_api_access_required
 def mega_create_folder_picker():
     """Create a new folder at a given MEGA path using rclone."""
     try:
@@ -738,6 +775,7 @@ pass = {obscured_pw}
         return jsonify({'error': f'Error creating folder: {str(e)}'})
 
 @setup.route('/api/setup/mega/save', methods=['POST'])
+@setup_api_access_required
 def mega_save():
     """Save MEGA config (obscured password, selected folder) securely and write rclone config."""
     try:

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -90,9 +90,23 @@ def create_user():
         logger.error(f"Error creating user: {e}")
         return jsonify({'success': False, 'error': str(e)})
 
-@setup.route('/api/setup/drives', methods=['GET'])
-def list_drives():
-    """List available drives with detailed information"""
+@setup.route('/api/setup/format-drives', methods=['GET'])
+def list_format_drives():
+    """List disks for the destructive format step."""
+    try:
+        # Step 2 is intentionally broader than the mount pickers because it is
+        # the "prepare or erase this disk" step, not the "pick an NTFS backup
+        # partition" step.
+        drives = get_available_backup_drives(runtime=runtime, ntfs_only=False)
+        return jsonify({'success': True, 'drives': drives})
+    except Exception as e:
+        logger.error(f"Error listing format drives: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)})
+
+
+@setup.route('/api/setup/mount-drives', methods=['GET'])
+def list_mount_drives():
+    """List NTFS partitions for the mount step."""
     try:
         # Step 3 is partition-oriented and only accepts NTFS backup targets, so
         # it must reuse the same NTFS scan as the Drive Health rerun flow. That
@@ -101,7 +115,7 @@ def list_drives():
         drives = get_available_backup_drives(runtime=runtime, ntfs_only=True)
         return jsonify({'success': True, 'drives': drives})
     except Exception as e:
-        logger.error(f"Error listing drives: {str(e)}")
+        logger.error(f"Error listing mount drives: {str(e)}")
         return jsonify({'success': False, 'error': str(e)})
 
 @setup.route('/api/setup/format', methods=['POST'])

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -1,4 +1,10 @@
 from flask import Blueprint, render_template, jsonify, request, redirect, session
+from backup_drive_setup import (
+    BackupDriveSetupError,
+    apply_backup_drive_configuration,
+    list_available_drives as get_available_backup_drives,
+    unmount_selected_drive,
+)
 from config_manager import ConfigManager
 from system_utils import SystemUtils
 from user_manager import UserManager
@@ -86,78 +92,8 @@ def create_user():
 def list_drives():
     """List available drives with detailed information"""
     try:
-        if runtime.is_fake:
-            return jsonify({'success': True, 'drives': fake_state.get_virtual_drives()})
-
-        # Get detailed drive information using lsblk
-        lsblk_result = subprocess.run(['lsblk', '-f', '-o', 'NAME,FSTYPE,LABEL,SIZE,MODEL,MOUNTPOINT,TYPE'], 
-                                    capture_output=True, text=True)
-        
-        if lsblk_result.returncode != 0:
-            return jsonify({'success': False, 'error': 'Failed to list drives'})
-
-        drives = []
-        current_drive = None
-        
-        # Get system drive to exclude it
-        root_mount = subprocess.run(['mount | grep "on / "'], shell=True, capture_output=True, text=True)
-        system_drive = None
-        if root_mount.returncode == 0:
-            system_drive = root_mount.stdout.split()[0]
-        
-        for line in lsblk_result.stdout.splitlines()[1:]:  # Skip header
-            parts = line.split()
-            if not parts:
-                continue
-                
-            name = parts[0]
-            if name.startswith('├─') or name.startswith('└─'):
-                # This is a partition
-                if current_drive:
-                    partition = {
-                        'path': f"/dev/{name[2:]}",  # Remove the tree characters
-                        'type': parts[1] if len(parts) > 1 else 'unknown',
-                        'label': parts[2] if len(parts) > 2 else '',
-                        'size': parts[3] if len(parts) > 3 else '',
-                        'mountpoint': parts[4] if len(parts) > 4 else ''
-                    }
-                    current_drive['partitions'].append(partition)
-            else:
-                # This is a drive
-                if current_drive:
-                    # Only add if it's a physical drive and not the system drive
-                    if current_drive['type'] in ['disk', 'usb'] and current_drive['path'] != system_drive:
-                        drives.append(current_drive)
-                
-                # Get drive model and type using udevadm
-                udev_result = subprocess.run(['udevadm', 'info', '--query=property', f"/dev/{name}"], 
-                                          capture_output=True, text=True)
-                model = 'Unknown Drive'
-                drive_type = 'unknown'
-                if udev_result.returncode == 0:
-                    for line in udev_result.stdout.splitlines():
-                        if line.startswith('ID_MODEL='):
-                            model = line.split('=')[1].strip()
-                        elif line.startswith('ID_TYPE='):
-                            drive_type = line.split('=')[1].strip()
-                
-                current_drive = {
-                    'path': f"/dev/{name}",
-                    'model': model,
-                    'size': parts[3] if len(parts) > 3 else '',
-                    'type': drive_type,
-                    'partitions': []
-                }
-        
-        # Add the last drive if it's a physical drive
-        if current_drive and current_drive['type'] in ['disk', 'usb'] and current_drive['path'] != system_drive:
-            drives.append(current_drive)
-
-        return jsonify({
-            'success': True,
-            'drives': drives
-        })
-
+        drives = get_available_backup_drives(runtime=runtime)
+        return jsonify({'success': True, 'drives': drives})
     except Exception as e:
         logger.error(f"Error listing drives: {str(e)}")
         return jsonify({'success': False, 'error': str(e)})
@@ -240,80 +176,14 @@ def format_drive():
 
 @setup.route('/api/setup/unmount', methods=['POST'])
 def unmount_drive():
-    """Unmount the selected drive and clean up fstab entries related to SimpleSaferServer"""
+    """Unmount the selected drive"""
     try:
-        if runtime.is_fake:
-            fake_state.set_mount(False)
-            return jsonify({'success': True, 'message': 'Fake backup source disconnected.'})
-
         data = request.get_json()
         drive = data.get('drive')
-        
-        if not drive:
-            return jsonify({'success': False, 'error': 'No drive selected'})
-
-        # Check if drive is mounted
-        mount_check = subprocess.run(['mount'], capture_output=True, text=True)
-        mounted_partitions = []
-        
-        # Find all mounted partitions for this drive
-        for line in mount_check.stdout.splitlines():
-            if drive in line:
-                parts = line.split()
-                if len(parts) >= 2:
-                    device = parts[0]
-                    mount_point = parts[2]
-                    mounted_partitions.append({
-                        'device': device,
-                        'mount_point': mount_point
-                    })
-
-        if not mounted_partitions:
-            return jsonify({
-                'success': False,
-                'error': f'No mounted partitions found for {drive}',
-                'details': 'The drive might not be mounted or might not have any partitions.'
-            })
-
-        # Try to unmount each partition
-        failed_unmounts = []
-        for partition in mounted_partitions:
-            result = subprocess.run(['umount', partition['device']], capture_output=True, text=True)
-            if result.returncode != 0:
-                error_msg = result.stderr.strip() if result.stderr else 'Unknown error occurred'
-                failed_unmounts.append({
-                    'device': partition['device'],
-                    'error': error_msg
-                })
-
-        if failed_unmounts:
-            error_details = '\n'.join([f"{f['device']}: {f['error']}" for f in failed_unmounts])
-            return jsonify({
-                'success': False,
-                'error': 'Failed to unmount some partitions',
-                'details': f'The following partitions could not be unmounted:\n{error_details}\n\nPlease ensure no applications are using these partitions.'
-            })
-
-        # Remove any fstab entries related to SimpleSaferServer
-        try:
-            with open('/etc/fstab', 'r') as fstab_file:
-                lines = fstab_file.readlines()
-            new_lines = [line for line in lines if 'SimpleSaferServer' not in line]
-            with open('/etc/fstab', 'w') as fstab_file:
-                fstab_file.writelines(new_lines)
-        except Exception as e:
-            logger.error(f"Error cleaning up fstab: {e}")
-            return jsonify({
-                'success': False,
-                'error': f'Error cleaning up fstab: {e}',
-                'details': 'Unmount succeeded, but failed to clean up /etc/fstab.'
-            })
-
-        return jsonify({
-            'success': True,
-            'message': f'Successfully unmounted {len(mounted_partitions)} partition(s)'
-        })
-
+        message = unmount_selected_drive(drive, runtime=runtime)
+        return jsonify({'success': True, 'message': message})
+    except BackupDriveSetupError as e:
+        return jsonify({'success': False, 'error': str(e)})
     except Exception as e:
         logger.error(f"Error unmounting drive: {str(e)}")
         return jsonify({
@@ -330,115 +200,18 @@ def mount_drive():
         drive = data.get('drive')
         mount_point = data.get('mount_point') or (runtime.default_mount_point if runtime.is_fake else '/media/backup')
         auto_mount = data.get('auto_mount', True)
-
-        if runtime.is_fake:
-            selected_path = Path(os.path.abspath(mount_point or runtime.default_mount_point))
-            if not selected_path.exists():
-                try:
-                    selected_path.relative_to(runtime.data_dir)
-                    selected_path.mkdir(parents=True, exist_ok=True)
-                except ValueError:
-                    return jsonify({
-                        'success': False,
-                        'error': 'Source folder does not exist',
-                        'details': 'In fake mode, choose an existing folder on this machine or a path inside .dev-data that can be created safely.'
-                    })
-            if not selected_path.is_dir():
-                return jsonify({'success': False, 'error': 'Source path must be a directory'})
-
-            config_manager.set_value('backup', 'mount_point', str(selected_path))
-            config_manager.set_value('backup', 'uuid', 'FAKE-UUID-0001')
-            config_manager.set_value('backup', 'usb_id', 'FAKE:0001')
-            fake_state.set_mount(True, mount_point=str(selected_path), drive=drive or '/dev/fakebackup1')
-            logger.info(f"Fake mode: using local backup source at {selected_path}")
-            return jsonify({
-                'success': True,
-                'message': f'Successfully selected local backup source at {selected_path}'
-            })
-
-        if not drive:
-            return jsonify({'success': False, 'error': 'No drive selected'})
-
-        # Check if drive is already mounted
-        mount_check = subprocess.run(['mount'], capture_output=True, text=True)
-        if drive in mount_check.stdout:
-            return jsonify({
-                'success': False,
-                'error': 'Drive is already mounted',
-                'details': 'Please unmount the drive first if you want to change mount settings.'
-            })
-
-        # Create mount point if it doesn't exist
-        os.makedirs(mount_point, exist_ok=True)
-
-        # Mount the drive using ntfs-3g
-        result = subprocess.run(['ntfs-3g', drive, mount_point, '-o', 'rw,uid=1000,gid=1000'], capture_output=True, text=True)
-        
-        if result.returncode != 0:
-            error_msg = result.stderr.strip() if result.stderr else 'Unknown error occurred'
-            return jsonify({
-                'success': False,
-                'error': f'Error mounting drive: {error_msg}',
-                'details': 'Please ensure the drive is not in use and try again.'
-            })
-
-        # Get UUID of the partition
-        uuid_result = subprocess.run(['blkid', '-s', 'UUID', '-o', 'value', drive], capture_output=True, text=True)
-        if uuid_result.returncode != 0:
-            return jsonify({
-                'success': False,
-                'error': 'Failed to get drive UUID',
-                'details': 'Could not determine the drive UUID. Please try again.'
-            })
-        
-        uuid = uuid_result.stdout.strip()
-
-        # Get USB ID of the drive (if available)
-        try:
-            usb_logger = logging.getLogger(__name__)
-            usb_id = ""
-            # Find sysfs path for the block device
-            sys_block_path = f"/sys/class/block/{os.path.basename(drive)}/device"
-            parent = os.path.realpath(sys_block_path)
-            usb_logger.info(f"Starting sysfs walk for USB ID from: {parent}")
-            while parent != "/":
-                id_vendor_path = os.path.join(parent, "idVendor")
-                id_product_path = os.path.join(parent, "idProduct")
-                if os.path.isfile(id_vendor_path) and os.path.isfile(id_product_path):
-                    with open(id_vendor_path) as f:
-                        vendor = f.read().strip()
-                    with open(id_product_path) as f:
-                        product = f.read().strip()
-                    usb_id = f"{vendor}:{product}"
-                    usb_logger.info(f"Found USB ID at {parent}: {usb_id}")
-                    break
-                parent = os.path.dirname(parent)
-            if not usb_id:
-                usb_logger.info("USB ID not found, likely not a USB device or not detected.")
-        except Exception as e:
-            usb_logger.error(f"Error getting USB ID: {e}")
-            usb_id = ""
-
-        # Add to fstab if auto_mount is enabled
-        if auto_mount:
-            fstab_entry = f"UUID={uuid}\t\t{mount_point}\tntfs-3g\tdefaults,nofail\t0\t0 # SimpleSaferServer\n"
-            with open('/etc/fstab', 'a') as f:
-                f.write(fstab_entry)
-
-        # Save to config using ConfigManager
-        config_manager.set_value('backup', 'mount_point', mount_point)
-        config_manager.set_value('backup', 'uuid', uuid)
-        config_manager.set_value('backup', 'usb_id', usb_id)  # Empty string means not a USB device or not detected
-        
-        # Verify the config was saved
-        current_config = config_manager.get_all_config()
-        logger.info(f"Current config after mounting: {current_config}")
-
-        return jsonify({
-            'success': True,
-            'message': f'Successfully mounted {drive} at {mount_point}'
-        })
-
+        result = apply_backup_drive_configuration(
+            drive,
+            mount_point,
+            auto_mount,
+            config_manager,
+            smb_manager,
+            runtime=runtime,
+        )
+        logger.info(f"Current config after mounting: {config_manager.get_all_config()}")
+        return jsonify({'success': True, 'message': result['message']})
+    except BackupDriveSetupError as e:
+        return jsonify({'success': False, 'error': str(e)})
     except Exception as e:
         logger.error(f"Error mounting drive: {str(e)}")
         return jsonify({

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -121,15 +121,14 @@ def format_drive():
         
         # Find all mounted partitions for this drive
         for line in mount_check.stdout.splitlines():
-            if drive in line:
-                parts = line.split()
-                if len(parts) >= 2:
-                    device = parts[0]
-                    mount_point = parts[2]
-                    mounted_partitions.append({
-                        'device': device,
-                        'mount_point': mount_point
-                    })
+            parts = line.split()
+            if len(parts) >= 3 and parts[0] == drive:
+                device = parts[0]
+                mount_point = parts[2]
+                mounted_partitions.append({
+                    'device': device,
+                    'mount_point': mount_point
+                })
 
         if mounted_partitions:
             partition_info = '\n'.join([f"- {p['device']} at {p['mount_point']}" for p in mounted_partitions])

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1715,6 +1715,14 @@ pre code {
 .text-warning   { color: var(--warning-text) !important; }
 .text-danger    { color: var(--danger-text) !important; }
 .text-info      { color: var(--info-text) !important; }
+.drive-setup-status {
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+  flex: 0 1 auto;
+  font-size: var(--text-xs);
+  line-height: 1.5;
+}
 .text-center    { text-align: center !important; }
 .text-end       { text-align: right !important; }
 .text-mono      { font-family: var(--font-mono) !important; }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -979,6 +979,7 @@ table .text-end { text-align: right; }
 
 .modal-body {
   padding: var(--sp-5);
+  white-space: pre-line;
 }
 
 .modal-footer {

--- a/system_utils.py
+++ b/system_utils.py
@@ -168,7 +168,9 @@ account default : simplesaferserver
             # Create destination directory if it doesn't exist
             scripts_dest_dir.mkdir(parents=True, exist_ok=True)
             
-            # Copy and configure each script
+            # Copy each script as-is. The scripts read live values from
+            # /etc/SimpleSaferServer/config.conf, so templating them here can
+            # accidentally bake stale UUID/USB_ID values into the installed copy.
             script_files = ['check_mount.sh', 'check_health.sh', 'check_health.py', 'backup_cloud.sh', 'predict_health.py', 'log_alert.py']
             
             for script_file in script_files:
@@ -179,14 +181,7 @@ account default : simplesaferserver
                     self.logger.warning(f"Script file not found: {source_path}")
                     continue
                 
-                # Read the script content
-                script_content = source_path.read_text()
-                
-                # Replace configuration variables in the script
-                script_content = self._configure_script(script_content, config)
-                
-                # Write the configured script
-                dest_path.write_text(script_content)
+                shutil.copy2(source_path, dest_path)
                 dest_path.chmod(0o755)  # Make executable
                 
                 self.logger.info(f"Installed script: {dest_path}")
@@ -196,41 +191,6 @@ account default : simplesaferserver
         except Exception as e:
             self.logger.error(f"Error installing systemd scripts: {e}")
             return False, str(e)
-
-    def _configure_script(self, script_content, config):
-        """Configure script content with the current configuration"""
-        try:
-            # Extract configuration values
-            backup_config = config.get('backup', {})
-            system_config = config.get('system', {})
-            
-            mount_point = backup_config.get('mount_point', '/media/backup')
-            uuid = backup_config.get('uuid', '')
-            usb_id = backup_config.get('usb_id', '')
-            email_address = backup_config.get('email_address', '')
-            rclone_dir = backup_config.get('rclone_dir', '')
-            bandwidth_limit = backup_config.get('bandwidth_limit', '')
-            server_name = system_config.get('server_name', 'SimpleSaferServer')
-            
-            # Replace variables in the script
-            replacements = {
-                'MOUNT_POINT': mount_point,
-                'UUID': uuid,
-                'USB_ID': usb_id,
-                'EMAIL_ADDRESS': email_address,
-                'RCLONE_DIR': rclone_dir,
-                'BANDWIDTH_LIMIT': bandwidth_limit,
-                'SERVER_NAME': server_name
-            }
-            
-            for var_name, value in replacements.items():
-                script_content = script_content.replace(f'${var_name}', str(value))
-            
-            return script_content
-            
-        except Exception as e:
-            self.logger.error(f"Error configuring script: {e}")
-            return script_content
 
     def create_systemd_config_file(self, config):
         """Create the /etc/SimpleSaferServer/config.conf file for scripts and Python (INI format)"""

--- a/system_utils.py
+++ b/system_utils.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 import json
 import logging

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -235,10 +235,20 @@ document.addEventListener('DOMContentLoaded', function() {
     // The configured backup drive stays app-managed here, so unmount only buys
     // enough time for a safe removal or swap before Check Mount notices it again.
     if (countdown) {
-      return `This only unmounts the configured backup drive temporarily. If the drive stays connected, SimpleSaferServer may remount it automatically during the next Check Mount run, in about ${countdown}. Remove it now if you do not want it mounted again.`;
+      return `This unmounts the configured backup drive temporarily.
+
+If it stays connected, SimpleSaferServer will remount it
+automatically during the next 'Check Mount' run (in about ${countdown}).
+
+Remove the drive now if you do not want it mounted again.`;
     }
 
-    return 'This only unmounts the configured backup drive temporarily. If the drive stays connected, SimpleSaferServer may remount it automatically during the next scheduled Check Mount run. Remove it now if you do not want it mounted again.';
+    return `This unmounts the configured backup drive temporarily.
+
+If it stays connected, SimpleSaferServer will remount it
+automatically during the next scheduled 'Check Mount' run.
+
+Remove the drive now if you do not want it mounted again.`;
   }
 
   function renderTaskRow(task) {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -129,12 +129,8 @@
   <div class="d-flex gap-3 flex-wrap">
     <div id="drive-action-slot">
       {% if mount_info and mount_info.is_mounted %}
-      <form method="post" action="{{ url_for('unmount') }}" class="d-inline dashboard-action-form" data-success-action="refresh-drive-ui">
-        <button type="submit" class="btn btn-warning btn-sm"
-          data-confirm="Are you sure you want to unmount the backup drive?"
-          data-confirm-title="Unmount Drive"
-          data-confirm-button="Unmount"
-          data-confirm-class="btn-warning">
+      <form method="post" action="{{ url_for('unmount') }}" class="d-inline dashboard-action-form" data-success-action="refresh-drive-ui" data-dashboard-unmount="true">
+        <button type="submit" class="btn btn-warning btn-sm">
           <i class="fas fa-eject me-1"></i> Unmount Drive
         </button>
       </form>
@@ -187,7 +183,10 @@ document.addEventListener('DOMContentLoaded', function() {
   const tasksBody = document.getElementById('tasks-body');
   const taskContextMenu = document.getElementById('taskContextMenu');
   const driveActionSlot = document.getElementById('drive-action-slot');
+  const taskScheduleByName = new Map();
   let activeContextTaskName = null;
+
+  rememberTaskSchedule({{ tasks | tojson }});
 
   function escapeHtml(value) {
     return String(value ?? '')
@@ -206,6 +205,40 @@ document.addEventListener('DOMContentLoaded', function() {
     if (status === 'Not Run Yet') return '<span class="badge badge-neutral"><i class="fas fa-clock"></i> Not Run Yet</span>';
     if (status === 'Stopped') return '<span class="badge badge-neutral"><i class="fas fa-circle-stop"></i> Stopped</span>';
     return `<span class="badge badge-warning">${escapeHtml(status || 'Unknown')}</span>`;
+  }
+
+  function rememberTaskSchedule(tasks) {
+    taskScheduleByName.clear();
+    (tasks || []).forEach((task) => {
+      if (task && task.name) {
+        taskScheduleByName.set(task.name, task);
+      }
+    });
+  }
+
+  function getDashboardUnmountCountdownText() {
+    const checkMountTask = taskScheduleByName.get('Check Mount');
+    const nextRun = checkMountTask && checkMountTask.next_run ? checkMountTask.next_run : '';
+    const parsed = window.parseServerDateTime(nextRun);
+    if (!parsed || parsed.getTime() <= Date.now()) {
+      return '';
+    }
+
+    return window.formatRelativeTimestamp(nextRun, {
+      fallback: '',
+      futurePrefix: false
+    });
+  }
+
+  function getDashboardUnmountConfirmationMessage() {
+    const countdown = getDashboardUnmountCountdownText();
+    // The configured backup drive stays app-managed here, so unmount only buys
+    // enough time for a safe removal or swap before Check Mount notices it again.
+    if (countdown) {
+      return `This only unmounts the configured backup drive temporarily. If the drive stays connected, SimpleSaferServer may remount it automatically during the next Check Mount run, in about ${countdown}. Remove it now if you do not want it mounted again.`;
+    }
+
+    return 'This only unmounts the configured backup drive temporarily. If the drive stays connected, SimpleSaferServer may remount it automatically during the next scheduled Check Mount run. Remove it now if you do not want it mounted again.';
   }
 
   function renderTaskRow(task) {
@@ -310,6 +343,7 @@ document.addEventListener('DOMContentLoaded', function() {
         throw new Error(data.error || 'Could not refresh task schedule.');
       }
 
+      rememberTaskSchedule(data.tasks);
       tasksBody.innerHTML = '';
       data.tasks.forEach(task => tasksBody.appendChild(renderTaskRow(task)));
       bindInteractiveRows();
@@ -323,12 +357,8 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!driveActionSlot) return;
 
     driveActionSlot.innerHTML = isMounted
-      ? `<form method="post" action="{{ url_for('unmount') }}" class="d-inline dashboard-action-form" data-success-action="refresh-drive-ui">
-          <button type="submit" class="btn btn-warning btn-sm"
-            data-confirm="Are you sure you want to unmount the backup drive?"
-            data-confirm-title="Unmount Drive"
-            data-confirm-button="Unmount"
-            data-confirm-class="btn-warning">
+      ? `<form method="post" action="{{ url_for('unmount') }}" class="d-inline dashboard-action-form" data-success-action="refresh-drive-ui" data-dashboard-unmount="true">
+          <button type="submit" class="btn btn-warning btn-sm">
             <i class="fas fa-eject me-1"></i> Unmount Drive
           </button>
         </form>`
@@ -377,6 +407,19 @@ document.addEventListener('DOMContentLoaded', function() {
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
         const submitButton = form.querySelector('button[type="submit"]');
+        const isDashboardUnmount = form.dataset.dashboardUnmount === 'true';
+
+        if (isDashboardUnmount) {
+          const confirmed = await window.showConfirmationDialog({
+            title: 'Unmount Drive',
+            message: getDashboardUnmountConfirmationMessage(),
+            confirmLabel: 'Unmount',
+            confirmClass: 'btn-warning'
+          });
+          if (!confirmed) {
+            return;
+          }
+        }
 
         if (submitButton) {
           window.AsyncButtonState.start(submitButton);

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -227,7 +227,7 @@
 
       <div class="d-flex items-center gap-2 mb-4 flex-wrap">
         <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
-        <div id="driveSetupStatus" class="text-muted d-flex items-center" style="font-size: var(--text-sm); min-height: 1.5rem; flex: 0 1 auto;"></div>
+        <div id="driveSetupStatus" class="text-muted d-flex items-center" style="font-size: var(--text-xs); line-height: 1.5; min-height: 1.5rem; flex: 0 1 auto;"></div>
       </div>
 
       <div class="form-row mb-4">

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -11,10 +11,10 @@
       <i class="fas fa-stethoscope me-1"></i> Run Health Check
     </button>
   </form>
-  <a href="/download_telemetry" class="btn btn-secondary btn-sm action-bar-btn">
+  <a href="/download_telemetry" id="downloadTelemetryBtn" class="btn btn-secondary btn-sm action-bar-btn">
     <i class="fas fa-download me-1"></i> Download Telemetry
   </a>
-  <a href="mailto:c.miniotis@acg.edu?subject=SMART%20Telemetry" class="btn btn-secondary btn-sm action-bar-btn" target="_blank">
+  <a href="mailto:simplesaferserver@chrismin13.com?subject=SMART%20Telemetry" class="btn btn-secondary btn-sm action-bar-btn" target="_blank">
     <i class="fas fa-envelope me-1"></i> Send Telemetry
   </a>
 </div>
@@ -391,6 +391,70 @@
 {% endblock %}
 
 {% block extra_js %}
+<script>
+  (function() {
+    const downloadTelemetryBtn = document.getElementById('downloadTelemetryBtn');
+    if (!downloadTelemetryBtn) {
+      return;
+    }
+
+    function getDownloadFilename(response) {
+      const disposition = response.headers.get('content-disposition') || '';
+      const match = disposition.match(/filename="?([^";]+)"?/i);
+      return match ? match[1] : 'telemetry.csv';
+    }
+
+    async function handleTelemetryDownload(event) {
+      event.preventDefault();
+      if (window.AsyncButtonState) {
+        window.AsyncButtonState.start(downloadTelemetryBtn);
+      }
+
+      try {
+        const response = await fetch(downloadTelemetryBtn.href, {
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          credentials: 'same-origin'
+        });
+
+        if (response.redirected || response.status === 401 || response.status === 403) {
+          throw new Error('Your session expired. Please log in again.');
+        }
+
+        if (response.status === 404) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || 'Telemetry has not been generated yet. Run a health check first.');
+        }
+
+        if (!response.ok) {
+          throw new Error('Failed to download telemetry.');
+        }
+
+        const blob = await response.blob();
+        const objectUrl = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = objectUrl;
+        link.download = getDownloadFilename(response);
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        window.URL.revokeObjectURL(objectUrl);
+
+        if (window.AsyncButtonState) {
+          window.AsyncButtonState.success(downloadTelemetryBtn);
+        }
+      } catch (error) {
+        if (window.AsyncButtonState) {
+          window.AsyncButtonState.error(downloadTelemetryBtn);
+        }
+        if (window.showAlert) {
+          window.showAlert(error.message || 'Failed to download telemetry.', 'warning');
+        }
+      }
+    }
+
+    downloadTelemetryBtn.addEventListener('click', handleTelemetryDownload);
+  })();
+</script>
 {% if can_manage_backup_drive %}
 <script>
   (function() {

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -222,7 +222,7 @@
 
       <div class="d-flex items-center gap-2 mb-4 flex-wrap">
         <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
-        <div id="driveSetupStatus" class="text-muted" style="font-size: var(--text-sm); min-height: 1.5rem; flex: 0 1 auto;"></div>
+        <div id="driveSetupStatus" class="text-muted d-flex items-center" style="font-size: var(--text-sm); min-height: 1.5rem; flex: 0 1 auto;"></div>
       </div>
 
       <div class="form-row mb-4">

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -569,7 +569,7 @@
         const response = await fetch('/api/backup_drive/unmount', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ drive: driveSelect.value })
+          body: JSON.stringify({ partition: driveSelect.value })
         });
         const data = await parseDriveSetupResponse(response);
         if (!data.success) {
@@ -603,7 +603,7 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            drive: driveSelect.value,
+            partition: driveSelect.value,
             mount_point: mountPointInput.value.trim()
           })
         });

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -75,76 +75,6 @@
   {% endif %}
 </div>
 
-{% if can_manage_backup_drive %}
-<section class="mb-6">
-  <details>
-    <summary><strong>Advanced: Re-run Backup Drive Setup</strong></summary>
-    <div class="mt-4">
-      <div class="alert alert-warning mb-4">
-        <div>
-          <strong>Warning:</strong> Use this only if the backup drive changed or the original drive identifiers were detected incorrectly. This updates the SimpleSaferServer-managed backup mount configuration.
-        </div>
-      </div>
-
-      <div class="table-container mb-4">
-        <table>
-          <tbody>
-            <tr>
-              <th>Configured Mount Point</th>
-              <td><code>{{ drive_config.mount_point }}</code></td>
-            </tr>
-            <tr>
-              <th>Configured UUID</th>
-              <td><code>{{ drive_config.uuid or '—' }}</code></td>
-            </tr>
-            <tr>
-              <th>Configured USB ID</th>
-              <td><code>{{ drive_config.usb_id or '—' }}</code></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div id="driveSetupStatus" class="text-muted mb-3" style="min-height: 1.5rem;"></div>
-      <div id="driveSetupError" class="alert alert-danger d-none mb-4"></div>
-
-      <div class="d-flex gap-2 mb-4 flex-wrap">
-        <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
-      </div>
-
-      <div class="form-row mb-4">
-        <div class="form-group">
-          <label class="form-label" for="backupDriveSelect">Backup Drive Partition</label>
-          <select class="form-control" id="backupDriveSelect">
-            <option value="">Scan connected drives first</option>
-          </select>
-        </div>
-        <div class="form-group">
-          <label class="form-label" for="backupDriveMountPoint">Mount Point</label>
-          <input type="text" class="form-control text-mono" id="backupDriveMountPoint" value="{{ drive_config.mount_point }}" placeholder="/media/backup">
-        </div>
-      </div>
-
-      <div class="form-group mb-4">
-        <label class="form-check-label" for="backupDriveAutoMount">
-          <input type="checkbox" class="form-check-input" id="backupDriveAutoMount" checked>
-          Update the SimpleSaferServer-managed `/etc/fstab` entry so this drive mounts automatically at boot
-        </label>
-      </div>
-
-      <div class="text-muted mb-4" style="font-size: var(--text-sm); line-height: 1.6;">
-        If the current drive is still mounted, unmount it first here or from the dashboard before applying the new selection. For fully manual recovery steps, use the documentation linked from the project website.
-      </div>
-
-      <div class="d-flex gap-2 justify-end flex-wrap">
-        <button type="button" id="unmountBackupDriveBtn" class="btn btn-secondary btn-sm">Unmount Selected Drive</button>
-        <button type="button" id="applyBackupDriveBtn" class="btn btn-primary btn-sm">Apply Backup Drive Setup</button>
-      </div>
-    </div>
-  </details>
-</section>
-{% endif %}
-
 <section class="mb-6">
   <div class="d-flex items-center justify-between mb-4 flex-wrap gap-3">
     <h2 style="font-size: var(--text-lg); margin: 0;">HDSentinel Monitoring</h2>
@@ -248,6 +178,135 @@
     </form>
   </details>
 </section>
+
+{% if can_manage_backup_drive %}
+<section class="mb-6">
+  <details>
+    <summary><strong>Advanced: Re-run Backup Drive Setup</strong></summary>
+    <div class="mt-4">
+      <div class="d-flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div class="text-muted" style="font-size: var(--text-sm); line-height: 1.6; max-width: 52rem;">
+          Use this only when the backup drive changed or the original drive detection was wrong. It re-runs the drive setup portion of onboarding for the backup disk only.
+        </div>
+        <button type="button" class="btn btn-secondary btn-sm" data-modal-target="backupDriveSetupHelpModal">
+          <i class="fas fa-circle-info me-1"></i> When Should I Use This?
+        </button>
+      </div>
+
+      <div class="alert alert-warning mb-4">
+        <div>
+          <strong>Warning:</strong> This will update the SimpleSaferServer-managed backup drive configuration, including the stored drive identifiers and the SimpleSaferServer-managed `/etc/fstab` entry.
+        </div>
+      </div>
+
+      <div class="table-container mb-4">
+        <table>
+          <tbody>
+            <tr>
+              <th>Configured Mount Point</th>
+              <td><code>{{ drive_config.mount_point }}</code></td>
+            </tr>
+            <tr>
+              <th>Configured UUID</th>
+              <td><code>{{ drive_config.uuid or '—' }}</code></td>
+            </tr>
+            <tr>
+              <th>Configured USB ID</th>
+              <td><code>{{ drive_config.usb_id or '—' }}</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div id="driveSetupStatus" class="text-muted mb-3" style="min-height: 1.5rem;"></div>
+      <div id="driveSetupError" class="alert alert-danger d-none mb-4"></div>
+
+      <div class="d-flex gap-2 mb-4 flex-wrap">
+        <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
+      </div>
+
+      <div class="form-row mb-4">
+        <div class="form-group">
+          <label class="form-label" for="backupDriveSelect">Backup Drive Partition</label>
+          <select class="form-control" id="backupDriveSelect">
+            <option value="">Scan connected drives first</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="backupDriveMountPoint">Mount Point</label>
+          <input type="text" class="form-control text-mono" id="backupDriveMountPoint" value="{{ drive_config.mount_point }}" placeholder="/media/backup">
+        </div>
+      </div>
+
+      <div class="form-group mb-4">
+        <label class="form-check-label" for="backupDriveAutoMount">
+          <input type="checkbox" class="form-check-input" id="backupDriveAutoMount" checked>
+          Update the SimpleSaferServer-managed `/etc/fstab` entry so this drive mounts automatically at boot
+        </label>
+      </div>
+
+      <div class="text-muted mb-4" style="font-size: var(--text-sm); line-height: 1.6;">
+        Scan drives, select the correct backup partition, unmount it first if needed, then apply the updated backup drive setup. Do not use this for unrelated system storage changes.
+      </div>
+
+      <div class="d-flex gap-2 justify-end flex-wrap">
+        <button type="button" id="unmountBackupDriveBtn" class="btn btn-secondary btn-sm">Unmount Selected Drive</button>
+        <button type="button" id="applyBackupDriveBtn" class="btn btn-primary btn-sm">Apply Backup Drive Setup</button>
+      </div>
+    </div>
+  </details>
+</section>
+
+<div class="modal-overlay" id="backupDriveSetupHelpModal">
+  <div class="modal-container modal-lg">
+    <div class="modal-header">
+      <h5>About Backup Drive Setup</h5>
+      <button class="modal-close" data-modal-close><i class="fas fa-xmark"></i></button>
+    </div>
+    <div class="modal-body">
+      <div class="mb-4">
+        <strong>Use this when:</strong>
+        <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
+          <li>you replaced the backup drive with a different physical disk</li>
+          <li>the original UUID or USB ID was detected incorrectly during setup or migration</li>
+          <li>you need to point the backup system at the correct backup partition again</li>
+        </ul>
+      </div>
+
+      <div class="mb-4">
+        <strong>Do not use this when:</strong>
+        <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
+          <li>you are only changing cloud backup settings or schedules</li>
+          <li>you are trying to manage unrelated disks or other `/etc/fstab` entries</li>
+          <li>the system is already configured correctly and the drive has not changed</li>
+        </ul>
+      </div>
+
+      <div class="mb-4">
+        <strong>What this updates:</strong>
+        <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
+          <li>the backup drive mount point in SimpleSaferServer config</li>
+          <li>the stored backup drive UUID and USB ID</li>
+          <li>the SimpleSaferServer-managed `/etc/fstab` entry for the backup drive</li>
+          <li>the Samba backup share path if the mount point changed</li>
+        </ul>
+      </div>
+
+      <div>
+        <strong>What it will not do:</strong>
+        <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
+          <li>it will not modify unrelated `/etc/fstab` entries</li>
+          <li>it will stop and ask for manual cleanup if it finds conflicting or ambiguous mount entries</li>
+          <li>it is not a general-purpose disk management tool</li>
+        </ul>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" data-modal-close>Close</button>
+    </div>
+  </div>
+</div>
+{% endif %}
 
 {% if smart %}
 <section>

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -251,15 +251,8 @@
         </div>
       </div>
 
-      <div class="form-group mb-4">
-        <label class="form-check-label" for="backupDriveAutoMount">
-          <input type="checkbox" class="form-check-input" id="backupDriveAutoMount" checked>
-          Update the SimpleSaferServer-managed <code>/etc/fstab</code> entry so this drive mounts automatically at boot
-        </label>
-      </div>
-
       <div class="text-muted mb-4" style="font-size: var(--text-sm); line-height: 1.6;">
-        Scan drives, select the correct backup partition, unmount it first if needed, then apply the updated backup drive setup. Do not use this for unrelated system storage changes.
+        Scan drives, select the correct backup partition, unmount it first if needed, then apply the updated backup drive setup. This always refreshes the SimpleSaferServer-managed <code>/etc/fstab</code> entry using the boot-safe <code>nofail</code> configuration. Do not use this for unrelated system storage changes.
       </div>
 
       <div class="d-flex gap-2 justify-end flex-wrap">
@@ -469,7 +462,6 @@
     const applyBtn = document.getElementById('applyBackupDriveBtn');
     const driveSelect = document.getElementById('backupDriveSelect');
     const mountPointInput = document.getElementById('backupDriveMountPoint');
-    const autoMountInput = document.getElementById('backupDriveAutoMount');
     const configuredMountPointValue = document.getElementById('configuredMountPointValue');
     const configuredUuidValue = document.getElementById('configuredUuidValue');
     const configuredUsbIdValue = document.getElementById('configuredUsbIdValue');
@@ -612,8 +604,7 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             drive: driveSelect.value,
-            mount_point: mountPointInput.value.trim(),
-            auto_mount: autoMountInput.checked
+            mount_point: mountPointInput.value.trim()
           })
         });
         const data = await parseDriveSetupResponse(response);

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -234,7 +234,7 @@
 
       <div class="d-flex items-center gap-2 mb-4 flex-wrap">
         <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
-        <div id="driveSetupStatus" class="text-muted d-flex items-center" style="font-size: var(--text-xs); line-height: 1.5; min-height: 1.5rem; flex: 0 1 auto;"></div>
+        <div id="driveSetupStatus" class="drive-setup-status text-muted"></div>
       </div>
 
       <div class="form-row mb-4">
@@ -476,7 +476,7 @@
 
     function setDriveSetupStatus(message, type) {
       statusEl.textContent = message || '';
-      statusEl.className = 'mb-3';
+      statusEl.className = 'drive-setup-status';
       const classMap = {
         info: 'text-info',
         success: 'text-success',

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -285,10 +285,10 @@
       <div class="mb-4">
         <strong>What this updates:</strong>
         <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
-          <li>the backup drive mount point in SimpleSaferServer config</li>
+          <li>the backup drive mount point in <code>/etc/SimpleSaferServer/config.conf</code></li>
           <li>the stored backup drive UUID and USB ID</li>
-          <li>the SimpleSaferServer-managed <code>/etc/fstab</code> entry for the backup drive</li>
-          <li>the Samba backup share path if the mount point changed</li>
+          <li>the SimpleSaferServer-managed line in <code>/etc/fstab</code> for the backup drive</li>
+          <li>the Samba backup share path in <code>/etc/samba/smb.conf</code> if the mount point changed</li>
         </ul>
       </div>
 
@@ -299,6 +299,17 @@
           <li>it will stop and ask for manual cleanup if it finds conflicting or ambiguous mount entries</li>
           <li>it is not a general-purpose disk management tool</li>
         </ul>
+      </div>
+
+      <div class="mt-4">
+        <strong>What “SimpleSaferServer-managed” means:</strong>
+        <p class="text-muted mt-2" style="line-height: 1.6;">
+          The app only updates the backup drive line in <code>/etc/fstab</code> that ends with its marker comment. That marker is just the trailing comment <code># SimpleSaferServer managed backup drive</code>.
+        </p>
+        <div class="mt-2">
+          <strong>Example:</strong>
+          <div class="mt-2"><code>UUID=2CD49023D48FED80 /media/backup ntfs-3g defaults,nofail 0 0 # SimpleSaferServer managed backup drive</code></div>
+        </div>
       </div>
     </div>
     <div class="modal-footer">

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -220,9 +220,9 @@
 
       <div id="driveSetupError" class="alert alert-danger d-none mb-4"></div>
 
-      <div class="d-flex items-center justify-between gap-3 mb-4 flex-wrap">
+      <div class="d-flex items-center gap-2 mb-4 flex-wrap">
         <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
-        <div id="driveSetupStatus" class="text-muted" style="font-size: var(--text-sm); min-height: 1.5rem;"></div>
+        <div id="driveSetupStatus" class="text-muted" style="font-size: var(--text-sm); min-height: 1.5rem; flex: 0 1 auto;"></div>
       </div>
 
       <div class="form-row mb-4">

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -186,7 +186,6 @@
   </details>
 </section>
 
-{% if can_manage_backup_drive %}
 <section class="mb-6">
   <details>
     <summary><strong>Advanced: Re-run Backup Drive Setup</strong></summary>
@@ -342,7 +341,6 @@
     </div>
   </div>
 </div>
-{% endif %}
 
 {% if smart %}
 <section>
@@ -449,7 +447,6 @@
     downloadTelemetryBtn.addEventListener('click', handleTelemetryDownload);
   })();
 </script>
-{% if can_manage_backup_drive %}
 <script>
   (function() {
     const statusEl = document.getElementById('driveSetupStatus');
@@ -657,5 +654,4 @@
     if (applyBtn) applyBtn.addEventListener('click', applyDriveSetup);
   })();
 </script>
-{% endif %}
 {% endblock %}

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -253,7 +253,7 @@
       <div class="form-group mb-4">
         <label class="form-check-label" for="backupDriveAutoMount">
           <input type="checkbox" class="form-check-input" id="backupDriveAutoMount" checked>
-          Update the SimpleSaferServer-managed `/etc/fstab` entry so this drive mounts automatically at boot
+          Update the SimpleSaferServer-managed <code>/etc/fstab</code> entry so this drive mounts automatically at boot
         </label>
       </div>
 

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -536,6 +536,10 @@
       });
     }
 
+    function getDriveHealthUnmountConfirmationMessage() {
+      return 'This only unmounts the selected partition temporarily so backup drive setup can continue. If the selected partition is still the configured backup drive, SimpleSaferServer may remount it automatically during a later Check Mount run if the drive stays connected. SMB access to the backup share may disconnect briefly so the unmount can succeed.';
+    }
+
     async function scanDrives() {
       hideDriveSetupError();
       setDriveSetupStatus('Scanning connected drives…', 'info');
@@ -563,6 +567,17 @@
         showDriveSetupError('Select a drive partition to unmount first.');
         return;
       }
+
+      const confirmed = await window.showConfirmationDialog({
+        title: 'Unmount Selected Drive',
+        message: getDriveHealthUnmountConfirmationMessage(),
+        confirmLabel: 'Unmount',
+        confirmClass: 'btn-warning'
+      });
+      if (!confirmed) {
+        return;
+      }
+
       setDriveSetupStatus('Unmounting selected drive…', 'info');
       if (window.AsyncButtonState && unmountBtn) window.AsyncButtonState.start(unmountBtn);
       try {

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -75,51 +75,75 @@
   {% endif %}
 </div>
 
+{% if can_manage_backup_drive %}
 <section class="mb-6">
-  <div class="d-flex items-center justify-between mb-4 flex-wrap gap-3">
-    <h2 style="font-size: var(--text-lg); margin: 0;">Backup Drive Identification</h2>
-  </div>
-
-  <div class="alert alert-info mb-4">
-    <div>
-      <strong>What these mean:</strong>
-      UUID identifies the backup partition itself. USB ID identifies the attached USB device in `vendor:product` form, such as `0480:a202`.
-    </div>
-  </div>
-
-  <form method="post">
-    <input type="hidden" name="form_action" value="save_drive_identifiers">
-    <div class="form-row mb-4">
-      <div class="form-group">
-        <label class="form-label" for="mountPoint">Mount Point</label>
-        <input type="text" class="form-control text-mono" id="mountPoint" name="mount_point" value="{{ drive_config.mount_point }}" placeholder="/media/backup" required>
-      </div>
-      <div class="form-group">
-        <label class="form-label" for="driveUuid">Drive UUID</label>
-        <input type="text" class="form-control text-mono" id="driveUuid" name="uuid" value="{{ drive_config.uuid }}" placeholder="2CD49023D48FED80" required>
-      </div>
-    </div>
-
-    <div class="form-row mb-4">
-      <div class="form-group">
-        <label class="form-label" for="usbId">USB ID <span class="text-muted">(optional)</span></label>
-        <input type="text" class="form-control text-mono" id="usbId" name="usb_id" value="{{ drive_config.usb_id }}" placeholder="0480:a202">
-      </div>
-      <div class="form-group">
-        <label class="form-label">How To Find Them</label>
-        <div class="text-muted" style="font-size: var(--text-sm); line-height: 1.6;">
-          UUID: <code>blkid -s UUID -o value /dev/sdX1</code><br>
-          USB ID: <code>lsusb</code><br>
-          Leave USB ID blank to skip the USB presence check.
+  <details>
+    <summary><strong>Advanced: Re-run Backup Drive Setup</strong></summary>
+    <div class="mt-4">
+      <div class="alert alert-warning mb-4">
+        <div>
+          <strong>Warning:</strong> Use this only if the backup drive changed or the original drive identifiers were detected incorrectly. This updates the SimpleSaferServer-managed backup mount configuration.
         </div>
       </div>
-    </div>
 
-    <div class="d-flex justify-end">
-      <button type="submit" class="btn btn-primary btn-sm">Save Drive Identification</button>
+      <div class="table-container mb-4">
+        <table>
+          <tbody>
+            <tr>
+              <th>Configured Mount Point</th>
+              <td><code>{{ drive_config.mount_point }}</code></td>
+            </tr>
+            <tr>
+              <th>Configured UUID</th>
+              <td><code>{{ drive_config.uuid or '—' }}</code></td>
+            </tr>
+            <tr>
+              <th>Configured USB ID</th>
+              <td><code>{{ drive_config.usb_id or '—' }}</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div id="driveSetupStatus" class="text-muted mb-3" style="min-height: 1.5rem;"></div>
+      <div id="driveSetupError" class="alert alert-danger d-none mb-4"></div>
+
+      <div class="d-flex gap-2 mb-4 flex-wrap">
+        <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
+      </div>
+
+      <div class="form-row mb-4">
+        <div class="form-group">
+          <label class="form-label" for="backupDriveSelect">Backup Drive Partition</label>
+          <select class="form-control" id="backupDriveSelect">
+            <option value="">Scan connected drives first</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="backupDriveMountPoint">Mount Point</label>
+          <input type="text" class="form-control text-mono" id="backupDriveMountPoint" value="{{ drive_config.mount_point }}" placeholder="/media/backup">
+        </div>
+      </div>
+
+      <div class="form-group mb-4">
+        <label class="form-check-label" for="backupDriveAutoMount">
+          <input type="checkbox" class="form-check-input" id="backupDriveAutoMount" checked>
+          Update the SimpleSaferServer-managed `/etc/fstab` entry so this drive mounts automatically at boot
+        </label>
+      </div>
+
+      <div class="text-muted mb-4" style="font-size: var(--text-sm); line-height: 1.6;">
+        If the current drive is still mounted, unmount it first here or from the dashboard before applying the new selection. For fully manual recovery steps, use the documentation linked from the project website.
+      </div>
+
+      <div class="d-flex gap-2 justify-end flex-wrap">
+        <button type="button" id="unmountBackupDriveBtn" class="btn btn-secondary btn-sm">Unmount Selected Drive</button>
+        <button type="button" id="applyBackupDriveBtn" class="btn btn-primary btn-sm">Apply Backup Drive Setup</button>
+      </div>
     </div>
-  </form>
+  </details>
 </section>
+{% endif %}
 
 <section class="mb-6">
   <div class="d-flex items-center justify-between mb-4 flex-wrap gap-3">
@@ -262,5 +286,152 @@
     </table>
   </div>
 </section>
+{% endif %}
+{% endblock %}
+
+{% block extra_js %}
+{% if can_manage_backup_drive %}
+<script>
+  (function() {
+    const statusEl = document.getElementById('driveSetupStatus');
+    const errorEl = document.getElementById('driveSetupError');
+    const scanBtn = document.getElementById('scanBackupDrivesBtn');
+    const unmountBtn = document.getElementById('unmountBackupDriveBtn');
+    const applyBtn = document.getElementById('applyBackupDriveBtn');
+    const driveSelect = document.getElementById('backupDriveSelect');
+    const mountPointInput = document.getElementById('backupDriveMountPoint');
+    const autoMountInput = document.getElementById('backupDriveAutoMount');
+
+    function setDriveSetupStatus(message, type) {
+      statusEl.textContent = message || '';
+      statusEl.className = 'mb-3';
+      const classMap = {
+        info: 'text-info',
+        success: 'text-success',
+        error: 'text-danger',
+        warning: 'text-warning'
+      };
+      statusEl.classList.add(classMap[type || 'info'] || 'text-muted');
+    }
+
+    function showDriveSetupError(message) {
+      errorEl.textContent = message;
+      errorEl.classList.remove('d-none');
+      setDriveSetupStatus(message, 'error');
+    }
+
+    function hideDriveSetupError() {
+      errorEl.classList.add('d-none');
+      errorEl.textContent = '';
+    }
+
+    function populateDriveSelect(drives) {
+      driveSelect.innerHTML = '';
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = drives.length ? 'Select a partition' : 'No backup drive partitions found';
+      driveSelect.appendChild(placeholder);
+
+      drives.forEach((drive) => {
+        const group = document.createElement('optgroup');
+        group.label = `${drive.model} (${drive.size || 'unknown size'})`;
+        (drive.partitions || []).forEach((partition) => {
+          const option = document.createElement('option');
+          option.value = partition.path;
+          option.textContent = `${partition.path}${partition.size ? ` (${partition.size})` : ''}`;
+          group.appendChild(option);
+        });
+        if (group.children.length > 0) {
+          driveSelect.appendChild(group);
+        }
+      });
+    }
+
+    async function scanDrives() {
+      hideDriveSetupError();
+      setDriveSetupStatus('Scanning connected drives…', 'info');
+      if (window.AsyncButtonState && scanBtn) window.AsyncButtonState.start(scanBtn);
+      try {
+        const response = await fetch('/api/backup_drive/drives');
+        const data = await response.json();
+        if (!data.success) {
+          throw new Error(data.error || 'Failed to scan connected drives.');
+        }
+        populateDriveSelect(data.drives || []);
+        setDriveSetupStatus('Drive scan complete.', 'success');
+        if (window.AsyncButtonState && scanBtn) window.AsyncButtonState.success(scanBtn);
+      } catch (error) {
+        showDriveSetupError(error.message || 'Failed to scan connected drives.');
+        if (window.AsyncButtonState && scanBtn) window.AsyncButtonState.error(scanBtn);
+      }
+    }
+
+    async function unmountSelectedDrive() {
+      hideDriveSetupError();
+      if (!driveSelect.value) {
+        showDriveSetupError('Select a drive partition to unmount first.');
+        return;
+      }
+      setDriveSetupStatus('Unmounting selected drive…', 'info');
+      if (window.AsyncButtonState && unmountBtn) window.AsyncButtonState.start(unmountBtn);
+      try {
+        const response = await fetch('/api/backup_drive/unmount', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ drive: driveSelect.value })
+        });
+        const data = await response.json();
+        if (!data.success) {
+          throw new Error(data.error || 'Failed to unmount the selected drive.');
+        }
+        setDriveSetupStatus(data.message || 'Drive unmounted successfully.', 'success');
+        if (window.AsyncButtonState && unmountBtn) window.AsyncButtonState.success(unmountBtn);
+      } catch (error) {
+        showDriveSetupError(error.message || 'Failed to unmount the selected drive.');
+        if (window.AsyncButtonState && unmountBtn) window.AsyncButtonState.error(unmountBtn);
+      }
+    }
+
+    async function applyDriveSetup() {
+      hideDriveSetupError();
+      if (!driveSelect.value) {
+        showDriveSetupError('Select a backup drive partition first.');
+        return;
+      }
+      if (!mountPointInput.value.trim()) {
+        showDriveSetupError('Mount point is required.');
+        return;
+      }
+
+      setDriveSetupStatus('Applying backup drive setup…', 'info');
+      if (window.AsyncButtonState && applyBtn) window.AsyncButtonState.start(applyBtn);
+      try {
+        const response = await fetch('/api/backup_drive/configure', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            drive: driveSelect.value,
+            mount_point: mountPointInput.value.trim(),
+            auto_mount: autoMountInput.checked
+          })
+        });
+        const data = await response.json();
+        if (!data.success) {
+          throw new Error(data.error || 'Failed to apply backup drive setup.');
+        }
+        setDriveSetupStatus((data.result && data.result.message) || 'Backup drive setup updated successfully.', 'success');
+        if (window.AsyncButtonState && applyBtn) window.AsyncButtonState.success(applyBtn);
+        window.location.reload();
+      } catch (error) {
+        showDriveSetupError(error.message || 'Failed to apply backup drive setup.');
+        if (window.AsyncButtonState && applyBtn) window.AsyncButtonState.error(applyBtn);
+      }
+    }
+
+    if (scanBtn) scanBtn.addEventListener('click', scanDrives);
+    if (unmountBtn) unmountBtn.addEventListener('click', unmountSelectedDrive);
+    if (applyBtn) applyBtn.addEventListener('click', applyDriveSetup);
+  })();
+</script>
 {% endif %}
 {% endblock %}

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -27,6 +27,13 @@
     </div>
   {% endif %}
 
+  {% if smart_support_warning %}
+    <div class="alert alert-warning">
+      <i class="fas fa-triangle-exclamation"></i>
+      <span>{{ smart_support_warning }}</span>
+    </div>
+  {% endif %}
+
   {% if settings_message %}
     <div class="alert alert-success">
       <i class="fas fa-circle-check"></i>

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -204,15 +204,15 @@
           <tbody>
             <tr>
               <th>Configured Mount Point</th>
-              <td><code>{{ drive_config.mount_point }}</code></td>
+              <td><code id="configuredMountPointValue">{{ drive_config.mount_point }}</code></td>
             </tr>
             <tr>
               <th>Configured UUID</th>
-              <td><code>{{ drive_config.uuid or '—' }}</code></td>
+              <td><code id="configuredUuidValue">{{ drive_config.uuid or '—' }}</code></td>
             </tr>
             <tr>
               <th>Configured USB ID</th>
-              <td><code>{{ drive_config.usb_id or '—' }}</code></td>
+              <td><code id="configuredUsbIdValue">{{ drive_config.usb_id or '—' }}</code></td>
             </tr>
           </tbody>
         </table>
@@ -398,6 +398,9 @@
     const driveSelect = document.getElementById('backupDriveSelect');
     const mountPointInput = document.getElementById('backupDriveMountPoint');
     const autoMountInput = document.getElementById('backupDriveAutoMount');
+    const configuredMountPointValue = document.getElementById('configuredMountPointValue');
+    const configuredUuidValue = document.getElementById('configuredUuidValue');
+    const configuredUsbIdValue = document.getElementById('configuredUsbIdValue');
     let currentDriveSetupErrorDetails = '';
 
     function setDriveSetupStatus(message, type) {
@@ -547,9 +550,15 @@
           error.details = data.details || '';
           throw error;
         }
-        setDriveSetupStatus((data.result && data.result.message) || 'Backup drive setup updated successfully.', 'success');
+        const result = data.result || {};
+        setDriveSetupStatus(result.message || 'Backup drive setup updated successfully.', 'success');
+        if (configuredMountPointValue) configuredMountPointValue.textContent = result.mount_point || mountPointInput.value.trim();
+        if (configuredUuidValue) configuredUuidValue.textContent = result.uuid || '—';
+        if (configuredUsbIdValue) configuredUsbIdValue.textContent = result.usb_id || '—';
+        if (window.showAlert) {
+          window.showAlert(result.message || 'Backup drive setup updated successfully.', 'success');
+        }
         if (window.AsyncButtonState && applyBtn) window.AsyncButtonState.success(applyBtn);
-        window.location.reload();
       } catch (error) {
         showDriveSetupError(error.message || 'Failed to apply backup drive setup.', error.details);
         if (window.AsyncButtonState && applyBtn) window.AsyncButtonState.error(applyBtn);

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -243,6 +243,7 @@
           <select class="form-control" id="backupDriveSelect">
             <option value="">Scan connected drives first</option>
           </select>
+          <div class="form-hint">NTFS only</div>
         </div>
         <div class="form-group">
           <label class="form-label" for="backupDriveMountPoint">Mount Point</label>
@@ -525,7 +526,7 @@
       driveSelect.innerHTML = '';
       const placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = drives.length ? 'Select a partition' : 'No backup drive partitions found';
+      placeholder.textContent = drives.length ? 'Select an NTFS partition' : 'No NTFS backup partitions found';
       driveSelect.appendChild(placeholder);
 
       drives.forEach((drive) => {

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -218,7 +218,12 @@
         </table>
       </div>
 
-      <div id="driveSetupError" class="alert alert-danger d-none mb-4"></div>
+      <div id="driveSetupError" class="alert alert-danger d-none mb-4">
+        <div class="d-flex items-center justify-between gap-3 flex-wrap">
+          <span id="driveSetupErrorText"></span>
+          <button type="button" id="driveSetupErrorDetailsBtn" class="btn btn-secondary btn-sm d-none">Show Details</button>
+        </div>
+      </div>
 
       <div class="d-flex items-center gap-2 mb-4 flex-wrap">
         <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
@@ -319,6 +324,23 @@
     </div>
   </div>
 </div>
+
+<div class="modal-overlay" id="backupDriveSetupErrorDetailsModal">
+  <div class="modal-container modal-lg">
+    <div class="modal-header">
+      <h5>Backup Drive Setup Error Details</h5>
+      <button class="modal-close" data-modal-close><i class="fas fa-xmark"></i></button>
+    </div>
+    <div class="modal-body">
+      <pre id="backupDriveSetupErrorDetailsText" style="white-space: pre-wrap; word-break: break-word; margin: 0;"></pre>
+    </div>
+    <div class="modal-footer">
+      <div class="modal-footer-actions">
+        <button class="btn btn-secondary" data-modal-close>Close</button>
+      </div>
+    </div>
+  </div>
+</div>
 {% endif %}
 
 {% if smart %}
@@ -367,12 +389,16 @@
   (function() {
     const statusEl = document.getElementById('driveSetupStatus');
     const errorEl = document.getElementById('driveSetupError');
+    const errorTextEl = document.getElementById('driveSetupErrorText');
+    const errorDetailsBtn = document.getElementById('driveSetupErrorDetailsBtn');
+    const errorDetailsTextEl = document.getElementById('backupDriveSetupErrorDetailsText');
     const scanBtn = document.getElementById('scanBackupDrivesBtn');
     const unmountBtn = document.getElementById('unmountBackupDriveBtn');
     const applyBtn = document.getElementById('applyBackupDriveBtn');
     const driveSelect = document.getElementById('backupDriveSelect');
     const mountPointInput = document.getElementById('backupDriveMountPoint');
     const autoMountInput = document.getElementById('backupDriveAutoMount');
+    let currentDriveSetupErrorDetails = '';
 
     function setDriveSetupStatus(message, type) {
       statusEl.textContent = message || '';
@@ -386,15 +412,23 @@
       statusEl.classList.add(classMap[type || 'info'] || 'text-muted');
     }
 
-    function showDriveSetupError(message) {
-      errorEl.textContent = message;
+    function showDriveSetupError(message, details) {
+      errorTextEl.textContent = message;
       errorEl.classList.remove('d-none');
+      currentDriveSetupErrorDetails = details || '';
+      if (currentDriveSetupErrorDetails) {
+        errorDetailsBtn.classList.remove('d-none');
+      } else {
+        errorDetailsBtn.classList.add('d-none');
+      }
       setDriveSetupStatus('', 'info');
     }
 
     function hideDriveSetupError() {
       errorEl.classList.add('d-none');
-      errorEl.textContent = '';
+      errorTextEl.textContent = '';
+      errorDetailsBtn.classList.add('d-none');
+      currentDriveSetupErrorDetails = '';
     }
 
     async function parseDriveSetupResponse(response) {
@@ -443,13 +477,15 @@
         const response = await fetch('/api/backup_drive/drives');
         const data = await parseDriveSetupResponse(response);
         if (!data.success) {
-          throw new Error(data.error || 'Failed to scan connected drives.');
+          const error = new Error(data.error || 'Failed to scan connected drives.');
+          error.details = data.details || '';
+          throw error;
         }
         populateDriveSelect(data.drives || []);
         setDriveSetupStatus('Drive scan complete.', 'success');
         if (window.AsyncButtonState && scanBtn) window.AsyncButtonState.success(scanBtn);
       } catch (error) {
-        showDriveSetupError(error.message || 'Failed to scan connected drives.');
+        showDriveSetupError(error.message || 'Failed to scan connected drives.', error.details);
         if (window.AsyncButtonState && scanBtn) window.AsyncButtonState.error(scanBtn);
       }
     }
@@ -470,12 +506,14 @@
         });
         const data = await parseDriveSetupResponse(response);
         if (!data.success) {
-          throw new Error(data.error || 'Failed to unmount the selected drive.');
+          const error = new Error(data.error || 'Failed to unmount the selected drive.');
+          error.details = data.details || '';
+          throw error;
         }
         setDriveSetupStatus(data.message || 'Drive unmounted successfully.', 'success');
         if (window.AsyncButtonState && unmountBtn) window.AsyncButtonState.success(unmountBtn);
       } catch (error) {
-        showDriveSetupError(error.message || 'Failed to unmount the selected drive.');
+        showDriveSetupError(error.message || 'Failed to unmount the selected drive.', error.details);
         if (window.AsyncButtonState && unmountBtn) window.AsyncButtonState.error(unmountBtn);
       }
     }
@@ -505,15 +543,26 @@
         });
         const data = await parseDriveSetupResponse(response);
         if (!data.success) {
-          throw new Error(data.error || 'Failed to apply backup drive setup.');
+          const error = new Error(data.error || 'Failed to apply backup drive setup.');
+          error.details = data.details || '';
+          throw error;
         }
         setDriveSetupStatus((data.result && data.result.message) || 'Backup drive setup updated successfully.', 'success');
         if (window.AsyncButtonState && applyBtn) window.AsyncButtonState.success(applyBtn);
         window.location.reload();
       } catch (error) {
-        showDriveSetupError(error.message || 'Failed to apply backup drive setup.');
+        showDriveSetupError(error.message || 'Failed to apply backup drive setup.', error.details);
         if (window.AsyncButtonState && applyBtn) window.AsyncButtonState.error(applyBtn);
       }
+    }
+
+    if (errorDetailsBtn) {
+      errorDetailsBtn.addEventListener('click', () => {
+        errorDetailsTextEl.textContent = currentDriveSetupErrorDetails || 'No additional details available.';
+        if (window.BunkerModal) {
+          window.BunkerModal.show('backupDriveSetupErrorDetailsModal');
+        }
+      });
     }
 
     if (scanBtn) scanBtn.addEventListener('click', scanDrives);

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -534,7 +534,12 @@
     }
 
     function getDriveHealthUnmountConfirmationMessage() {
-      return 'This only unmounts the selected partition temporarily so backup drive setup can continue. If the selected partition is still the configured backup drive, SimpleSaferServer may remount it automatically during a later Check Mount run if the drive stays connected. SMB access to the backup share may disconnect briefly so the unmount can succeed.';
+      return `This unmounts the partition temporarily so backup drive setup can continue.
+
+If it stays connected, SimpleSaferServer will remount it
+automatically during the next 'Check Mount' run.
+
+Note: SMB access will briefly disconnect while unmounting.`;
     }
 
     async function scanDrives() {

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -195,7 +195,7 @@
 
       <div class="alert alert-warning mb-4">
         <div>
-          <strong>Warning:</strong> This will update the SimpleSaferServer-managed backup drive configuration, including the stored drive identifiers and the SimpleSaferServer-managed `/etc/fstab` entry.
+          <strong>Warning:</strong> This will update the SimpleSaferServer-managed backup drive configuration, including the stored drive identifiers and the SimpleSaferServer-managed <code>/etc/fstab</code> entry.
         </div>
       </div>
 
@@ -218,11 +218,11 @@
         </table>
       </div>
 
-      <div id="driveSetupStatus" class="text-muted mb-3" style="min-height: 1.5rem;"></div>
       <div id="driveSetupError" class="alert alert-danger d-none mb-4"></div>
 
-      <div class="d-flex gap-2 mb-4 flex-wrap">
+      <div class="d-flex items-center justify-between gap-3 mb-4 flex-wrap">
         <button type="button" id="scanBackupDrivesBtn" class="btn btn-secondary btn-sm">Scan Connected Drives</button>
+        <div id="driveSetupStatus" class="text-muted" style="font-size: var(--text-sm); min-height: 1.5rem;"></div>
       </div>
 
       <div class="form-row mb-4">
@@ -277,7 +277,7 @@
         <strong>Do not use this when:</strong>
         <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
           <li>you are only changing cloud backup settings or schedules</li>
-          <li>you are trying to manage unrelated disks or other `/etc/fstab` entries</li>
+          <li>you are trying to manage unrelated disks or other <code>/etc/fstab</code> entries</li>
           <li>the system is already configured correctly and the drive has not changed</li>
         </ul>
       </div>
@@ -287,7 +287,7 @@
         <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
           <li>the backup drive mount point in SimpleSaferServer config</li>
           <li>the stored backup drive UUID and USB ID</li>
-          <li>the SimpleSaferServer-managed `/etc/fstab` entry for the backup drive</li>
+          <li>the SimpleSaferServer-managed <code>/etc/fstab</code> entry for the backup drive</li>
           <li>the Samba backup share path if the mount point changed</li>
         </ul>
       </div>
@@ -295,14 +295,16 @@
       <div>
         <strong>What it will not do:</strong>
         <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
-          <li>it will not modify unrelated `/etc/fstab` entries</li>
+          <li>it will not modify unrelated <code>/etc/fstab</code> entries</li>
           <li>it will stop and ask for manual cleanup if it finds conflicting or ambiguous mount entries</li>
           <li>it is not a general-purpose disk management tool</li>
         </ul>
       </div>
     </div>
     <div class="modal-footer">
-      <button class="btn btn-secondary" data-modal-close>Close</button>
+      <div class="modal-footer-actions">
+        <button class="btn btn-secondary" data-modal-close>Close</button>
+      </div>
     </div>
   </div>
 </div>
@@ -384,6 +386,22 @@
       errorEl.textContent = '';
     }
 
+    async function parseDriveSetupResponse(response) {
+      const contentType = response.headers.get('content-type') || '';
+      if (!contentType.includes('application/json')) {
+        if (response.status === 401 || response.status === 403 || response.redirected) {
+          throw new Error('Your session expired or you are not authorized to perform this action. Please log in again.');
+        }
+        throw new Error('The server returned an unexpected response.');
+      }
+
+      const data = await response.json();
+      if ((response.status === 401 || response.status === 403) && !data.success) {
+        throw new Error(data.error || 'You are not authorized to perform this action.');
+      }
+      return data;
+    }
+
     function populateDriveSelect(drives) {
       driveSelect.innerHTML = '';
       const placeholder = document.createElement('option');
@@ -412,7 +430,7 @@
       if (window.AsyncButtonState && scanBtn) window.AsyncButtonState.start(scanBtn);
       try {
         const response = await fetch('/api/backup_drive/drives');
-        const data = await response.json();
+        const data = await parseDriveSetupResponse(response);
         if (!data.success) {
           throw new Error(data.error || 'Failed to scan connected drives.');
         }
@@ -439,7 +457,7 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ drive: driveSelect.value })
         });
-        const data = await response.json();
+        const data = await parseDriveSetupResponse(response);
         if (!data.success) {
           throw new Error(data.error || 'Failed to unmount the selected drive.');
         }
@@ -474,7 +492,7 @@
             auto_mount: autoMountInput.checked
           })
         });
-        const data = await response.json();
+        const data = await parseDriveSetupResponse(response);
         if (!data.success) {
           throw new Error(data.error || 'Failed to apply backup drive setup.');
         }

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -389,7 +389,7 @@
     function showDriveSetupError(message) {
       errorEl.textContent = message;
       errorEl.classList.remove('d-none');
-      setDriveSetupStatus(message, 'error');
+      setDriveSetupStatus('', 'info');
     }
 
     function hideDriveSetupError() {

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -119,7 +119,11 @@
                             </div>
                             <div id="driveStatusArea" class="d-flex items-center mb-3" style="min-height:1.5rem;font-size:var(--text-sm);"></div>
                             <div class="d-flex gap-3 mb-4">
-                                <button id="unmountDriveBtn" class="btn btn-warning btn-sm" data-confirm="Are you sure you want to unmount this drive? This only clears the current live mounts so formatting can continue. Backup-drive settings, if any, are updated later in the Drive Mount step.">
+                                <button id="unmountDriveBtn" class="btn btn-warning btn-sm" data-confirm="Unmount this drive?
+
+This only clears live mounts so formatting can continue.
+
+Backup settings are NOT updated until the 'Drive Mount' step.">
                                     <i class="fas fa-eject me-1"></i> Unmount
                                 </button>
                                 <button id="formatDriveBtn" class="btn btn-danger btn-sm" data-confirm="Are you sure you want to format this drive? This will erase all data.">
@@ -167,7 +171,11 @@
                                 </div>
                             </div>
                             <div class="d-flex gap-2 justify-end mb-4">
-                                <button id="unmountMountDriveBtn" class="btn btn-warning btn-sm" data-confirm="Are you sure you want to unmount this drive? This only clears the current live mount so the selected partition can be configured again. Backup-drive settings are updated only after Mount Drive succeeds.">
+                                <button id="unmountMountDriveBtn" class="btn btn-warning btn-sm" data-confirm="Unmount this drive?
+
+This only clears the live mount so you can configure the partition.
+
+Backup settings are NOT updated until 'Mount Drive' succeeds.">
                                     <i class="fas fa-eject me-1"></i> Unmount
                                 </button>
                                 <button id="mountDriveBtn" class="btn btn-primary btn-sm" data-confirm="Are you sure you want to mount this drive?">
@@ -180,7 +188,10 @@
                             <button
                                 id="retryManagedUnmountBtn"
                                 class="btn btn-warning btn-sm d-none mt-3"
-                                data-confirm="Are you sure you want to retry using the SMB-safe unmount path? This may temporarily stop SMB access and related background backup tasks, unmount the configured backup share, and then start SMB again."
+                                data-confirm="Retry using the SMB-safe unmount path?
+
+This will temporarily stop SMB and background tasks to safely
+unmount the share, then restart SMB automatically."
                                 data-confirm-button="Retry SMB-safe Unmount"
                                 data-confirm-class="btn-warning"
                             >

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -177,6 +177,15 @@
                             <div class="form-hint mb-4">Unmount here is temporary preparation for mounting the selected partition. Backup-drive settings change only when Mount Drive succeeds.</div>
                             <div id="mountError" class="text-danger d-none" style="font-size:var(--text-sm);"></div>
                             <div id="mountDetails" class="text-muted d-none" style="font-size:var(--text-xs);"></div>
+                            <button
+                                id="retryManagedUnmountBtn"
+                                class="btn btn-warning btn-sm d-none mt-3"
+                                data-confirm="Are you sure you want to retry using the SMB-safe unmount path? This may temporarily stop SMB access and related background backup tasks, unmount the configured backup share, and then start SMB again."
+                                data-confirm-button="Retry SMB-safe Unmount"
+                                data-confirm-class="btn-warning"
+                            >
+                                <i class="fas fa-triangle-exclamation me-1"></i> Retry SMB-safe Unmount
+                            </button>
                         </div>
                     </div>
 
@@ -469,6 +478,20 @@
             area.classList.add(colorMap[type] || 'text-info');
         }
         function clearDriveStatus() { setDriveStatus('', 'info'); }
+        let canRetryManagedUnmount = false;
+
+        function getDriveTypeLabel(drive) {
+            if (drive.type === 'usb') return 'USB Drive';
+            if (drive.type === 'removable') return 'Removable Drive';
+            return 'Internal Drive';
+        }
+
+        function setManagedUnmountRetryState(enabled) {
+            canRetryManagedUnmount = enabled;
+            const retryBtn = document.getElementById('retryManagedUnmountBtn');
+            if (!retryBtn) return;
+            retryBtn.classList.toggle('d-none', !enabled);
+        }
 
         function updateDriveMountStatusBadge() {
             const select = document.getElementById('formatDriveSelect');
@@ -488,7 +511,7 @@
             formatSelect.innerHTML = '<option value="">Select a drive…</option>';
             let foundPrev = false;
             drives.forEach(drive => {
-                const driveType = drive.type === 'usb' ? 'USB Drive' : 'Internal Drive';
+                const driveType = getDriveTypeLabel(drive);
                 let isMounted = false;
                 drive.partitions.forEach(partition => { if (partition.mountpoint) isMounted = true; });
                 let label = `${drive.model} (${drive.size}) - ${driveType}`;
@@ -516,7 +539,7 @@
                 drive.partitions.forEach(partition => {
                     const mountStatus = partition.mountpoint ? ` (Mounted at ${partition.mountpoint})` : '';
                     const label = partition.label ? ` - ${partition.label}` : '';
-                    const driveType = drive.type === 'usb' ? 'USB Drive' : 'Internal Drive';
+                    const driveType = getDriveTypeLabel(drive);
                     const option = new Option(
                         `${drive.model} - ${partition.path}${label} (${partition.size}) - ${driveType}${mountStatus}`,
                         partition.path
@@ -554,6 +577,7 @@
                     throw new Error(data.error || 'Failed to load NTFS drives for mounting');
                 }
                 populateMountDriveSelect(data.drives || []);
+                setManagedUnmountRetryState(false);
             } catch (error) {
                 console.error('Error:', error);
                 showMountError('Failed to load NTFS drives for mounting');
@@ -639,28 +663,55 @@
         }
 
         async function unmountMountDrive() {
+            return submitMountUnmountRequest({ forceManaged: false });
+        }
+
+        async function retryManagedUnmount() {
+            return submitMountUnmountRequest({ forceManaged: true });
+        }
+
+        async function submitMountUnmountRequest({ forceManaged }) {
             const unmountMountBtn = document.getElementById('unmountMountDriveBtn');
+            const retryManagedBtn = document.getElementById('retryManagedUnmountBtn');
+            const activeBtn = forceManaged ? retryManagedBtn : unmountMountBtn;
             const partition = document.getElementById('mountDriveSelect').value;
             if (!partition) { showMountError('Please select a drive'); setMountStatus('Please select a drive.', 'warning'); return; }
-            window.AsyncButtonState.start(unmountMountBtn);
-            setMountStatus('Unmounting drive…', 'info');
+            window.AsyncButtonState.start(activeBtn);
+            setMountStatus(forceManaged ? 'Retrying with the SMB-safe unmount path…' : 'Unmounting drive…', 'info');
             try {
-                const response = await fetch('/api/setup/unmount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ partition }) });
+                const response = await fetch('/api/setup/unmount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ partition, force_managed: forceManaged }) });
                 const data = await response.json();
                 // This stays temporary on purpose so only a successful mount step
                 // changes the backup-drive settings.
-                if (data.success) { window.AsyncButtonState.success(unmountMountBtn); hideMountError(); setMountStatus('Drive unmounted. You can continue mounting the selected partition.', 'success'); await loadDrives(); }
-                else { window.AsyncButtonState.error(unmountMountBtn); setMountStatus('Failed to unmount drive.', 'error'); showMountError(data.error, data.details); }
-            } catch (error) { window.AsyncButtonState.error(unmountMountBtn); setMountStatus('An error occurred.', 'error'); showMountError('An error occurred while unmounting the drive'); }
+                if (data.success) {
+                    window.AsyncButtonState.success(activeBtn);
+                    hideMountError();
+                    setMountStatus('Drive unmounted. You can continue mounting the selected partition.', 'success');
+                    await loadDrives();
+                } else {
+                    window.AsyncButtonState.error(activeBtn);
+                    setMountStatus('Failed to unmount drive.', 'error');
+                    showMountError(data.error, data.details, { canRetryManagedUnmount: !!data.can_retry_managed_unmount });
+                }
+            } catch (error) {
+                window.AsyncButtonState.error(activeBtn);
+                setMountStatus('An error occurred.', 'error');
+                showMountError('An error occurred while unmounting the drive');
+            }
         }
 
-        function showMountError(error, details = null) {
+        function showMountError(error, details = null, options = {}) {
             const errorDiv = document.getElementById('mountError');
             const detailsDiv = document.getElementById('mountDetails');
             errorDiv.textContent = error; errorDiv.classList.remove('d-none');
             if (details) { detailsDiv.textContent = details; detailsDiv.classList.remove('d-none'); } else { detailsDiv.classList.add('d-none'); }
+            setManagedUnmountRetryState(!!options.canRetryManagedUnmount);
         }
-        function hideMountError() { document.getElementById('mountError').classList.add('d-none'); document.getElementById('mountDetails').classList.add('d-none'); }
+        function hideMountError() {
+            document.getElementById('mountError').classList.add('d-none');
+            document.getElementById('mountDetails').classList.add('d-none');
+            setManagedUnmountRetryState(false);
+        }
 
         // --- Email ---
         async function setupEmail() {
@@ -874,6 +925,12 @@
             if (mountBtn) mountBtn.addEventListener('click', function(e) { if (e.defaultPrevented) return; mountDrive(); });
             const unmountMountBtn = document.getElementById('unmountMountDriveBtn');
             if (unmountMountBtn) unmountMountBtn.addEventListener('click', function(e) { if (e.defaultPrevented) return; unmountMountDrive(); });
+            const retryManagedUnmountBtn = document.getElementById('retryManagedUnmountBtn');
+            if (retryManagedUnmountBtn) retryManagedUnmountBtn.addEventListener('click', function(e) { if (e.defaultPrevented) return; retryManagedUnmount(); });
+            const mountDriveSelect = document.getElementById('mountDriveSelect');
+            if (mountDriveSelect) mountDriveSelect.addEventListener('change', function() {
+                if (canRetryManagedUnmount) hideMountError();
+            });
         });
     </script>
 </body>

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -530,12 +530,12 @@
 
         async function formatDrive() {
             const formatBtn = document.getElementById('formatDriveBtn');
-            const drive = document.getElementById('formatDriveSelect').value;
-            if (!drive) { showFormatError('Please select a drive first'); setDriveStatus('Please select a drive first.', 'warning'); return; }
+            const disk = document.getElementById('formatDriveSelect').value;
+            if (!disk) { showFormatError('Please select a drive first'); setDriveStatus('Please select a drive first.', 'warning'); return; }
             window.AsyncButtonState.start(formatBtn);
             setDriveStatus('Formatting drive…', 'info');
             try {
-                const response = await fetch('/api/setup/format', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ drive }) });
+                const response = await fetch('/api/setup/format', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ disk }) });
                 const data = await response.json();
                 if (data.success) {
                     window.AsyncButtonState.success(formatBtn);
@@ -545,21 +545,21 @@
                     setDriveStatus('Drive formatted successfully.', 'success');
                     await loadDrives();
                     const formatSelect = document.getElementById('formatDriveSelect');
-                    for (let i = 0; i < formatSelect.options.length; i++) { if (formatSelect.options[i].value === drive) { formatSelect.selectedIndex = i; break; } }
+                    for (let i = 0; i < formatSelect.options.length; i++) { if (formatSelect.options[i].value === disk) { formatSelect.selectedIndex = i; break; } }
                 } else { window.AsyncButtonState.error(formatBtn); setDriveStatus('Failed to format drive.', 'error'); showFormatError(data.error, data.details, data.can_unmount); }
             } catch (error) { window.AsyncButtonState.error(formatBtn); setDriveStatus('An error occurred.', 'error'); showFormatError('An error occurred while formatting the drive'); }
         }
 
         async function unmountDrive() {
             const unmountBtn = document.getElementById('unmountDriveBtn');
-            const drive = document.getElementById('formatDriveSelect').value;
-            if (!drive) { showFormatError('Please select a drive first'); setDriveStatus('Please select a drive first.', 'warning'); return; }
+            const disk = document.getElementById('formatDriveSelect').value;
+            if (!disk) { showFormatError('Please select a drive first'); setDriveStatus('Please select a drive first.', 'warning'); return; }
             window.AsyncButtonState.start(unmountBtn);
             setDriveStatus('Unmounting drive…', 'info');
             try {
-                const response = await fetch('/api/setup/unmount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ drive }) });
+                const response = await fetch('/api/setup/unmount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ disk }) });
                 const data = await response.json();
-                if (data.success) { window.AsyncButtonState.success(unmountBtn); hideFormatError(); setDriveStatus('Drive unmounted successfully.', 'success'); await loadDrives(); const formatSelect = document.getElementById('formatDriveSelect'); for (let i = 0; i < formatSelect.options.length; i++) { if (formatSelect.options[i].value === drive) { formatSelect.selectedIndex = i; break; } } }
+                if (data.success) { window.AsyncButtonState.success(unmountBtn); hideFormatError(); setDriveStatus('Drive unmounted successfully.', 'success'); await loadDrives(); const formatSelect = document.getElementById('formatDriveSelect'); for (let i = 0; i < formatSelect.options.length; i++) { if (formatSelect.options[i].value === disk) { formatSelect.selectedIndex = i; break; } } }
                 else { window.AsyncButtonState.error(unmountBtn); setDriveStatus('Failed to unmount drive.', 'error'); showFormatError(data.error, data.details); }
             } catch (error) { window.AsyncButtonState.error(unmountBtn); setDriveStatus('An error occurred.', 'error'); showFormatError('An error occurred while unmounting the drive'); }
         }
@@ -586,14 +586,14 @@
 
         async function mountDrive() {
             const mountBtn = document.getElementById('mountDriveBtn');
-            const drive = document.getElementById('mountDriveSelect').value;
+            const partition = document.getElementById('mountDriveSelect').value;
             const mountPoint = document.getElementById('mountPoint').value;
             const autoMount = document.getElementById('autoMount').checked;
-            if (!drive) { showMountError('Please select a drive to mount'); setMountStatus('Please select a drive.', 'warning'); return; }
+            if (!partition) { showMountError('Please select a drive to mount'); setMountStatus('Please select a drive.', 'warning'); return; }
             window.AsyncButtonState.start(mountBtn);
             setMountStatus('Mounting drive…', 'info');
             try {
-                const response = await fetch('/api/setup/mount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ drive, mount_point: mountPoint, auto_mount: autoMount }) });
+                const response = await fetch('/api/setup/mount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ partition, mount_point: mountPoint, auto_mount: autoMount }) });
                 const data = await response.json();
                 if (data.success) { window.AsyncButtonState.success(mountBtn); localStorage.setItem('mountSuccess', '1'); nextStep(); hideMountError(); setMountStatus('Drive mounted successfully.', 'success'); await loadDrives(); }
                 else { window.AsyncButtonState.error(mountBtn); setMountStatus('Failed to mount drive.', 'error'); showMountError(data.error, data.details); }
@@ -602,12 +602,12 @@
 
         async function unmountMountDrive() {
             const unmountMountBtn = document.getElementById('unmountMountDriveBtn');
-            const drive = document.getElementById('mountDriveSelect').value;
-            if (!drive) { showMountError('Please select a drive'); setMountStatus('Please select a drive.', 'warning'); return; }
+            const partition = document.getElementById('mountDriveSelect').value;
+            if (!partition) { showMountError('Please select a drive'); setMountStatus('Please select a drive.', 'warning'); return; }
             window.AsyncButtonState.start(unmountMountBtn);
             setMountStatus('Unmounting drive…', 'info');
             try {
-                const response = await fetch('/api/setup/unmount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ drive }) });
+                const response = await fetch('/api/setup/unmount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ partition }) });
                 const data = await response.json();
                 if (data.success) { window.AsyncButtonState.success(unmountMountBtn); hideMountError(); setMountStatus('Drive unmounted successfully.', 'success'); await loadDrives(); }
                 else { window.AsyncButtonState.error(unmountMountBtn); setMountStatus('Failed to unmount drive.', 'error'); showMountError(data.error, data.details); }

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -119,13 +119,14 @@
                             </div>
                             <div id="driveStatusArea" class="d-flex items-center mb-3" style="min-height:1.5rem;font-size:var(--text-sm);"></div>
                             <div class="d-flex gap-3 mb-4">
-                                <button id="unmountDriveBtn" class="btn btn-warning btn-sm" data-confirm="Are you sure you want to unmount this drive? This is required before formatting.">
+                                <button id="unmountDriveBtn" class="btn btn-warning btn-sm" data-confirm="Are you sure you want to unmount this drive? This only clears the current live mounts so formatting can continue. Backup-drive settings, if any, are updated later in the Drive Mount step.">
                                     <i class="fas fa-eject me-1"></i> Unmount
                                 </button>
                                 <button id="formatDriveBtn" class="btn btn-danger btn-sm" data-confirm="Are you sure you want to format this drive? This will erase all data.">
                                     <i class="fas fa-exclamation-triangle me-1"></i> Format Drive
                                 </button>
                             </div>
+                            <div class="form-hint mb-4">Unmount here only removes current live mounts. Backup-drive settings, if any, are applied later when the Drive Mount step succeeds.</div>
                             <div id="formatError" class="text-danger d-none" style="font-size:var(--text-sm);"></div>
                             <div id="formatDetails" class="text-muted d-none" style="font-size:var(--text-xs);"></div>
                             <div class="setup-actions">
@@ -166,13 +167,14 @@
                                 </div>
                             </div>
                             <div class="d-flex gap-2 justify-end mb-4">
-                                <button id="unmountMountDriveBtn" class="btn btn-warning btn-sm" data-confirm="Are you sure you want to unmount this drive?">
+                                <button id="unmountMountDriveBtn" class="btn btn-warning btn-sm" data-confirm="Are you sure you want to unmount this drive? This only clears the current live mount so the selected partition can be configured again. Backup-drive settings are updated only after Mount Drive succeeds.">
                                     <i class="fas fa-eject me-1"></i> Unmount
                                 </button>
                                 <button id="mountDriveBtn" class="btn btn-primary btn-sm" data-confirm="Are you sure you want to mount this drive?">
                                     <i class="fas fa-plug me-1"></i> Mount Drive
                                 </button>
                             </div>
+                            <div class="form-hint mb-4">Unmount here is temporary preparation for mounting the selected partition. Backup-drive settings change only when Mount Drive succeeds.</div>
                             <div id="mountError" class="text-danger d-none" style="font-size:var(--text-sm);"></div>
                             <div id="mountDetails" class="text-muted d-none" style="font-size:var(--text-xs);"></div>
                         </div>
@@ -593,7 +595,9 @@
             try {
                 const response = await fetch('/api/setup/unmount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ disk }) });
                 const data = await response.json();
-                if (data.success) { window.AsyncButtonState.success(unmountBtn); hideFormatError(); setDriveStatus('Drive unmounted successfully.', 'success'); await loadDrives(); const formatSelect = document.getElementById('formatDriveSelect'); for (let i = 0; i < formatSelect.options.length; i++) { if (formatSelect.options[i].value === disk) { formatSelect.selectedIndex = i; break; } } }
+                // Keep this message explicit because setup unmount only affects
+                // live mounts. Backup-drive settings are applied later.
+                if (data.success) { window.AsyncButtonState.success(unmountBtn); hideFormatError(); setDriveStatus('Drive unmounted. You can continue formatting.', 'success'); await loadDrives(); const formatSelect = document.getElementById('formatDriveSelect'); for (let i = 0; i < formatSelect.options.length; i++) { if (formatSelect.options[i].value === disk) { formatSelect.selectedIndex = i; break; } } }
                 else { window.AsyncButtonState.error(unmountBtn); setDriveStatus('Failed to unmount drive.', 'error'); showFormatError(data.error, data.details); }
             } catch (error) { window.AsyncButtonState.error(unmountBtn); setDriveStatus('An error occurred.', 'error'); showFormatError('An error occurred while unmounting the drive'); }
         }
@@ -643,7 +647,9 @@
             try {
                 const response = await fetch('/api/setup/unmount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ partition }) });
                 const data = await response.json();
-                if (data.success) { window.AsyncButtonState.success(unmountMountBtn); hideMountError(); setMountStatus('Drive unmounted successfully.', 'success'); await loadDrives(); }
+                // This stays temporary on purpose so only a successful mount step
+                // changes the backup-drive settings.
+                if (data.success) { window.AsyncButtonState.success(unmountMountBtn); hideMountError(); setMountStatus('Drive unmounted. You can continue mounting the selected partition.', 'success'); await loadDrives(); }
                 else { window.AsyncButtonState.error(unmountMountBtn); setMountStatus('Failed to unmount drive.', 'error'); showMountError(data.error, data.details); }
             } catch (error) { window.AsyncButtonState.error(unmountMountBtn); setMountStatus('An error occurred.', 'error'); showMountError('An error occurred while unmounting the drive'); }
         }

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -480,52 +480,86 @@
             }
         }
 
-        async function loadDrives() {
-            try {
-                const response = await fetch('/api/setup/drives');
-                const data = await response.json();
-                const formatSelect = document.getElementById('formatDriveSelect');
-                const prevValue = formatSelect.value;
-                formatSelect.innerHTML = '<option value="">Select a drive…</option>';
-                let foundPrev = false;
-                data.drives.forEach(drive => {
+        function populateFormatDriveSelect(drives) {
+            const formatSelect = document.getElementById('formatDriveSelect');
+            const prevValue = formatSelect.value;
+            formatSelect.innerHTML = '<option value="">Select a drive…</option>';
+            let foundPrev = false;
+            drives.forEach(drive => {
+                const driveType = drive.type === 'usb' ? 'USB Drive' : 'Internal Drive';
+                let isMounted = false;
+                drive.partitions.forEach(partition => { if (partition.mountpoint) isMounted = true; });
+                let label = `${drive.model} (${drive.size}) - ${driveType}`;
+                if (!isMounted) label += ' [unmounted]';
+                const option = new Option(label, drive.path);
+                if (drive.path === prevValue) { option.selected = true; foundPrev = true; }
+                formatSelect.add(option);
+            });
+            if (!foundPrev && prevValue) {
+                const option = new Option(`${prevValue} [unmounted]`, prevValue);
+                option.selected = true;
+                formatSelect.add(option);
+            }
+            updateDriveMountStatusBadge();
+        }
+
+        function populateMountDriveSelect(drives) {
+            const mountSelect = document.getElementById('mountDriveSelect');
+            if (!mountSelect) return;
+
+            const prevValue = mountSelect.value;
+            mountSelect.innerHTML = '<option value="">Select a drive…</option>';
+            let foundPrev = false;
+            drives.forEach(drive => {
+                drive.partitions.forEach(partition => {
+                    const mountStatus = partition.mountpoint ? ` (Mounted at ${partition.mountpoint})` : '';
+                    const label = partition.label ? ` - ${partition.label}` : '';
                     const driveType = drive.type === 'usb' ? 'USB Drive' : 'Internal Drive';
-                    let isMounted = false;
-                    drive.partitions.forEach(partition => { if (partition.mountpoint) isMounted = true; });
-                    let label = `${drive.model} (${drive.size}) - ${driveType}`;
-                    if (!isMounted) label += ' [unmounted]';
-                    const option = new Option(label, drive.path);
-                    if (drive.path === prevValue) { option.selected = true; foundPrev = true; }
-                    formatSelect.add(option);
+                    const option = new Option(
+                        `${drive.model} - ${partition.path}${label} (${partition.size}) - ${driveType}${mountStatus}`,
+                        partition.path
+                    );
+                    if (partition.path === prevValue) { option.selected = true; foundPrev = true; }
+                    mountSelect.add(option);
                 });
-                if (!foundPrev && prevValue) {
-                    const option = new Option(`${prevValue} [unmounted]`, prevValue);
-                    option.selected = true;
-                    formatSelect.add(option);
+            });
+            if (!foundPrev && prevValue) {
+                const option = new Option(prevValue, prevValue);
+                option.selected = true;
+                mountSelect.add(option);
+            }
+        }
+
+        async function loadFormatDrives() {
+            try {
+                const response = await fetch('/api/setup/format-drives');
+                const data = await response.json();
+                if (!data.success) {
+                    throw new Error(data.error || 'Failed to load drives for formatting');
                 }
-                const mountSelect = document.getElementById('mountDriveSelect');
-                if (mountSelect) {
-                    mountSelect.innerHTML = '<option value="">Select a drive…</option>';
-                    data.drives.forEach(drive => {
-                        drive.partitions.forEach(partition => {
-                            if (partition.type === 'ntfs') {
-                                const mountStatus = partition.mountpoint ? ` (Mounted at ${partition.mountpoint})` : '';
-                                const label = partition.label ? ` - ${partition.label}` : '';
-                                const driveType = drive.type === 'usb' ? 'USB Drive' : 'Internal Drive';
-                                const option = new Option(
-                                    `${drive.model} - ${partition.path}${label} (${partition.size}) - ${driveType}${mountStatus}`,
-                                    partition.path
-                                );
-                                mountSelect.add(option);
-                            }
-                        });
-                    });
-                }
-                updateDriveMountStatusBadge();
+                populateFormatDriveSelect(data.drives || []);
             } catch (error) {
                 console.error('Error:', error);
-                showFormatError('Failed to load drives');
+                showFormatError('Failed to load drives for formatting');
             }
+        }
+
+        async function loadMountDrives() {
+            try {
+                const response = await fetch('/api/setup/mount-drives');
+                const data = await response.json();
+                if (!data.success) {
+                    throw new Error(data.error || 'Failed to load NTFS drives for mounting');
+                }
+                populateMountDriveSelect(data.drives || []);
+            } catch (error) {
+                console.error('Error:', error);
+                showMountError('Failed to load NTFS drives for mounting');
+            }
+        }
+
+        async function loadDrives() {
+            await Promise.all([loadFormatDrives(), loadMountDrives()]);
         }
 
         async function formatDrive() {

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -6,6 +6,75 @@ import backup_drive_setup
 
 
 class BackupDriveSetupTests(unittest.TestCase):
+    @patch('backup_drive_setup._get_system_drive_path', return_value='/dev/sda')
+    @patch('backup_drive_setup._load_lsblk_devices')
+    def test_list_available_drives_keeps_fuseblk_partition_when_blkid_confirms_ntfs(
+        self,
+        mock_load_lsblk_devices,
+        _mock_get_system_drive_path,
+    ):
+        mock_load_lsblk_devices.return_value = [
+            {
+                'type': 'disk',
+                'path': '/dev/sdb',
+                'model': 'Backup Disk',
+                'size': '1T',
+                'children': [
+                    {
+                        'path': '/dev/sdb1',
+                        'fstype': 'fuseblk',
+                        'label': 'Backup',
+                        'size': '1T',
+                        'mountpoint': '/media/backup',
+                    }
+                ],
+            }
+        ]
+
+        with patch('backup_drive_setup._get_blkid_filesystem_type', return_value='ntfs') as mock_blkid:
+            drives = backup_drive_setup.list_available_drives(
+                runtime=SimpleNamespace(is_fake=False),
+                ntfs_only=True,
+            )
+
+        self.assertEqual(len(drives), 1)
+        self.assertEqual(drives[0]['partitions'][0]['path'], '/dev/sdb1')
+        mock_blkid.assert_called_once_with('/dev/sdb1')
+
+    @patch('backup_drive_setup._get_system_drive_path', return_value='/dev/sda')
+    @patch('backup_drive_setup._load_lsblk_devices')
+    def test_list_available_drives_skips_fuseblk_partition_when_blkid_is_not_ntfs(
+        self,
+        mock_load_lsblk_devices,
+        _mock_get_system_drive_path,
+    ):
+        mock_load_lsblk_devices.return_value = [
+            {
+                'type': 'disk',
+                'path': '/dev/sdb',
+                'model': 'Backup Disk',
+                'size': '1T',
+                'children': [
+                    {
+                        'path': '/dev/sdb1',
+                        'fstype': 'fuseblk',
+                        'label': 'Something Else',
+                        'size': '1T',
+                        'mountpoint': '/media/other',
+                    }
+                ],
+            }
+        ]
+
+        with patch('backup_drive_setup._get_blkid_filesystem_type', return_value='exfat') as mock_blkid:
+            drives = backup_drive_setup.list_available_drives(
+                runtime=SimpleNamespace(is_fake=False),
+                ntfs_only=True,
+            )
+
+        self.assertEqual(drives, [])
+        mock_blkid.assert_called_once_with('/dev/sdb1')
+
     def test_get_mounted_partitions_for_disk_matches_child_partitions(self):
         blockdevices = [
             {

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -207,6 +207,7 @@ class BackupDriveSetupTests(unittest.TestCase):
 
     @patch('backup_drive_setup.subprocess.run')
     @patch('backup_drive_setup.os.makedirs')
+    @patch('backup_drive_setup._reload_systemd_mount_units')
     @patch('backup_drive_setup.update_managed_fstab')
     @patch('backup_drive_setup._get_partition_filesystem_type')
     @patch('backup_drive_setup.get_drive_usb_id')
@@ -219,6 +220,7 @@ class BackupDriveSetupTests(unittest.TestCase):
         mock_get_usb_id,
         mock_get_fstype,
         mock_update_fstab,
+        mock_reload_mount_units,
         mock_makedirs,
         mock_run,
     ):
@@ -246,11 +248,113 @@ class BackupDriveSetupTests(unittest.TestCase):
 
         self.assertEqual(result['uuid'], 'UUID-1')
         mock_get_mount.assert_called_once_with('/dev/sdb1')
+        mock_reload_mount_units.assert_called_once_with(runtime=runtime)
         mock_run.assert_called_once_with(
             ['ntfs-3g', '/dev/sdb1', '/media/backup', '-o', 'rw,uid=1000,gid=1000'],
             capture_output=True,
             text=True,
         )
+
+    @patch('backup_drive_setup.subprocess.run')
+    @patch('backup_drive_setup.restore_fstab_backup')
+    @patch('backup_drive_setup.os.makedirs')
+    @patch('backup_drive_setup._reload_systemd_mount_units')
+    @patch('backup_drive_setup.update_managed_fstab')
+    @patch('backup_drive_setup._get_partition_filesystem_type')
+    @patch('backup_drive_setup.get_drive_usb_id')
+    @patch('backup_drive_setup.get_drive_uuid')
+    @patch('backup_drive_setup._get_mount_for_partition')
+    def test_apply_backup_drive_configuration_restores_and_reloads_fstab_after_mount_failure(
+        self,
+        mock_get_mount,
+        mock_get_uuid,
+        mock_get_usb_id,
+        mock_get_fstype,
+        mock_update_fstab,
+        mock_reload_mount_units,
+        mock_makedirs,
+        mock_restore_fstab_backup,
+        mock_run,
+    ):
+        runtime = SimpleNamespace(is_fake=False, default_mount_point='/media/backup')
+        config_manager = MagicMock()
+        config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', '1234:5678']
+        smb_manager = MagicMock()
+        smb_manager.get_shares.return_value = []
+
+        mock_get_mount.return_value = None
+        mock_get_uuid.return_value = 'UUID-1'
+        mock_get_usb_id.return_value = '1234:5678'
+        mock_get_fstype.return_value = 'ntfs'
+        mock_update_fstab.return_value = '/tmp/fstab.backup'
+        mock_run.return_value = SimpleNamespace(returncode=1, stderr='busy', stdout='')
+
+        with self.assertRaisesRegex(backup_drive_setup.BackupDriveSetupError, 'Error mounting drive: busy'):
+            backup_drive_setup.apply_backup_drive_configuration(
+                '/dev/sdb1',
+                '/media/backup',
+                True,
+                config_manager,
+                smb_manager,
+                runtime=runtime,
+            )
+
+        mock_restore_fstab_backup.assert_called_once_with('/tmp/fstab.backup', runtime=runtime)
+        self.assertEqual(mock_reload_mount_units.call_count, 2)
+
+    @patch('backup_drive_setup.subprocess.run')
+    @patch('backup_drive_setup.restore_fstab_backup')
+    @patch('backup_drive_setup.os.makedirs')
+    @patch('backup_drive_setup._reload_systemd_mount_units')
+    @patch('backup_drive_setup.update_managed_fstab')
+    @patch('backup_drive_setup._get_partition_filesystem_type')
+    @patch('backup_drive_setup.get_drive_usb_id')
+    @patch('backup_drive_setup.get_drive_uuid')
+    @patch('backup_drive_setup._get_mount_for_partition')
+    def test_apply_backup_drive_configuration_restores_fstab_when_daemon_reload_fails(
+        self,
+        mock_get_mount,
+        mock_get_uuid,
+        mock_get_usb_id,
+        mock_get_fstype,
+        mock_update_fstab,
+        mock_reload_mount_units,
+        mock_makedirs,
+        mock_restore_fstab_backup,
+        mock_run,
+    ):
+        runtime = SimpleNamespace(is_fake=False, default_mount_point='/media/backup')
+        config_manager = MagicMock()
+        config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', '1234:5678']
+        smb_manager = MagicMock()
+        smb_manager.get_shares.return_value = []
+
+        mock_get_mount.return_value = None
+        mock_get_uuid.return_value = 'UUID-1'
+        mock_get_usb_id.return_value = '1234:5678'
+        mock_get_fstype.return_value = 'ntfs'
+        mock_update_fstab.return_value = '/tmp/fstab.backup'
+        mock_reload_mount_units.side_effect = [
+            backup_drive_setup.BackupDriveSetupError('Failed to reload systemd after updating /etc/fstab: bad reload'),
+            None,
+        ]
+
+        with self.assertRaisesRegex(
+            backup_drive_setup.BackupDriveSetupError,
+            'Failed to reload systemd after updating /etc/fstab: bad reload',
+        ):
+            backup_drive_setup.apply_backup_drive_configuration(
+                '/dev/sdb1',
+                '/media/backup',
+                True,
+                config_manager,
+                smb_manager,
+                runtime=runtime,
+            )
+
+        mock_restore_fstab_backup.assert_called_once_with('/tmp/fstab.backup', runtime=runtime)
+        self.assertEqual(mock_reload_mount_units.call_count, 2)
+        mock_run.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -77,6 +77,63 @@ class BackupDriveSetupTests(unittest.TestCase):
 
     @patch('backup_drive_setup._get_system_drive_path', return_value='/dev/sda')
     @patch('backup_drive_setup._load_lsblk_devices')
+    def test_list_available_drives_marks_usb_transport_as_usb_drive(
+        self,
+        mock_load_lsblk_devices,
+        _mock_get_system_drive_path,
+    ):
+        mock_load_lsblk_devices.return_value = [
+            {
+                'type': 'disk',
+                'path': '/dev/sdb',
+                'model': 'USB Backup Disk',
+                'size': '1T',
+                'tran': 'usb',
+                'rm': False,
+                'hotplug': False,
+                'children': [],
+            }
+        ]
+
+        drives = backup_drive_setup.list_available_drives(
+            runtime=SimpleNamespace(is_fake=False),
+            ntfs_only=False,
+        )
+
+        self.assertEqual(len(drives), 1)
+        self.assertEqual(drives[0]['type'], 'usb')
+        self.assertEqual(drives[0]['device_type'], 'disk')
+
+    @patch('backup_drive_setup._get_system_drive_path', return_value='/dev/sda')
+    @patch('backup_drive_setup._load_lsblk_devices')
+    def test_list_available_drives_marks_hotplug_disk_as_removable_when_transport_is_missing(
+        self,
+        mock_load_lsblk_devices,
+        _mock_get_system_drive_path,
+    ):
+        mock_load_lsblk_devices.return_value = [
+            {
+                'type': 'disk',
+                'path': '/dev/sdb',
+                'model': 'Card Reader',
+                'size': '128G',
+                'tran': '',
+                'rm': '1',
+                'hotplug': '1',
+                'children': [],
+            }
+        ]
+
+        drives = backup_drive_setup.list_available_drives(
+            runtime=SimpleNamespace(is_fake=False),
+            ntfs_only=False,
+        )
+
+        self.assertEqual(len(drives), 1)
+        self.assertEqual(drives[0]['type'], 'removable')
+
+    @patch('backup_drive_setup._get_system_drive_path', return_value='/dev/sda')
+    @patch('backup_drive_setup._load_lsblk_devices')
     def test_list_available_drives_skips_fuseblk_partition_when_blkid_is_not_ntfs(
         self,
         mock_load_lsblk_devices,

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -1,0 +1,128 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import backup_drive_setup
+
+
+class BackupDriveSetupTests(unittest.TestCase):
+    def test_get_mounted_partitions_for_disk_matches_child_partitions(self):
+        blockdevices = [
+            {
+                'type': 'disk',
+                'path': '/dev/sdb',
+                'children': [
+                    {'path': '/dev/sdb1'},
+                    {'path': '/dev/sdb2'},
+                ],
+            }
+        ]
+        mounts = [
+            {'device': '/dev/sdb1', 'mount_point': '/media/one'},
+            {'device': '/dev/sdc1', 'mount_point': '/media/other'},
+        ]
+
+        mounted = backup_drive_setup._get_mounted_partitions_for_disk(
+            '/dev/sdb',
+            blockdevices=blockdevices,
+            mounts=mounts,
+        )
+
+        self.assertEqual(
+            mounted,
+            [{'device': '/dev/sdb1', 'mount_point': '/media/one'}],
+        )
+
+    def test_get_mount_for_partition_requires_exact_match(self):
+        mounts = [
+            {'device': '/dev/sdb11', 'mount_point': '/media/eleven'},
+            {'device': '/dev/sdb1', 'mount_point': '/media/one'},
+        ]
+
+        mount = backup_drive_setup._get_mount_for_partition('/dev/sdb1', mounts=mounts)
+
+        self.assertEqual(mount, {'device': '/dev/sdb1', 'mount_point': '/media/one'})
+
+    @patch('backup_drive_setup.subprocess.run')
+    @patch('backup_drive_setup._get_mounted_partitions_for_disk')
+    def test_unmount_disk_partitions_unmounts_all_members(self, mock_get_mounted, mock_run):
+        runtime = SimpleNamespace(is_fake=False)
+        mock_get_mounted.return_value = [
+            {'device': '/dev/sdb1', 'mount_point': '/media/one'},
+            {'device': '/dev/sdb2', 'mount_point': '/media/two'},
+        ]
+        mock_run.return_value = SimpleNamespace(returncode=0, stderr='')
+
+        message = backup_drive_setup.unmount_disk_partitions('/dev/sdb', runtime=runtime)
+
+        self.assertEqual(message, 'Successfully unmounted 2 partition(s).')
+        self.assertEqual(
+            mock_run.call_args_list,
+            [
+                unittest.mock.call(['umount', '/dev/sdb1'], capture_output=True, text=True),
+                unittest.mock.call(['umount', '/dev/sdb2'], capture_output=True, text=True),
+            ],
+        )
+
+    @patch('backup_drive_setup.subprocess.run')
+    @patch('backup_drive_setup._get_mount_for_partition')
+    def test_unmount_selected_partition_only_unmounts_exact_partition(self, mock_get_mount, mock_run):
+        runtime = SimpleNamespace(is_fake=False)
+        mock_get_mount.return_value = {'device': '/dev/sdb1', 'mount_point': '/media/one'}
+        mock_run.return_value = SimpleNamespace(returncode=0, stderr='')
+
+        message = backup_drive_setup.unmount_selected_partition('/dev/sdb1', runtime=runtime)
+
+        self.assertEqual(message, 'Successfully unmounted /dev/sdb1.')
+        mock_run.assert_called_once_with(['umount', '/dev/sdb1'], capture_output=True, text=True)
+
+    @patch('backup_drive_setup.subprocess.run')
+    @patch('backup_drive_setup.os.makedirs')
+    @patch('backup_drive_setup.update_managed_fstab')
+    @patch('backup_drive_setup._get_partition_filesystem_type')
+    @patch('backup_drive_setup.get_drive_usb_id')
+    @patch('backup_drive_setup.get_drive_uuid')
+    @patch('backup_drive_setup._get_mount_for_partition')
+    def test_apply_backup_drive_configuration_checks_only_selected_partition_mount(
+        self,
+        mock_get_mount,
+        mock_get_uuid,
+        mock_get_usb_id,
+        mock_get_fstype,
+        mock_update_fstab,
+        mock_makedirs,
+        mock_run,
+    ):
+        runtime = SimpleNamespace(is_fake=False, default_mount_point='/media/backup')
+        config_manager = MagicMock()
+        config_manager.get_value.side_effect = ['/media/backup', '', '']
+        smb_manager = MagicMock()
+        smb_manager.get_shares.return_value = []
+
+        mock_get_mount.return_value = None
+        mock_get_uuid.return_value = 'UUID-1'
+        mock_get_usb_id.return_value = '1234:5678'
+        mock_get_fstype.return_value = 'ntfs'
+        mock_update_fstab.return_value = None
+        mock_run.return_value = SimpleNamespace(returncode=0, stderr='', stdout='')
+
+        result = backup_drive_setup.apply_backup_drive_configuration(
+            '/dev/sdb1',
+            '/media/backup',
+            True,
+            config_manager,
+            smb_manager,
+            runtime=runtime,
+        )
+
+        self.assertEqual(result['uuid'], 'UUID-1')
+        mock_get_mount.assert_called_once_with('/dev/sdb1')
+        mock_run.assert_called_once_with(
+            ['ntfs-3g', '/dev/sdb1', '/media/backup', '-o', 'rw,uid=1000,gid=1000'],
+            capture_output=True,
+            text=True,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -39,7 +39,41 @@ class BackupDriveSetupTests(unittest.TestCase):
 
         self.assertEqual(len(drives), 1)
         self.assertEqual(drives[0]['partitions'][0]['path'], '/dev/sdb1')
+        self.assertEqual(drives[0]['partitions'][0]['type'], 'ntfs')
         mock_blkid.assert_called_once_with('/dev/sdb1')
+
+    @patch('backup_drive_setup._get_system_drive_path', return_value='/dev/sda')
+    @patch('backup_drive_setup._load_lsblk_devices')
+    def test_list_available_drives_normalizes_ntfs3_partition_type_for_ntfs_picker(
+        self,
+        mock_load_lsblk_devices,
+        _mock_get_system_drive_path,
+    ):
+        mock_load_lsblk_devices.return_value = [
+            {
+                'type': 'disk',
+                'path': '/dev/sdb',
+                'model': 'Backup Disk',
+                'size': '1T',
+                'children': [
+                    {
+                        'path': '/dev/sdb1',
+                        'fstype': 'ntfs3',
+                        'label': 'Backup',
+                        'size': '1T',
+                        'mountpoint': '',
+                    }
+                ],
+            }
+        ]
+
+        drives = backup_drive_setup.list_available_drives(
+            runtime=SimpleNamespace(is_fake=False),
+            ntfs_only=True,
+        )
+
+        self.assertEqual(len(drives), 1)
+        self.assertEqual(drives[0]['partitions'][0]['type'], 'ntfs')
 
     @patch('backup_drive_setup._get_system_drive_path', return_value='/dev/sda')
     @patch('backup_drive_setup._load_lsblk_devices')
@@ -101,6 +135,32 @@ class BackupDriveSetupTests(unittest.TestCase):
             mounted,
             [{'device': '/dev/sdb1', 'mount_point': '/media/one'}],
         )
+
+    @patch('backup_drive_setup._get_system_drive_path', return_value='/dev/sda')
+    @patch('backup_drive_setup._load_lsblk_devices')
+    def test_list_available_drives_keeps_blank_disk_for_broad_format_scan(
+        self,
+        mock_load_lsblk_devices,
+        _mock_get_system_drive_path,
+    ):
+        mock_load_lsblk_devices.return_value = [
+            {
+                'type': 'disk',
+                'path': '/dev/sdb',
+                'model': 'Blank Disk',
+                'size': '2T',
+                'children': [],
+            }
+        ]
+
+        drives = backup_drive_setup.list_available_drives(
+            runtime=SimpleNamespace(is_fake=False),
+            ntfs_only=False,
+        )
+
+        self.assertEqual(len(drives), 1)
+        self.assertEqual(drives[0]['path'], '/dev/sdb')
+        self.assertEqual(drives[0]['partitions'], [])
 
     def test_get_mount_for_partition_requires_exact_match(self):
         mounts = [

--- a/tests/test_backup_drive_unmount.py
+++ b/tests/test_backup_drive_unmount.py
@@ -7,12 +7,10 @@ from backup_drive_setup import BackupDriveSetupError
 
 
 class BackupDriveUnmountTests(unittest.TestCase):
-    @patch('backup_drive_unmount.get_drive_uuid')
     @patch('backup_drive_unmount._get_mount_for_partition')
     def test_is_selected_partition_managed_backup_drive_matches_live_mount_point(
         self,
         mock_get_mount,
-        mock_get_uuid,
     ):
         system_utils = MagicMock()
         runtime = SimpleNamespace(is_fake=False)
@@ -28,14 +26,11 @@ class BackupDriveUnmountTests(unittest.TestCase):
 
         self.assertTrue(result)
         system_utils.is_mounted.assert_not_called()
-        mock_get_uuid.assert_not_called()
 
-    @patch('backup_drive_unmount.get_drive_uuid', return_value='UUID-1')
     @patch('backup_drive_unmount._get_mount_for_partition', return_value=None)
-    def test_is_selected_partition_managed_backup_drive_matches_uuid_only_when_managed_mount_is_live(
+    def test_is_selected_partition_managed_backup_drive_does_not_match_by_uuid_only(
         self,
         _mock_get_mount,
-        mock_get_uuid,
     ):
         system_utils = MagicMock()
         system_utils.is_mounted.return_value = True
@@ -49,19 +44,15 @@ class BackupDriveUnmountTests(unittest.TestCase):
             runtime=runtime,
         )
 
-        self.assertTrue(result)
-        system_utils.is_mounted.assert_called_once_with('/media/backup')
-        mock_get_uuid.assert_called_once_with('/dev/sdb1')
+        self.assertFalse(result)
+        system_utils.is_mounted.assert_not_called()
 
-    @patch('backup_drive_unmount.get_drive_uuid', return_value='UUID-1')
     @patch('backup_drive_unmount._get_mount_for_partition', return_value=None)
     def test_is_selected_partition_managed_backup_drive_does_not_match_unmounted_old_backup_partition(
         self,
         _mock_get_mount,
-        mock_get_uuid,
     ):
         system_utils = MagicMock()
-        system_utils.is_mounted.return_value = False
         runtime = SimpleNamespace(is_fake=False)
 
         result = backup_drive_unmount.is_selected_partition_managed_backup_drive(
@@ -73,8 +64,7 @@ class BackupDriveUnmountTests(unittest.TestCase):
         )
 
         self.assertFalse(result)
-        system_utils.is_mounted.assert_called_once_with('/media/backup')
-        mock_get_uuid.assert_not_called()
+        system_utils.is_mounted.assert_not_called()
 
     @patch('backup_drive_unmount.subprocess.run')
     def test_unmount_managed_backup_drive_stops_services_and_restarts_smb_without_power_down(self, mock_run):

--- a/tests/test_backup_drive_unmount.py
+++ b/tests/test_backup_drive_unmount.py
@@ -1,0 +1,176 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import backup_drive_unmount
+from backup_drive_setup import BackupDriveSetupError
+
+
+class BackupDriveUnmountTests(unittest.TestCase):
+    @patch('backup_drive_unmount.get_drive_uuid')
+    @patch('backup_drive_unmount._get_mount_for_partition')
+    def test_is_selected_partition_managed_backup_drive_matches_live_mount_point(
+        self,
+        mock_get_mount,
+        mock_get_uuid,
+    ):
+        system_utils = MagicMock()
+        runtime = SimpleNamespace(is_fake=False)
+        mock_get_mount.return_value = {'device': '/dev/sdb1', 'mount_point': '/media/backup'}
+
+        result = backup_drive_unmount.is_selected_partition_managed_backup_drive(
+            '/dev/sdb1',
+            '/media/backup',
+            'UUID-1',
+            system_utils,
+            runtime=runtime,
+        )
+
+        self.assertTrue(result)
+        system_utils.is_mounted.assert_not_called()
+        mock_get_uuid.assert_not_called()
+
+    @patch('backup_drive_unmount.get_drive_uuid', return_value='UUID-1')
+    @patch('backup_drive_unmount._get_mount_for_partition', return_value=None)
+    def test_is_selected_partition_managed_backup_drive_matches_uuid_only_when_managed_mount_is_live(
+        self,
+        _mock_get_mount,
+        mock_get_uuid,
+    ):
+        system_utils = MagicMock()
+        system_utils.is_mounted.return_value = True
+        runtime = SimpleNamespace(is_fake=False)
+
+        result = backup_drive_unmount.is_selected_partition_managed_backup_drive(
+            '/dev/sdb1',
+            '/media/backup',
+            'UUID-1',
+            system_utils,
+            runtime=runtime,
+        )
+
+        self.assertTrue(result)
+        system_utils.is_mounted.assert_called_once_with('/media/backup')
+        mock_get_uuid.assert_called_once_with('/dev/sdb1')
+
+    @patch('backup_drive_unmount.get_drive_uuid', return_value='UUID-1')
+    @patch('backup_drive_unmount._get_mount_for_partition', return_value=None)
+    def test_is_selected_partition_managed_backup_drive_does_not_match_unmounted_old_backup_partition(
+        self,
+        _mock_get_mount,
+        mock_get_uuid,
+    ):
+        system_utils = MagicMock()
+        system_utils.is_mounted.return_value = False
+        runtime = SimpleNamespace(is_fake=False)
+
+        result = backup_drive_unmount.is_selected_partition_managed_backup_drive(
+            '/dev/sdb1',
+            '/media/backup',
+            'UUID-1',
+            system_utils,
+            runtime=runtime,
+        )
+
+        self.assertFalse(result)
+        system_utils.is_mounted.assert_called_once_with('/media/backup')
+        mock_get_uuid.assert_not_called()
+
+    @patch('backup_drive_unmount.subprocess.run')
+    def test_unmount_managed_backup_drive_stops_services_and_restarts_smb_without_power_down(self, mock_run):
+        runtime = SimpleNamespace(is_fake=False)
+        system_utils = MagicMock()
+        mock_run.return_value = SimpleNamespace(returncode=0, stderr='', stdout='')
+
+        backup_drive_unmount.unmount_managed_backup_drive(
+            '/media/backup',
+            'UUID-1',
+            system_utils,
+            runtime=runtime,
+            power_down=False,
+        )
+
+        self.assertEqual(
+            mock_run.call_args_list,
+            [
+                call(['sudo', 'smbcontrol', 'all', 'close-share', '/media/backup'], check=False),
+                call(['sudo', 'systemctl', 'stop', 'check_mount.service'], check=False),
+                call(['sudo', 'systemctl', 'stop', 'check_health.service'], check=False),
+                call(['sudo', 'systemctl', 'stop', 'backup_cloud.service'], check=False),
+                call(['sudo', 'systemctl', 'stop', 'smbd'], check=False),
+                call(['sudo', 'systemctl', 'stop', 'nmbd'], check=False),
+                call(['sudo', 'umount', '/media/backup'], capture_output=True, text=True),
+                call(['sudo', 'systemctl', 'start', 'smbd'], check=False),
+                call(['sudo', 'systemctl', 'start', 'nmbd'], check=False),
+            ],
+        )
+
+    @patch('backup_drive_unmount.subprocess.run')
+    def test_unmount_managed_backup_drive_can_power_down_parent_device(self, mock_run):
+        runtime = SimpleNamespace(is_fake=False)
+        system_utils = MagicMock()
+        system_utils.get_parent_device.return_value = '/dev/sdb'
+        mock_run.side_effect = [
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout='/dev/sdb1\n'),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+        ]
+
+        backup_drive_unmount.unmount_managed_backup_drive(
+            '/media/backup',
+            'UUID-1',
+            system_utils,
+            runtime=runtime,
+            power_down=True,
+        )
+
+        self.assertIn(
+            call(['blkid', '-t', 'UUID=UUID-1', '-o', 'device'], capture_output=True, text=True),
+            mock_run.call_args_list,
+        )
+        self.assertIn(call(['sudo', 'hdparm', '-y', '/dev/sdb'], check=False), mock_run.call_args_list)
+
+    @patch('backup_drive_unmount.subprocess.run')
+    def test_unmount_managed_backup_drive_restarts_smb_after_unmount_failure(self, mock_run):
+        runtime = SimpleNamespace(is_fake=False)
+        system_utils = MagicMock()
+        mock_run.side_effect = [
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=1, stderr='busy', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+            SimpleNamespace(returncode=0, stderr='', stdout=''),
+        ]
+
+        with self.assertRaisesRegex(BackupDriveSetupError, 'Failed to unmount drive: busy'):
+            backup_drive_unmount.unmount_managed_backup_drive(
+                '/media/backup',
+                'UUID-1',
+                system_utils,
+                runtime=runtime,
+                power_down=False,
+            )
+
+        self.assertEqual(
+            mock_run.call_args_list[-2:],
+            [
+                call(['sudo', 'systemctl', 'start', 'smbd'], check=False),
+                call(['sudo', 'systemctl', 'start', 'nmbd'], check=False),
+            ],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dashboard_messages.py
+++ b/tests/test_dashboard_messages.py
@@ -1,0 +1,43 @@
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+import dashboard_messages
+
+
+class DashboardMessageTests(unittest.TestCase):
+    def test_parse_server_datetime_accepts_systemd_style_timestamp(self):
+        parsed = dashboard_messages.parse_server_datetime('Mon 2026-04-06 02:58:00 UTC')
+
+        self.assertEqual(parsed, datetime(2026, 4, 6, 2, 58, 0))
+
+    def test_format_future_delay_returns_compact_countdown(self):
+        delay = dashboard_messages.format_future_delay(
+            '2026-04-06 02:58:00',
+            now=datetime(2026, 4, 6, 0, 45, 0),
+        )
+
+        self.assertEqual(delay, 'in about 2h 13m')
+
+    def test_build_dashboard_unmount_success_message_includes_eta_when_available(self):
+        with patch('dashboard_messages.format_future_delay', return_value='in about 2h 13m'):
+            message = dashboard_messages.build_dashboard_unmount_success_message(
+                'Drive unmounted and powered down. It is now safe to remove the drive.',
+                'Mon 2026-04-06 02:58:00 UTC',
+            )
+
+        self.assertIn('safe to remove the drive', message)
+        self.assertIn('next Check Mount run, in about 2h 13m', message)
+
+    def test_build_dashboard_unmount_success_message_uses_schedule_fallback(self):
+        with patch('dashboard_messages.format_future_delay', return_value=None):
+            message = dashboard_messages.build_dashboard_unmount_success_message(
+                'Drive unmounted and powered down. It is now safe to remove the drive.',
+                'Retrieval Error',
+            )
+
+        self.assertIn('next scheduled Check Mount run', message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_drive_health.py
+++ b/tests/test_drive_health.py
@@ -1,0 +1,88 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import drive_health
+
+
+class DriveHealthTests(unittest.TestCase):
+    @patch("drive_health.get_smartctl_json_support", return_value=(False, drive_health.SMARTCTL_JSON_UPGRADE_MESSAGE))
+    def test_get_smart_attributes_keeps_json_unsupported_flow(self, _mock_json_support):
+        runtime = SimpleNamespace(is_fake=False)
+
+        attrs, missing, error = drive_health.get_smart_attributes(
+            config_manager=None,
+            system_utils=None,
+            device="/dev/sdb",
+            runtime=runtime,
+        )
+
+        self.assertIsNone(attrs)
+        self.assertIsNone(missing)
+        self.assertEqual(error, drive_health.SMARTCTL_JSON_UPGRADE_MESSAGE)
+
+    @patch("drive_health.get_smartctl_json_support", return_value=(True, None))
+    @patch("drive_health.subprocess.run")
+    def test_get_smart_attributes_treats_json_error_response_as_failure(self, mock_run, _mock_json_support):
+        runtime = SimpleNamespace(is_fake=False)
+        mock_run.return_value = SimpleNamespace(
+            returncode=2,
+            stdout=json.dumps(
+                {
+                    "smartctl": {
+                        "messages": [
+                            {"string": "Read Device Identity failed: scsi error unsupported scsi opcode"}
+                        ]
+                    }
+                }
+            ),
+            stderr="",
+        )
+
+        attrs, missing, error = drive_health.get_smart_attributes(
+            config_manager=None,
+            system_utils=None,
+            device="/dev/sdb",
+            runtime=runtime,
+        )
+
+        self.assertIsNone(attrs)
+        self.assertIsNone(missing)
+        self.assertIn("Read Device Identity failed", error)
+
+    @patch("drive_health.get_smartctl_json_support", return_value=(True, None))
+    @patch("drive_health.subprocess.run")
+    def test_get_smart_attributes_accepts_nonzero_exit_when_attributes_are_present(self, mock_run, _mock_json_support):
+        runtime = SimpleNamespace(is_fake=False)
+        mock_run.return_value = SimpleNamespace(
+            returncode=4,
+            stdout=json.dumps(
+                {
+                    "ata_smart_attributes": {
+                        "table": [
+                            {"id": 194, "raw": {"value": "34"}},
+                            {"id": 5, "raw": {"value": "2"}},
+                        ]
+                    }
+                }
+            ),
+            stderr="SMART status check returned DISK FAILING",
+        )
+
+        attrs, missing, error = drive_health.get_smart_attributes(
+            config_manager=None,
+            system_utils=None,
+            device="/dev/sdb",
+            runtime=runtime,
+        )
+
+        self.assertIsNotNone(attrs)
+        self.assertIsNone(error)
+        self.assertEqual(attrs["smart_194_raw"], 34.0)
+        self.assertEqual(attrs["smart_5_raw"], 2.0)
+        self.assertIn("smart_1_raw", missing)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_drive_health.py
+++ b/tests/test_drive_health.py
@@ -83,6 +83,31 @@ class DriveHealthTests(unittest.TestCase):
         self.assertEqual(attrs["smart_5_raw"], 2.0)
         self.assertIn("smart_1_raw", missing)
 
+    @patch("drive_health.get_smartctl_json_support", return_value=(True, None))
+    @patch("drive_health.subprocess.run")
+    def test_get_smart_attributes_preserves_parse_failure_when_json_supported(self, mock_run, _mock_json_support):
+        runtime = SimpleNamespace(is_fake=False)
+        mock_run.return_value = SimpleNamespace(
+            returncode=2,
+            stdout=(
+                "/dev/sda: Unknown USB bridge [0x1058:0x25ee (0x4009)]\n"
+                "Please specify device type with the -d option."
+            ),
+            stderr="",
+        )
+
+        attrs, missing, error = drive_health.get_smart_attributes(
+            config_manager=None,
+            system_utils=None,
+            device="/dev/sdb",
+            runtime=runtime,
+        )
+
+        self.assertIsNone(attrs)
+        self.assertIsNone(missing)
+        self.assertIn("Unknown USB bridge", error)
+        self.assertNotEqual(error, drive_health.SMARTCTL_JSON_UPGRADE_MESSAGE)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_drive_health_support.py
+++ b/tests/test_drive_health_support.py
@@ -1,0 +1,23 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import drive_health
+
+
+class DriveHealthSupportTests(unittest.TestCase):
+    @patch("drive_health.subprocess.run")
+    @patch("drive_health.shutil.which")
+    def test_get_smartctl_json_support_rechecks_after_runtime_upgrade(self, mock_which, mock_run):
+        # This guards the easy-to-forget case where operators install or
+        # upgrade smartmontools without restarting the web process.
+        mock_which.side_effect = [None, "/usr/sbin/smartctl"]
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="smartctl supports -j", stderr="")
+
+        first_result = drive_health.get_smartctl_json_support()
+        second_result = drive_health.get_smartctl_json_support()
+
+        self.assertEqual(first_result, (False, "smartctl is not installed on this machine."))
+        self.assertEqual(second_result, (True, None))
+        self.assertEqual(mock_which.call_count, 2)
+        mock_run.assert_called_once_with(["smartctl", "-h"], capture_output=True, text=True)

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -2,7 +2,7 @@ import unittest
 import importlib
 import sys
 import types
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from flask import Flask
 
@@ -74,4 +74,79 @@ class SetupWizardTests(unittest.TestCase):
         mock_get_available_backup_drives.assert_called_once_with(
             runtime=self.setup_wizard.runtime,
             ntfs_only=True,
+        )
+
+    def test_setup_unmount_offers_managed_retry_after_busy_partition_unmount(self):
+        managed_config = MagicMock()
+        managed_config.get_value.side_effect = ['/media/backup', 'UUID-1']
+
+        with patch.object(self.setup_wizard, 'config_manager', managed_config):
+            with patch.object(
+                self.setup_wizard,
+                'unmount_selected_partition',
+                side_effect=self.setup_wizard.BackupDriveSetupError('Failed to unmount partition: target is busy'),
+            ) as mock_unmount_selected:
+                with patch.object(
+                    self.setup_wizard,
+                    'is_selected_partition_managed_backup_drive',
+                    return_value=True,
+                ) as mock_is_managed:
+                    with self.app.test_client() as client:
+                        response = client.post('/api/setup/unmount', json={'partition': '/dev/sdb1'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get_json(),
+            {
+                'success': False,
+                'error': self.setup_wizard.MANAGED_UNMOUNT_RETRY_ERROR,
+                'details': self.setup_wizard.MANAGED_UNMOUNT_RETRY_DETAILS,
+                'can_retry_managed_unmount': True,
+            },
+        )
+        mock_unmount_selected.assert_called_once_with('/dev/sdb1', runtime=self.setup_wizard.runtime)
+        mock_is_managed.assert_called_once_with(
+            '/dev/sdb1',
+            '/media/backup',
+            'UUID-1',
+            self.setup_wizard.system_utils,
+            runtime=self.setup_wizard.runtime,
+        )
+
+    def test_setup_unmount_can_retry_with_managed_backup_path(self):
+        managed_config = MagicMock()
+        managed_config.get_value.side_effect = ['/media/backup', 'UUID-1']
+
+        with patch.object(self.setup_wizard, 'config_manager', managed_config):
+            with patch.object(
+                self.setup_wizard,
+                'is_selected_partition_managed_backup_drive',
+                return_value=True,
+            ) as mock_is_managed:
+                with patch.object(
+                    self.setup_wizard,
+                    'unmount_managed_backup_drive',
+                ) as mock_unmount_managed:
+                    with self.app.test_client() as client:
+                        response = client.post(
+                            '/api/setup/unmount',
+                            json={'partition': '/dev/sdb1', 'force_managed': True},
+                        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['success'], True)
+        self.assertIn('SMB-safe retry', response.get_json()['message'])
+        mock_is_managed.assert_called_once_with(
+            '/dev/sdb1',
+            '/media/backup',
+            'UUID-1',
+            self.setup_wizard.system_utils,
+            runtime=self.setup_wizard.runtime,
+        )
+        mock_unmount_managed.assert_called_once_with(
+            '/media/backup',
+            'UUID-1',
+            self.setup_wizard.system_utils,
+            runtime=self.setup_wizard.runtime,
+            power_down=False,
         )

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,61 @@
+import unittest
+import importlib
+import sys
+import types
+from unittest.mock import patch
+
+from flask import Flask
+
+
+class SetupWizardTests(unittest.TestCase):
+    def setUp(self):
+        config_manager_module = types.ModuleType("config_manager")
+        config_manager_module.ConfigManager = lambda runtime=None: object()
+        system_utils_module = types.ModuleType("system_utils")
+        system_utils_module.SystemUtils = lambda runtime=None: object()
+        user_manager_module = types.ModuleType("user_manager")
+        user_manager_module.UserManager = lambda runtime=None: object()
+        smb_manager_module = types.ModuleType("smb_manager")
+        smb_manager_module.SMBManager = lambda runtime=None: object()
+        runtime_module = types.ModuleType("runtime")
+        runtime_module.get_runtime = lambda: types.SimpleNamespace(is_fake=False)
+        runtime_module.get_fake_state = lambda: None
+
+        self._module_patches = [
+            patch.dict(
+                sys.modules,
+                {
+                    "config_manager": config_manager_module,
+                    "system_utils": system_utils_module,
+                    "user_manager": user_manager_module,
+                    "smb_manager": smb_manager_module,
+                    "runtime": runtime_module,
+                },
+            )
+        ]
+        for module_patch in self._module_patches:
+            module_patch.start()
+        self.addCleanup(lambda: sys.modules.pop("setup_wizard", None))
+        self.addCleanup(lambda: [module_patch.stop() for module_patch in reversed(self._module_patches)])
+
+        import setup_wizard
+
+        self.setup_wizard = importlib.reload(setup_wizard)
+        self.app = Flask(__name__)
+        self.app.register_blueprint(self.setup_wizard.setup)
+
+    def test_list_drives_uses_ntfs_only_partition_scan(self):
+        with patch.object(
+            self.setup_wizard,
+            "get_available_backup_drives",
+            return_value=[{"path": "/dev/sdb", "partitions": []}],
+        ) as mock_get_available_backup_drives:
+            with self.app.test_client() as client:
+                response = client.get("/api/setup/drives")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["success"], True)
+        mock_get_available_backup_drives.assert_called_once_with(
+            runtime=self.setup_wizard.runtime,
+            ntfs_only=True,
+        )

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -44,14 +44,30 @@ class SetupWizardTests(unittest.TestCase):
         self.app = Flask(__name__)
         self.app.register_blueprint(self.setup_wizard.setup)
 
-    def test_list_drives_uses_ntfs_only_partition_scan(self):
+    def test_list_format_drives_uses_broad_disk_scan(self):
         with patch.object(
             self.setup_wizard,
             "get_available_backup_drives",
             return_value=[{"path": "/dev/sdb", "partitions": []}],
         ) as mock_get_available_backup_drives:
             with self.app.test_client() as client:
-                response = client.get("/api/setup/drives")
+                response = client.get("/api/setup/format-drives")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["success"], True)
+        mock_get_available_backup_drives.assert_called_once_with(
+            runtime=self.setup_wizard.runtime,
+            ntfs_only=False,
+        )
+
+    def test_list_mount_drives_uses_ntfs_only_partition_scan(self):
+        with patch.object(
+            self.setup_wizard,
+            "get_available_backup_drives",
+            return_value=[{"path": "/dev/sdb", "partitions": []}],
+        ) as mock_get_available_backup_drives:
+            with self.app.test_client() as client:
+                response = client.get("/api/setup/mount-drives")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json()["success"], True)

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -10,11 +10,15 @@ from flask import Flask
 class SetupWizardTests(unittest.TestCase):
     def setUp(self):
         config_manager_module = types.ModuleType("config_manager")
-        config_manager_module.ConfigManager = lambda runtime=None: object()
+        config_manager_module.ConfigManager = lambda runtime=None: types.SimpleNamespace(
+            is_setup_complete=lambda: False,
+        )
         system_utils_module = types.ModuleType("system_utils")
         system_utils_module.SystemUtils = lambda runtime=None: object()
         user_manager_module = types.ModuleType("user_manager")
-        user_manager_module.UserManager = lambda runtime=None: object()
+        user_manager_module.UserManager = lambda runtime=None: types.SimpleNamespace(
+            is_admin=lambda username: False,
+        )
         smb_manager_module = types.ModuleType("smb_manager")
         smb_manager_module.SMBManager = lambda runtime=None: object()
         runtime_module = types.ModuleType("runtime")
@@ -42,6 +46,7 @@ class SetupWizardTests(unittest.TestCase):
 
         self.setup_wizard = importlib.reload(setup_wizard)
         self.app = Flask(__name__)
+        self.app.secret_key = 'test-secret'
         self.app.register_blueprint(self.setup_wizard.setup)
 
     def test_list_format_drives_uses_broad_disk_scan(self):
@@ -76,8 +81,41 @@ class SetupWizardTests(unittest.TestCase):
             ntfs_only=True,
         )
 
+    def test_setup_api_requires_login_after_setup_is_complete(self):
+        completed_config = MagicMock()
+        completed_config.is_setup_complete.return_value = True
+
+        with patch.object(self.setup_wizard, 'config_manager', completed_config):
+            with patch.object(self.setup_wizard, 'get_available_backup_drives') as mock_get_available_backup_drives:
+                with self.app.test_client() as client:
+                    response = client.get('/api/setup/format-drives')
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json(), {'success': False, 'error': 'Please log in again.'})
+        mock_get_available_backup_drives.assert_not_called()
+
+    def test_setup_api_requires_admin_after_setup_is_complete(self):
+        completed_config = MagicMock()
+        completed_config.is_setup_complete.return_value = True
+        non_admin_user_manager = MagicMock()
+        non_admin_user_manager.is_admin.return_value = False
+
+        with patch.object(self.setup_wizard, 'config_manager', completed_config):
+            with patch.object(self.setup_wizard, 'user_manager', non_admin_user_manager):
+                with patch.object(self.setup_wizard, 'get_available_backup_drives') as mock_get_available_backup_drives:
+                    with self.app.test_client() as client:
+                        with client.session_transaction() as session:
+                            session['username'] = 'operator'
+                        response = client.get('/api/setup/format-drives')
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.get_json(), {'success': False, 'error': 'Admin privileges required.'})
+        non_admin_user_manager.is_admin.assert_called_once_with('operator')
+        mock_get_available_backup_drives.assert_not_called()
+
     def test_setup_unmount_offers_managed_retry_after_busy_partition_unmount(self):
         managed_config = MagicMock()
+        managed_config.is_setup_complete.return_value = False
         managed_config.get_value.side_effect = ['/media/backup', 'UUID-1']
 
         with patch.object(self.setup_wizard, 'config_manager', managed_config):
@@ -115,6 +153,7 @@ class SetupWizardTests(unittest.TestCase):
 
     def test_setup_unmount_can_retry_with_managed_backup_path(self):
         managed_config = MagicMock()
+        managed_config.is_setup_complete.return_value = False
         managed_config.get_value.side_effect = ['/media/backup', 'UUID-1']
 
         with patch.object(self.setup_wizard, 'config_manager', managed_config):

--- a/user_manager.py
+++ b/user_manager.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 import logging
 from functools import wraps
-from flask import session, redirect, url_for, flash
+from flask import session, redirect, url_for, flash, jsonify
 import re
 import os
 import datetime
@@ -307,4 +307,28 @@ def admin_required(f):
             flash('Admin privileges required', 'error')
             return redirect(url_for('dashboard'))
         return f(*args, **kwargs)
-    return decorated_function 
+    return decorated_function
+
+
+def api_login_required(f):
+    """Decorator to require login for JSON API routes"""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'username' not in session:
+            return jsonify({'success': False, 'error': 'Please log in again.'}), 401
+        return f(*args, **kwargs)
+    return decorated_function
+
+
+def api_admin_required(f):
+    """Decorator to require admin privileges for JSON API routes"""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'username' not in session:
+            return jsonify({'success': False, 'error': 'Please log in again.'}), 401
+
+        user_manager = UserManager()
+        if not user_manager.is_admin(session['username']):
+            return jsonify({'success': False, 'error': 'Admin privileges required.'}), 403
+        return f(*args, **kwargs)
+    return decorated_function


### PR DESCRIPTION
- [x] Add `import shutil` to `system_utils.py` (fixes `NameError` in `install_systemd_scripts()`)
- [x] Fix `unmount_selected_drive()` exact-match for device paths — use `parts[0] == drive` instead of substring `if drive in line`
- [x] Fix `list_available_drives()` root disk exclusion via `lsblk -no PKNAME` to resolve mapper/UUID paths to parent disk, plus warning log when PKNAME lookup fails