### PR TITLE
fix Railway config persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ bash reset_fake_mode.sh
 This project includes detailed documentation for each main feature and page. See the following files for step-by-step guides and explanations:
 
 - [access.md](docs/access.md)
+- [railway.md](docs/railway.md)
 - [manual_install.md](docs/manual_install.md)
 - [setup.md](docs/setup.md)
 - [login.md](docs/login.md)

--- a/app.py
+++ b/app.py
@@ -43,13 +43,15 @@ from typing import Dict, List, Tuple
 from system_utils import SystemUtils
 from smb_manager import SMBManager
 from tempfile import NamedTemporaryFile
-from runtime import get_runtime, get_fake_state
+from runtime import get_runtime, get_fake_state, get_flask_secret_key
 
-app = Flask(__name__)
-app.secret_key = os.urandom(24)  # Required for session management
-socketio = SocketIO(app) 
 runtime = get_runtime()
 fake_state = get_fake_state() if runtime.is_fake else None
+app = Flask(__name__)
+# Keep the session secret stable across deploys so a restart does not
+# invalidate every login cookie when the app's config directory persists.
+app.secret_key = get_flask_secret_key(runtime)
+socketio = SocketIO(app)
 user_manager = UserManager(runtime=runtime)
 
 system_utils = SystemUtils(runtime=runtime)
@@ -68,6 +70,12 @@ handler.setLevel(logging.INFO)
 app.logger.addHandler(handler)
 app.logger.setLevel(logging.INFO)
 app.logger.info('SimpleSaferServer startup')
+
+if runtime.is_fake and os.environ.get('RAILWAY_PROJECT_ID') and not os.environ.get('RAILWAY_VOLUME_MOUNT_PATH'):
+    app.logger.warning(
+        'Railway volume is not attached. Fake-mode config under %s is ephemeral, so setup state will reset on deploy.',
+        runtime.data_dir,
+    )
 
 # Initialize configuration
 config_manager = ConfigManager(runtime=runtime)

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,0 +1,49 @@
+# Railway Deployment Notes
+
+SimpleSaferServer runs in fake mode on Railway on purpose. That keeps the live
+demo safe because Railway cannot provide the local disks, Samba services, or
+systemd environment that the full Debian install uses.
+
+## Why setup resets without a volume
+
+In Railway fake mode, the app stores its writable state under the fake-mode data
+directory. That includes:
+
+- `config/config.conf`
+- `config/users.json`
+- `config/.secrets`
+- `config/.key`
+- `config/.flask-secret-key`
+- logs and fake task state
+
+The repo config sets `SSS_DATA_DIR=/data` in `nixpacks.toml`. If Railway does
+not have a persistent volume attached, `/data` is only a normal container
+directory, so every deploy starts from an empty filesystem again.
+
+## How to keep config across deploys
+
+1. Create a Railway volume for the service.
+2. Attach it to the `SimpleSaferServer` service.
+3. Mount it at `/data`, or mount it somewhere else and let the app use
+   Railway's `RAILWAY_VOLUME_MOUNT_PATH` runtime variable automatically.
+4. Redeploy once after the volume is attached.
+
+Useful CLI checks:
+
+```bash
+railway status
+railway volume list
+railway volume add --mount-path /data
+```
+
+If you create the volume with a different mount path later, the app now prefers
+`RAILWAY_VOLUME_MOUNT_PATH` over the default `/data` setting so the writable
+state still follows the real attached volume.
+
+## Session behavior
+
+The app now persists its Flask session secret inside the writable config
+directory unless `FLASK_SECRET_KEY` is set explicitly. That keeps login cookies
+stable across deploys when the Railway volume persists.
+
+If there is no volume, both configuration and session state remain disposable.

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -19,13 +19,15 @@ normal install flow instead:
 
 ## Deploy Checklist
 
+Run these steps from the root of the `SimpleSaferServer` repository.
+
 1. Open the Railway project and select the `SimpleSaferServer` service.
 
 2. Create a persistent volume and attach it to that service.
 
 3. Mount the volume at `/data`.
 
-4. Deploy the latest commit.
+4. Deploy the repository from the repo root.
 
 5. Open the app and complete setup once.
 
@@ -35,11 +37,15 @@ If setup is still there after step 6, the deployment is correct.
 
 ## CLI Version Of The Same Flow
 
+`railway up` uploads the files from your current local checkout, so run it from
+the root of the repository state you actually want to deploy.
+
 ```bash
+cd /path/to/SimpleSaferServer
 railway status
 railway volume list
 railway volume add --mount-path /data
-railway deploy
+railway up
 ```
 
 After the deploy finishes, run this once to verify the volume exists:

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,13 +1,56 @@
 # Railway Deployment Notes
 
-SimpleSaferServer runs in fake mode on Railway on purpose. That keeps the live
-demo safe because Railway cannot provide the local disks, Samba services, or
-systemd environment that the full Debian install uses.
+Railway is a cloud hosting platform that can build and run this repository
+directly from GitHub.
 
-## Why setup resets without a volume
+SimpleSaferServer runs in fake mode on Railway on purpose. Railway cannot
+provide the local disks, Samba services, or systemd environment that the full
+Debian install uses, so the demo stores its writable state in a Railway volume
+instead.
 
-In Railway fake mode, the app stores its writable state under the fake-mode data
-directory. That includes:
+Regular SimpleSaferServer users do not need any of this. This document is only
+for development and demo hosting on Railway.
+
+If you are installing SimpleSaferServer on a real Debian-based machine, use the
+normal install flow instead:
+
+- [README.md](../README.md)
+- [manual_install.md](manual_install.md)
+
+## Deploy Checklist
+
+1. Open the Railway project and select the `SimpleSaferServer` service.
+
+2. Create a persistent volume and attach it to that service.
+
+3. Mount the volume at `/data`.
+
+4. Deploy the latest commit.
+
+5. Open the app and complete setup once.
+
+6. Redeploy one more time to confirm the setup still exists.
+
+If setup is still there after step 6, the deployment is correct.
+
+## CLI Version Of The Same Flow
+
+```bash
+railway status
+railway volume list
+railway volume add --mount-path /data
+railway deploy
+```
+
+After the deploy finishes, run this once to verify the volume exists:
+
+```bash
+railway volume list
+```
+
+## What Must Persist
+
+The writable state lives under the fake-mode data directory. That includes:
 
 - `config/config.conf`
 - `config/users.json`
@@ -16,34 +59,14 @@ directory. That includes:
 - `config/.flask-secret-key`
 - logs and fake task state
 
-The repo config sets `SSS_DATA_DIR=/data` in `nixpacks.toml`. If Railway does
-not have a persistent volume attached, `/data` is only a normal container
-directory, so every deploy starts from an empty filesystem again.
+The repo sets `SSS_DATA_DIR=/data` in `nixpacks.toml`, so `/data` must be a
+real Railway volume. If no volume is attached, `/data` is only a normal
+container directory and every deploy starts from an empty filesystem again.
 
-## How to keep config across deploys
+## Notes
 
-1. Create a Railway volume for the service.
-2. Attach it to the `SimpleSaferServer` service.
-3. Mount it at `/data`, or mount it somewhere else and let the app use
-   Railway's `RAILWAY_VOLUME_MOUNT_PATH` runtime variable automatically.
-4. Redeploy once after the volume is attached.
-
-Useful CLI checks:
-
-```bash
-railway status
-railway volume list
-railway volume add --mount-path /data
-```
-
-If you create the volume with a different mount path later, the app now prefers
-`RAILWAY_VOLUME_MOUNT_PATH` over the default `/data` setting so the writable
-state still follows the real attached volume.
-
-## Session behavior
-
-The app now persists its Flask session secret inside the writable config
-directory unless `FLASK_SECRET_KEY` is set explicitly. That keeps login cookies
-stable across deploys when the Railway volume persists.
-
-If there is no volume, both configuration and session state remain disposable.
+- The app now persists the Flask session secret in the writable config
+  directory unless `FLASK_SECRET_KEY` is set explicitly. That keeps login
+  cookies stable across deploys when the volume persists.
+- If you ever mount the Railway volume somewhere other than `/data`, the app
+  prefers Railway's `RAILWAY_VOLUME_MOUNT_PATH` variable automatically.

--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
         <ul class="doc-list list-unstyled">
             <li><i class="fa-brands fa-github"></i> <a href="https://github.com/chrismin13/SimpleSaferServer" target="_blank">GitHub Repository</a></li>
             <li><i class="fa-solid fa-user-shield"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/access.md" target="_blank">Access &amp; Permissions</a></li>
+            <li><i class="fa-solid fa-train-subway"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/railway.md" target="_blank">Railway Deployment Notes</a></li>
             <li><i class="fa-solid fa-gear"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/setup.md" target="_blank">Setup Guide</a></li>
             <li><i class="fa-solid fa-right-to-bracket"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/login.md" target="_blank">Login &amp; User Management</a></li>
             <li><i class="fa-solid fa-gauge-high"></i> <a href="https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/dashboard.md" target="_blank">Dashboard</a></li>

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,4 +1,7 @@
 [variables]
+# Railway fake mode stores config, users, secrets, and the persisted Flask
+# session key under SSS_DATA_DIR. That path must be backed by a Railway volume
+# in production, or every fresh deploy starts from an empty setup state.
 SSS_MODE = "fake"
 SSS_SKIP_LOGIN = "true"
 SSS_DATA_DIR = "/data"

--- a/runtime.py
+++ b/runtime.py
@@ -258,20 +258,46 @@ def resolve_fake_data_dir(repo_root: Optional[Path] = None) -> Path:
     return (repo_root / ".dev-data").resolve()
 
 
+def _read_persisted_text_secret(secret_path: Path) -> Optional[str]:
+    """Read a secret file after forcing the expected restrictive mode."""
+    try:
+        # Keep the permissions tight even if an older deploy or manual edit
+        # left this file more open than the app expects.
+        secret_path.chmod(0o600)
+        existing_secret = secret_path.read_text().strip()
+    except FileNotFoundError:
+        return None
+
+    return existing_secret or None
+
+
 def load_or_create_text_secret(secret_path: Path) -> str:
     """Load a persisted secret, or create one once if it does not exist yet."""
     secret_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if secret_path.exists():
-        existing_secret = secret_path.read_text().strip()
-        if existing_secret:
-            return existing_secret
+    existing_secret = _read_persisted_text_secret(secret_path)
+    if existing_secret:
+        return existing_secret
 
     # Persisting this once avoids the easy-to-miss deploy problem where Flask
     # session cookies become invalid simply because the process restarted.
     secret_value = secrets.token_urlsafe(48)
-    secret_path.write_text(secret_value)
-    secret_path.chmod(0o600)
+    try:
+        secret_fd = os.open(secret_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        # Another worker won the creation race after our first read. Re-read the
+        # file so every process converges on the exact same persisted secret.
+        existing_secret = _read_persisted_text_secret(secret_path)
+        if existing_secret:
+            return existing_secret
+        raise RuntimeError(f"Secret file exists but is empty: {secret_path}")
+
+    with os.fdopen(secret_fd, "w", encoding="utf-8") as secret_file:
+        # fchmod closes the gap where umask could otherwise leave the new file
+        # more permissive than intended on some systems.
+        os.fchmod(secret_file.fileno(), 0o600)
+        secret_file.write(secret_value)
+
     return secret_value
 
 

--- a/runtime.py
+++ b/runtime.py
@@ -3,6 +3,7 @@ import os
 import secrets
 import tempfile
 import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -284,13 +285,16 @@ def load_or_create_text_secret(secret_path: Path) -> str:
     secret_value = secrets.token_urlsafe(48)
     try:
         secret_fd = os.open(secret_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    except FileExistsError:
-        # Another worker won the creation race after our first read. Re-read the
-        # file so every process converges on the exact same persisted secret.
-        existing_secret = _read_persisted_text_secret(secret_path)
-        if existing_secret:
-            return existing_secret
-        raise RuntimeError(f"Secret file exists but is empty: {secret_path}")
+    except FileExistsError as err:
+        # Another worker won the creation race after our first read. Give that
+        # process a short window to finish writing so every worker converges on
+        # the same persisted secret instead of tripping over a transient empty file.
+        for _ in range(5):
+            existing_secret = _read_persisted_text_secret(secret_path)
+            if existing_secret:
+                return existing_secret
+            time.sleep(0.05)
+        raise RuntimeError(f"Secret file exists but is empty: {secret_path}") from err
 
     with os.fdopen(secret_fd, "w", encoding="utf-8") as secret_file:
         # fchmod closes the gap where umask could otherwise leave the new file

--- a/runtime.py
+++ b/runtime.py
@@ -1,5 +1,6 @@
 import json
 import os
+import secrets
 import tempfile
 import threading
 from dataclasses import dataclass
@@ -238,6 +239,52 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parent
 
 
+def resolve_fake_data_dir(repo_root: Optional[Path] = None) -> Path:
+    """Resolve the writable state directory for fake mode."""
+    repo_root = repo_root or _repo_root()
+    configured_data_dir = os.environ.get("SSS_DATA_DIR", "").strip()
+    railway_volume_mount = os.environ.get("RAILWAY_VOLUME_MOUNT_PATH", "").strip()
+
+    # Railway only injects RAILWAY_VOLUME_MOUNT_PATH when a real persistent
+    # volume is attached. If SSS_DATA_DIR still points at the repo's default
+    # /data path, prefer the mounted location so deploys keep the same config
+    # even if the volume was attached somewhere else in the service settings.
+    if railway_volume_mount and (not configured_data_dir or configured_data_dir == "/data"):
+        return Path(railway_volume_mount).resolve()
+
+    if configured_data_dir:
+        return Path(configured_data_dir).resolve()
+
+    return (repo_root / ".dev-data").resolve()
+
+
+def load_or_create_text_secret(secret_path: Path) -> str:
+    """Load a persisted secret, or create one once if it does not exist yet."""
+    secret_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if secret_path.exists():
+        existing_secret = secret_path.read_text().strip()
+        if existing_secret:
+            return existing_secret
+
+    # Persisting this once avoids the easy-to-miss deploy problem where Flask
+    # session cookies become invalid simply because the process restarted.
+    secret_value = secrets.token_urlsafe(48)
+    secret_path.write_text(secret_value)
+    secret_path.chmod(0o600)
+    return secret_value
+
+
+def get_flask_secret_key(runtime: Optional[Runtime] = None) -> str:
+    """Return the Flask session secret, preferring an explicit env var first."""
+    env_secret = os.environ.get("FLASK_SECRET_KEY", "").strip()
+    if env_secret:
+        return env_secret
+
+    runtime = runtime or get_runtime()
+    return load_or_create_text_secret(runtime.config_dir / ".flask-secret-key")
+
+
 def get_runtime() -> Runtime:
     global _runtime
     if _runtime is not None:
@@ -247,7 +294,7 @@ def get_runtime() -> Runtime:
     mode = os.environ.get("SSS_MODE", "real").strip().lower() or "real"
 
     if mode == "fake":
-        data_dir = Path(os.environ.get("SSS_DATA_DIR", str(repo_root / ".dev-data"))).resolve()
+        data_dir = resolve_fake_data_dir(repo_root)
         skip_login = os.environ.get("SSS_SKIP_LOGIN", "false").strip().lower() in {"1", "true", "yes", "on"}
         _runtime = Runtime(
             mode="fake",

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -78,3 +78,18 @@ class RuntimeHelpersTests(unittest.TestCase):
                 self.assertEqual(runtime.load_or_create_text_secret(secret_path), "winner-secret")
 
             self.assertEqual(secret_path.stat().st_mode & 0o777, 0o600)
+
+    def test_load_or_create_text_secret_retries_until_race_winner_finishes_writing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = Path(temp_dir) / ".flask-secret-key"
+
+            with patch("runtime.os.open", side_effect=FileExistsError):
+                with patch(
+                    "runtime._read_persisted_text_secret",
+                    side_effect=[None, None, "winner-secret"],
+                ) as mock_read_secret:
+                    with patch("runtime.time.sleep") as mock_sleep:
+                        self.assertEqual(runtime.load_or_create_text_secret(secret_path), "winner-secret")
+
+            self.assertEqual(mock_read_secret.call_count, 3)
+            self.assertEqual(mock_sleep.call_count, 1)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -9,7 +9,7 @@ import runtime
 
 class RuntimeHelpersTests(unittest.TestCase):
     def test_resolve_fake_data_dir_prefers_railway_volume_over_default_data_path(self):
-        repo_root = Path("/tmp/simple-safer-server")
+        repo_root = Path("/srv/simple-safer-server")
 
         # The repo pins SSS_DATA_DIR to /data for Railway, so this guards the
         # easy-to-forget case where the real volume gets mounted somewhere else.
@@ -27,7 +27,7 @@ class RuntimeHelpersTests(unittest.TestCase):
             )
 
     def test_resolve_fake_data_dir_keeps_explicit_custom_path(self):
-        repo_root = Path("/tmp/simple-safer-server")
+        repo_root = Path("/srv/simple-safer-server")
 
         with patch.dict(
             os.environ,
@@ -46,8 +46,10 @@ class RuntimeHelpersTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             secret_path = Path(temp_dir) / ".flask-secret-key"
             secret_path.write_text("persisted-secret")
+            secret_path.chmod(0o644)
 
             self.assertEqual(runtime.load_or_create_text_secret(secret_path), "persisted-secret")
+            self.assertEqual(secret_path.stat().st_mode & 0o777, 0o600)
 
     def test_load_or_create_text_secret_creates_new_secret_once(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -59,3 +61,20 @@ class RuntimeHelpersTests(unittest.TestCase):
             self.assertTrue(first_secret)
             self.assertEqual(first_secret, second_secret)
             self.assertEqual(secret_path.read_text().strip(), first_secret)
+            self.assertEqual(secret_path.stat().st_mode & 0o777, 0o600)
+
+    def test_load_or_create_text_secret_reads_winner_after_race(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = Path(temp_dir) / ".flask-secret-key"
+
+            def fake_os_open(path, flags, mode):
+                # Simulate another process creating the secret after our first
+                # existence check but before our exclusive create runs.
+                secret_path.write_text("winner-secret")
+                secret_path.chmod(0o644)
+                raise FileExistsError
+
+            with patch("runtime.os.open", side_effect=fake_os_open):
+                self.assertEqual(runtime.load_or_create_text_secret(secret_path), "winner-secret")
+
+            self.assertEqual(secret_path.stat().st_mode & 0o777, 0o600)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import runtime
+
+
+class RuntimeHelpersTests(unittest.TestCase):
+    def test_resolve_fake_data_dir_prefers_railway_volume_over_default_data_path(self):
+        repo_root = Path("/tmp/simple-safer-server")
+
+        # The repo pins SSS_DATA_DIR to /data for Railway, so this guards the
+        # easy-to-forget case where the real volume gets mounted somewhere else.
+        with patch.dict(
+            os.environ,
+            {
+                "SSS_DATA_DIR": "/data",
+                "RAILWAY_VOLUME_MOUNT_PATH": "/var/lib/railway/volumes/app-data",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                runtime.resolve_fake_data_dir(repo_root),
+                Path("/var/lib/railway/volumes/app-data"),
+            )
+
+    def test_resolve_fake_data_dir_keeps_explicit_custom_path(self):
+        repo_root = Path("/tmp/simple-safer-server")
+
+        with patch.dict(
+            os.environ,
+            {
+                "SSS_DATA_DIR": "/srv/simple-safer-server",
+                "RAILWAY_VOLUME_MOUNT_PATH": "/var/lib/railway/volumes/app-data",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                runtime.resolve_fake_data_dir(repo_root),
+                Path("/srv/simple-safer-server"),
+            )
+
+    def test_load_or_create_text_secret_reuses_existing_file_contents(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = Path(temp_dir) / ".flask-secret-key"
+            secret_path.write_text("persisted-secret")
+
+            self.assertEqual(runtime.load_or_create_text_secret(secret_path), "persisted-secret")
+
+    def test_load_or_create_text_secret_creates_new_secret_once(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = Path(temp_dir) / ".flask-secret-key"
+
+            first_secret = runtime.load_or_create_text_secret(secret_path)
+            second_secret = runtime.load_or_create_text_secret(secret_path)
+
+            self.assertTrue(first_secret)
+            self.assertEqual(first_secret, second_secret)
+            self.assertEqual(secret_path.read_text().strip(), first_secret)


### PR DESCRIPTION
## What changed

- prefer Railway's mounted volume path in fake mode when `RAILWAY_VOLUME_MOUNT_PATH` is present
- persist the Flask session secret in the writable config directory so deploys do not rotate every login session
- add Railway deployment documentation and surface it from the docs index and landing page
- add runtime tests that cover the volume-path and secret-persistence helpers

## Why this changed

Railway production for this service had no attached volume, so the app's fake-mode state under `/data` was stored on the disposable container filesystem. Every deploy recreated `config.conf`, users, secrets, and setup state from scratch.

The runtime fix makes the app follow the actual Railway mount path automatically when a volume is attached, and the persisted Flask secret removes an easy-to-miss session reset on deploy.

## Impact

- Railway deploys keep setup state once a persistent volume is attached
- operators get a clearer warning in logs when the app is running on Railway without a volume
- the repo now documents the deployment requirement directly

## Validation

- `python -m pytest -q tests/test_runtime.py tests/test_drive_health_support.py tests/test_setup_wizard.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Railway deployment guide and link in the docs site; added explanatory comments to build config and README.

* **New Features**
  * Flask session secret now persists to disk when persistent storage is configured, preserving sessions across restarts.
  * App logs a warning at startup if deployed without an attached persistent volume.

* **Tests**
  * Added tests for data-directory resolution and secret persistence/retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->