### PR TITLE
Add ownership-aware Samba share management

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ curl -fsSL https://sss.chrismin13.com/uninstall.sh | sudo bash
 This will:
 - Remove all installed scripts, models, and application files
 - Remove the systemd service and background tasks
-- Clean up configuration, logs, and user data
-- Remove Samba shares and related configuration
+- Clean up SimpleSaferServer configuration, logs, user data, and the managed `/etc/fstab` entry
+- Remove the Samba users synced from SimpleSaferServer accounts
+- Remove marker-wrapped SimpleSaferServer-managed Samba share blocks from `/etc/samba/smb.conf`
+
+This does not remove shared system packages such as Samba, Python, or rclone.
+Unmanaged or legacy untagged Samba share blocks are left in `/etc/samba/smb.conf` for safety.
 
 **Note:** This process is irreversible. Back up any important data before uninstalling.

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ import sys
 import time
 from typing import Dict, List, Tuple
 from system_utils import SystemUtils
-from smb_manager import SMBManager
+from smb_manager import SMBManager, SMB_DOCS_URL
 from tempfile import NamedTemporaryFile
 from runtime import get_runtime, get_fake_state, get_flask_secret_key
 
@@ -426,7 +426,12 @@ def auto_login_fake_mode_user():
 @login_required
 def network_file_sharing():
     backup_mount_point = config_manager.get_value('backup', 'mount_point', runtime.default_mount_point)
-    return render_template('network_file_sharing.html', username=session.get('username'), backup_mount_point=backup_mount_point)
+    return render_template(
+        'network_file_sharing.html',
+        username=session.get('username'),
+        backup_mount_point=backup_mount_point,
+        smb_docs_url=SMB_DOCS_URL,
+    )
 
 @app.route('/users')
 @login_required
@@ -1218,10 +1223,16 @@ def api_delete_user(username):
 @app.route('/api/smb/shares', methods=['GET'])
 @admin_required
 def api_list_smb_shares():
-    """Get list of all SMB shares from smb.conf"""
+    """Get the SimpleSaferServer-managed SMB shares plus unmanaged-share metadata."""
     try:
-        shares = smb_manager.get_shares()
-        return jsonify({'shares': shares})
+        shares = smb_manager.list_managed_shares()
+        unmanaged_shares = smb_manager.list_unmanaged_shares()
+        return jsonify({
+            'shares': shares,
+            'unmanaged_shares_detected': bool(unmanaged_shares),
+            'unmanaged_share_count': len(unmanaged_shares),
+            'unmanaged_share_names': [share['name'] for share in unmanaged_shares],
+        })
     except Exception as e:
         current_app.logger.error(f"Error reading SMB shares: {e}")
         return jsonify({'error': 'Failed to read SMB shares'}), 500
@@ -1247,7 +1258,7 @@ def api_add_smb_share():
             return jsonify({'error': 'Share name contains invalid characters'}), 400
         
         # Add share using SMB manager
-        smb_manager.add_share(share_name, path, writable, comment, valid_users)
+        smb_manager.create_managed_share(share_name, path, writable, comment, valid_users)
         
         return jsonify({'message': f'Share {share_name} added successfully'})
     except ValueError as e:
@@ -1277,7 +1288,7 @@ def api_edit_smb_share(share_name):
             return jsonify({'error': 'Share name contains invalid characters'}), 400
         
         # Update share using SMB manager
-        smb_manager.update_share(share_name, new_name, path, writable, comment, valid_users)
+        smb_manager.update_managed_share(share_name, new_name, path, writable, comment, valid_users)
         
         return jsonify({'message': f'Share {share_name} updated successfully'})
     except ValueError as e:
@@ -1291,7 +1302,7 @@ def api_edit_smb_share(share_name):
 def api_delete_smb_share(share_name):
     """Delete an SMB share"""
     try:
-        smb_manager.delete_share(share_name)
+        smb_manager.delete_managed_share(share_name)
         return jsonify({'message': f'Share {share_name} deleted successfully'})
     except ValueError as e:
         return jsonify({'error': str(e)}), 400
@@ -1328,7 +1339,15 @@ def api_restart_smb():
 def api_get_share_users(share_name):
     """Get users who have access to a specific share"""
     try:
-        users = smb_manager.get_share_users(share_name)
+        share = smb_manager.get_managed_share(share_name)
+        if share is None:
+            return jsonify({
+                'error': (
+                    f"Share {share_name} is not managed by SimpleSaferServer. "
+                    f"See {SMB_DOCS_URL} for manual conversion guidance."
+                )
+            }), 400
+        users = share.get('valid_users', [])
         return jsonify({'users': users})
     except Exception as e:
         current_app.logger.error(f"Error getting share users: {e}")

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -558,10 +558,11 @@ def unmount_selected_partition(partition_path, runtime=None):
 
 
 def _sync_backup_share_path(smb_manager, new_path):
-    for share in smb_manager.get_shares():
-        if share.get('name') != 'backup':
-            continue
-        smb_manager.update_share(
+    share = smb_manager.get_managed_share('backup')
+    if share:
+        # Only rewrite the owned backup share. Older untagged shares are
+        # deliberately left alone until the user converts them manually.
+        smb_manager.update_managed_share(
             old_name='backup',
             new_name='backup',
             path=new_path,
@@ -609,11 +610,7 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
             fstab_backup = update_managed_fstab(uuid, selected_path_str, bool(auto_mount), runtime=runtime)
             _reload_systemd_mount_units(runtime=runtime)
 
-            backup_share = None
-            for share in smb_manager.get_shares():
-                if share.get('name') == 'backup':
-                    backup_share = share
-                    break
+            backup_share = smb_manager.get_managed_share('backup')
 
             if backup_share and backup_share.get('path') != selected_path_str:
                 share_backup = backup_share
@@ -695,11 +692,7 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
             raise BackupDriveSetupError('Error mounting drive: {}'.format(error_msg))
         mounted = True
 
-        backup_share = None
-        for share in smb_manager.get_shares():
-            if share.get('name') == 'backup':
-                backup_share = share
-                break
+        backup_share = smb_manager.get_managed_share('backup')
 
         if backup_share and backup_share.get('path') != mount_point:
             share_backup = backup_share
@@ -724,7 +717,7 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
             _reload_systemd_mount_units(runtime=runtime)
         if share_backup:
             try:
-                smb_manager.update_share(
+                smb_manager.update_managed_share(
                     old_name='backup',
                     new_name='backup',
                     path=share_backup.get('path', previous_mount_point),

--- a/backup_drive_setup.py
+++ b/backup_drive_setup.py
@@ -633,7 +633,7 @@ def apply_backup_drive_configuration(partition, mount_point, auto_mount, config_
                 _reload_systemd_mount_units(runtime=runtime)
             if share_backup:
                 try:
-                    smb_manager.update_share(
+                    smb_manager.update_managed_share(
                         old_name='backup',
                         new_name='backup',
                         path=share_backup.get('path', previous_mount_point),

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -129,6 +129,8 @@ UUID=2CD49023D48FED80    /media/backup    ntfs-3g    defaults,nofail    0    0 #
 
 After manual changes, verify the result:
 
+Restarting `smbd` and `nmbd` disconnects anyone who is currently connected to a share, so active file copies or other SMB activity will drop.
+
 ```bash
 sudo findmnt --verify
 sudo mkdir -p /media/backup

--- a/docs/network_file_sharing.md
+++ b/docs/network_file_sharing.md
@@ -17,6 +17,7 @@ That ownership split matters because SimpleSaferServer only edits shares that it
 - **Delete Share**: removes a SimpleSaferServer-managed share
 - **Unmanaged share warning**: appears when SimpleSaferServer detects other non-system Samba shares in `smb.conf`
 - **Restart Services**: restarts `smbd` and `nmbd`
+  Restarting Samba disconnects anyone who is currently connected to a share, so active file copies or other SMB activity will drop.
 
 If unmanaged shares are detected, the page shows a small warning button with the count.
 That button opens a modal that:
@@ -143,7 +144,8 @@ Convert it to:
 # END SimpleSaferServer share: backup
 ```
 
-Then restart Samba:
+Then restart Samba.
+Restarting Samba disconnects anyone who is currently connected to a share, so active file copies or other SMB activity will drop:
 
 ```bash
 sudo systemctl restart smbd nmbd

--- a/docs/network_file_sharing.md
+++ b/docs/network_file_sharing.md
@@ -1,31 +1,182 @@
 # Network File Sharing
 
-The Network File Sharing page manages SMB shares and service status.
+The Network File Sharing page manages Samba shares and Samba service status.
 
-## System Status
-- **System Status Card**: Shows overall status, service details (SMB and NetBIOS daemons), and technical details (collapsible).
-- **Restart Services**: Button to restart SMB services.
-- **Status Badges**: Show current state (operational, warning, error).
+SimpleSaferServer now distinguishes between two kinds of Samba shares:
 
-## Shares Management
-- **Shares Table**: Lists all SMB shares with columns for Name, Path, Writable, Comment, Users, and Actions.
-- **Add Share**: Button opens a modal to add a new share.
-- **Edit Share**: Button opens a modal to edit an existing share.
-- **Delete Share**: Button opens a modal to confirm deletion.
-- **Browse**: Folder picker for selecting share paths.
-- **Writable**: Checkbox to allow users to write to the share.
-- **Users with Access**: Select users who can access the share (leave empty for all users).
+- **SimpleSaferServer-managed shares**: share blocks wrapped with explicit SimpleSaferServer ownership markers in `smb.conf`
+- **Unmanaged shares**: any non-system Samba share blocks that exist in `smb.conf` without those markers
 
-## Modals
-- **Add/Edit Share**: Forms for creating or editing shares, with validation and feedback.
-- **Delete Confirmation**: Modal to confirm share deletion.
-- **Folder Picker**: Modal to select a directory for sharing.
+That ownership split matters because SimpleSaferServer only edits shares that it can identify safely.
 
-## UI Details
-- Inline validation and feedback for all fields.
-- Spinners and alerts for loading and errors.
-- Tooltips for technical explanations.
+## What the Page Shows
 
----
+- **Managed shares table**: lists only SimpleSaferServer-managed shares
+- **Add Share**: creates a new SimpleSaferServer-managed share
+- **Edit Share**: updates a SimpleSaferServer-managed share
+- **Delete Share**: removes a SimpleSaferServer-managed share
+- **Unmanaged share warning**: appears when SimpleSaferServer detects other non-system Samba shares in `smb.conf`
+- **Restart Services**: restarts `smbd` and `nmbd`
 
-This page allows you to manage network file sharing and user access to shared folders. 
+If unmanaged shares are detected, the page shows a small warning button with the count.
+That button opens a modal that:
+
+- lists the unmanaged share names
+- explains that SimpleSaferServer will not edit or remove them
+- links to this document for manual conversion guidance
+
+## SimpleSaferServer-Managed Share Format
+
+A SimpleSaferServer-managed share uses wrapper comments like this:
+
+```ini
+# BEGIN SimpleSaferServer share: backup
+[backup]
+   path = /media/backup
+   writeable = Yes
+   create mask = 0777
+   directory mask = 0777
+   public = no
+   comment = Default backup share created by SimpleSaferServer setup
+   valid users = admin
+# END SimpleSaferServer share: backup
+```
+
+Those wrapper comments are the ownership markers.
+They are what let SimpleSaferServer:
+
+- show only its own shares in the editable table
+- update only the shares it owns
+- delete only the shares it owns
+- remove only its managed share blocks during uninstall
+
+## Supported SimpleSaferServer Share Settings
+
+SimpleSaferServer-managed shares support only these share fields:
+
+- share name
+- `path`
+- `writeable` or `writable`
+- `comment`
+- `valid users`
+
+SimpleSaferServer also writes these fixed defaults into every managed share:
+
+- `create mask = 0777`
+- `directory mask = 0777`
+- `public = no`
+
+Those defaults are intentional. They keep the managed share format narrow and predictable so the app can rewrite it safely months later.
+
+## Settings SimpleSaferServer Does Not Preserve or Manage
+
+SimpleSaferServer is not a general Samba configuration editor.
+If a share depends on other Samba directives, keep managing it manually outside the app.
+
+Examples of settings that SimpleSaferServer does not preserve or manage:
+
+- `browseable`
+- `guest ok`
+- `read only`
+- `write list`
+- `read list`
+- `force user`
+- `force group`
+- `hosts allow`
+- `hosts deny`
+- recycle-bin settings
+- veto or hide rules
+- symlink rules
+- ACL or inheritance tuning
+- any custom Samba directive not listed in the supported settings above
+
+## Why Unmanaged Shares Are Hidden From Editing
+
+An unmanaged share may contain Samba options that the SimpleSaferServer UI does not understand.
+If the app tried to import and rewrite those blocks automatically, it could silently remove or change settings that still matter.
+
+SimpleSaferServer therefore takes the safer path:
+
+- detect unmanaged shares
+- warn the user that they exist
+- leave them active in Samba
+- refuse to edit or remove them
+
+## Manual Conversion: Unmanaged Share to SimpleSaferServer-Managed Share
+
+Only convert a share if it can fit the supported SimpleSaferServer-managed format.
+If the share depends on unsupported Samba directives, leave it unmanaged and maintain it manually.
+
+### Conversion Steps
+
+1. Back up `/etc/samba/smb.conf`.
+2. Find the unmanaged share block that you want to convert.
+3. Replace it with the SimpleSaferServer-managed wrapper format.
+4. Keep only the supported share settings.
+5. Restart Samba.
+6. Reload the Network File Sharing page and confirm the share appears in the managed table.
+
+### Example
+
+Suppose you currently have this unmanaged share:
+
+```ini
+[backup]
+   path = /media/backup
+   writeable = Yes
+   comment = Backup share
+   valid users = admin
+```
+
+Convert it to:
+
+```ini
+# BEGIN SimpleSaferServer share: backup
+[backup]
+   path = /media/backup
+   writeable = Yes
+   create mask = 0777
+   directory mask = 0777
+   public = no
+   comment = Backup share
+   valid users = admin
+# END SimpleSaferServer share: backup
+```
+
+Then restart Samba:
+
+```bash
+sudo systemctl restart smbd nmbd
+```
+
+Reload the Network File Sharing page after that.
+
+## Setup Wizard Behavior
+
+During setup, SimpleSaferServer tries to create or refresh the default `backup` share using the same ownership-aware SMB logic as the main UI.
+
+If an unmanaged share named `[backup]` already exists:
+
+- setup does not overwrite it
+- setup reports a clear error
+- the user must either remove that unmanaged share manually or convert it into the SimpleSaferServer-managed format first
+
+This is intentional. Ownership by share name alone is not safe enough.
+
+## Uninstall Behavior
+
+The uninstaller removes only marker-wrapped SimpleSaferServer-managed share blocks from `/etc/samba/smb.conf`.
+
+It does not remove:
+
+- unmanaged share blocks
+- legacy untagged share blocks
+- unrelated Samba configuration
+
+That means older or manually maintained Samba shares survive uninstall unless they have been converted into the marker-wrapped SimpleSaferServer-managed format.
+
+## Operational Notes
+
+- The page still shows Samba service status for the whole system, not just SimpleSaferServer-managed shares.
+- The folder picker only helps choose a filesystem path. It does not validate advanced Samba semantics.
+- If you manually edit a SimpleSaferServer-managed share block, keep the wrapper markers and the supported field set intact so the app can still recognize it later.

--- a/index.html
+++ b/index.html
@@ -148,7 +148,14 @@
             <pre class="flex-grow-1 mb-0"><code id="uninstall-cmd-web">curl -fsSL https://sss.chrismin13.com/uninstall.sh | sudo bash</code></pre>
             <button class="copy-btn" onclick="copyCmd('uninstall-cmd-web', this)"><i class="fa-regular fa-copy"></i> Copy</button>
         </div>
-        <p class="note"><i class="fa-solid fa-circle-info"></i> This will remove all installed files, services, configuration, and user data. <strong>This process is irreversible.</strong></p>
+        <p class="note">
+            <i class="fa-solid fa-circle-info"></i>
+            This removes SimpleSaferServer files, services, timers, app data, the managed <code>/etc/fstab</code> entry,
+            and marker-wrapped SimpleSaferServer-managed Samba share blocks.
+            Shared system packages such as Samba, Python, and rclone stay installed.
+            Unmanaged or legacy untagged Samba share blocks stay in <code>/etc/samba/smb.conf</code> for safety.
+            <strong>This process is irreversible.</strong>
+        </p>
         <div class="text-center mt-4">
             <span class="text-muted">&copy; 2025 Christos Miniotis &mdash; <a href="https://github.com/chrismin13/SimpleSaferServer" target="_blank">SimpleSaferServer</a></span>
         </div>

--- a/legacy_migration.py
+++ b/legacy_migration.py
@@ -239,24 +239,11 @@ def _configure_backup_share(
     runtime = smb_manager.runtime
 
     if runtime.is_fake:
-        existing_shares = smb_manager.get_shares()
-        if any(share["name"] == "backup" for share in existing_shares):
-            smb_manager.update_share(
-                old_name="backup",
-                new_name="backup",
-                path=mount_point,
-                writable=True,
-                comment="Fake-mode backup share",
-                valid_users=[admin_username],
-            )
-        else:
-            smb_manager.add_share(
-                name="backup",
-                path=mount_point,
-                writable=True,
-                comment="Fake-mode backup share",
-                valid_users=[admin_username],
-            )
+        smb_manager.ensure_default_backup_share(
+            mount_point,
+            admin_username,
+            fake_mode_comment="Fake-mode backup share",
+        )
         return
 
     user_manager.users = user_manager._load_users()
@@ -268,24 +255,11 @@ def _configure_backup_share(
             f"Admin user '{admin_username}' is missing from Samba after migration."
         )
 
-    existing_shares = smb_manager.get_shares()
-    if any(share["name"] == "backup" for share in existing_shares):
-        smb_manager.update_share(
-            old_name="backup",
-            new_name="backup",
-            path=mount_point,
-            writable=True,
-            comment="Default backup share created by SimpleSaferServer migration",
-            valid_users=[admin_username],
-        )
-    else:
-        smb_manager.add_share(
-            name="backup",
-            path=mount_point,
-            writable=True,
-            comment="Default backup share created by SimpleSaferServer migration",
-            valid_users=[admin_username],
-        )
+    smb_manager.ensure_default_backup_share(
+        mount_point,
+        admin_username,
+        comment="Default backup share created by SimpleSaferServer migration",
+    )
 
     try:
         subprocess.run(["systemctl", "enable", "smbd"], check=True)

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -658,25 +658,11 @@ def setup_smb_share(config):
         admin_username = system.get('username', 'admin')
 
         if runtime.is_fake:
-            existing_shares = smb_manager.get_shares()
-            backup_share_exists = any(share['name'] == 'backup' for share in existing_shares)
-            if backup_share_exists:
-                smb_manager.update_share(
-                    old_name='backup',
-                    new_name='backup',
-                    path=mount_point,
-                    writable=True,
-                    comment='Fake-mode backup share',
-                    valid_users=[admin_username]
-                )
-            else:
-                smb_manager.add_share(
-                    name='backup',
-                    path=mount_point,
-                    writable=True,
-                    comment='Fake-mode backup share',
-                    valid_users=[admin_username]
-                )
+            smb_manager.ensure_default_backup_share(
+                mount_point,
+                admin_username,
+                fake_mode_comment='Fake-mode backup share',
+            )
             return True, None
          
         if admin_username not in user_manager.users:
@@ -690,31 +676,8 @@ def setup_smb_share(config):
                 "Recreate the admin user through the setup flow or reset the Samba password manually."
             )
         
-        # Check if backup share already exists and update it, or create new one
-        existing_shares = smb_manager.get_shares()
-        backup_share_exists = any(share['name'] == 'backup' for share in existing_shares)
-        
-        if backup_share_exists:
-            # Update existing backup share
-            smb_manager.update_share(
-                old_name='backup',
-                new_name='backup',
-                path=mount_point,
-                writable=True,
-                comment='Default backup share created by SimpleSaferServer setup',
-                valid_users=[admin_username]
-            )
-            logger.info(f"Updated existing backup share at {mount_point}")
-        else:
-            # Create new backup share
-            smb_manager.add_share(
-                name='backup',
-                path=mount_point,
-                writable=True,
-                comment='Default backup share created by SimpleSaferServer setup',
-                valid_users=[admin_username]
-            )
-            logger.info(f"Created new backup share at {mount_point}")
+        smb_manager.ensure_default_backup_share(mount_point, admin_username)
+        logger.info("Ensured the SimpleSaferServer-managed backup share points at %s", mount_point)
         
         # Enable SMB services to start on boot
         try:
@@ -725,7 +688,7 @@ def setup_smb_share(config):
             logger.error(f"Failed to enable SMB services: {e}")
             # Don't fail setup for this, just log it
         
-        logger.info(f"SMB share setup completed successfully. Share 'backup' created at {mount_point}")
+        logger.info("SMB share setup completed successfully. Share 'backup' is configured at %s", mount_point)
         return True, None
         
     except Exception as e:

--- a/smb_manager.py
+++ b/smb_manager.py
@@ -551,8 +551,13 @@ class SMBManager:
         return value
 
     def _validate_valid_users(self, valid_users):
+        if valid_users is None:
+            return []
+        if isinstance(valid_users, (str, bytes)):
+            raise ValueError("valid_users must be a sequence of usernames, not a string")
+
         validated_users = []
-        for username in valid_users or []:
+        for username in valid_users:
             if not isinstance(username, str):
                 raise ValueError("Share usernames must be strings.")
             if _contains_control_characters(username) or not VALID_SHARE_NAME_RE.fullmatch(username):
@@ -718,22 +723,28 @@ class SMBManager:
     def delete_share(self, name):
         return self.delete_managed_share(name)
 
+    def _get_managed_share_or_raise(self, share_name):
+        # Keep the unmanaged-share rejection in one place so legacy helper
+        # methods do not drift apart and accidentally expose raw Samba state.
+        _, shares = self._load_shares()
+        share = self._find_share_record(shares, share_name)
+        if share is None:
+            raise ValueError(f"Share {share_name} not found")
+        if not share.managed:
+            raise ValueError(
+                "Share '{}' is not managed by SimpleSaferServer, so it cannot be edited here. "
+                "See {} for manual conversion guidance.".format(share_name, SMB_DOCS_URL)
+            )
+        return self.get_managed_share(share_name)
+
     def get_share_users(self, share_name):
-        share = self.get_managed_share(share_name)
-        if not share:
-            return []
+        # Callers use this to populate edit flows, so unmanaged shares need an
+        # explicit error instead of looking like empty access lists.
+        share = self._get_managed_share_or_raise(share_name)
         return share.get("valid_users", [])
 
     def update_share_users(self, share_name, users):
-        share = self.get_managed_share(share_name)
-        if not share:
-            if self._find_share_record(self._load_shares()[1], share_name, managed=False) is not None:
-                raise ValueError(
-                    "Share '{}' is not managed by SimpleSaferServer, so its users cannot be edited here. "
-                    "See {} for manual conversion guidance.".format(share_name, SMB_DOCS_URL)
-                )
-            raise ValueError(f"Share {share_name} not found")
-
+        share = self._get_managed_share_or_raise(share_name)
         return self.update_managed_share(
             share_name,
             share_name,

--- a/smb_manager.py
+++ b/smb_manager.py
@@ -735,7 +735,7 @@ class SMBManager:
                 "Share '{}' is not managed by SimpleSaferServer, so it cannot be edited here. "
                 "See {} for manual conversion guidance.".format(share_name, SMB_DOCS_URL)
             )
-        return self.get_managed_share(share_name)
+        return share.as_dict()
 
     def get_share_users(self, share_name):
         # Callers use this to populate edit flows, so unmanaged shares need an

--- a/smb_manager.py
+++ b/smb_manager.py
@@ -369,12 +369,19 @@ class SMBManager:
             if replaced_live_config:
                 try:
                     self._restore_smb_conf_backup(backup_path)
-                    self._restart_services()
+                    if not self._restart_services():
+                        raise RuntimeError("Failed to restart SMB services after restoring smb.conf backup")
                 except Exception as rollback_error:
                     logger.error(
                         "Failed to restore smb.conf after SMB update error: %s",
                         rollback_error,
                     )
+                    raise RuntimeError(
+                        "Failed to roll back smb.conf after SMB update error: {}. Original error: {}".format(
+                            rollback_error,
+                            original_error,
+                        )
+                    ) from rollback_error
 
             raise original_error
 
@@ -491,6 +498,14 @@ class SMBManager:
                 shares.append(share)
                 index = block_end
                 continue
+
+            if stripped.startswith(MANAGED_SHARE_END_PREFIX):
+                marker_name = stripped[len(MANAGED_SHARE_END_PREFIX):].strip() or stripped
+                raise SMBConfigError(
+                    "Unexpected SimpleSaferServer END marker was found in smb.conf for '{}'.".format(
+                        marker_name
+                    )
+                )
 
             section_name = _extract_section_name(stripped)
             if section_name and section_name.lower() not in SYSTEM_SHARE_NAMES:
@@ -621,8 +636,8 @@ class SMBManager:
         lines, shares = self._load_shares()
         if self._find_share_record(shares, name) is not None:
             raise ValueError(
-                "Share '{}' already exists. SimpleSaferServer will not overwrite an existing unmanaged "
-                "share with the same name. See {} for manual conversion guidance.".format(name, SMB_DOCS_URL)
+                "Share '{}' already exists. SimpleSaferServer will not overwrite an existing share "
+                "with the same name. See {} for manual conversion guidance.".format(name, SMB_DOCS_URL)
             )
 
         block_lines = self._render_managed_share_block(name, path, writable, comment, valid_users)
@@ -647,7 +662,7 @@ class SMBManager:
         conflict = self._find_share_record(shares, new_name)
         if conflict is not None and not (conflict.managed and conflict.name == old_name):
             raise ValueError(
-                "Share '{}' already exists. SimpleSaferServer will not overwrite an unmanaged share "
+                "Share '{}' already exists. SimpleSaferServer will not overwrite an existing share "
                 "with the same name. See {} for manual conversion guidance.".format(new_name, SMB_DOCS_URL)
             )
 

--- a/smb_manager.py
+++ b/smb_manager.py
@@ -1,49 +1,97 @@
-import subprocess
 import logging
 import os
+import re
+import subprocess
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
-from runtime import get_runtime, get_fake_state
+from typing import List, Optional, Tuple
+
+from runtime import get_fake_state, get_runtime
 
 logger = logging.getLogger(__name__)
+
+SMB_DOCS_URL = "https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/network_file_sharing.md"
+MANAGED_SHARE_BEGIN_PREFIX = "# BEGIN SimpleSaferServer share: "
+MANAGED_SHARE_END_PREFIX = "# END SimpleSaferServer share: "
+SYSTEM_SHARE_NAMES = {"global", "homes", "printers", "print$"}
+VALID_SHARE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+class SMBConfigError(ValueError):
+    """Raised when smb.conf contains ownership markers that SimpleSaferServer cannot trust."""
+
+
+@dataclass
+class ParsedShare:
+    name: str
+    managed: bool
+    path: str = ""
+    writable: bool = False
+    public: bool = False
+    comment: str = ""
+    valid_users: List[str] = field(default_factory=list)
+    start_line: int = 0
+    end_line: int = 0
+    raw_text: str = ""
+
+    def as_dict(self):
+        return {
+            "name": self.name,
+            "path": self.path,
+            "writable": self.writable,
+            "public": self.public,
+            "comment": self.comment,
+            "valid_users": list(self.valid_users),
+            "managed": self.managed,
+        }
+
+
+def _extract_section_name(line: str) -> Optional[str]:
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]") and len(stripped) > 2:
+        return stripped[1:-1].strip()
+    return None
+
 
 class SMBManager:
     def __init__(self, runtime=None):
         self.runtime = runtime or get_runtime()
-        self.smb_conf_path = str(self.runtime.samba_dir / 'smb.conf')
+        self.smb_conf_path = str(self.runtime.samba_dir / "smb.conf")
         self.backup_dir = str(self.runtime.samba_backup_dir)
         self.fake_state = get_fake_state() if self.runtime.is_fake else None
-        
-        # Ensure backup directory exists
+
+        # The backup directory is intentionally outside smb.conf itself so a
+        # parse failure never prevents us from preserving the last good file.
         Path(self.backup_dir).mkdir(parents=True, exist_ok=True)
 
     def _create_backup(self):
-        """Create a backup of the current smb.conf"""
-        timestamp = time.strftime('%Y%m%d_%H%M%S')
-        backup_path = f'{self.backup_dir}/smb.conf.backup.{timestamp}'
+        """Create a backup of the current smb.conf."""
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        backup_path = f"{self.backup_dir}/smb.conf.backup.{timestamp}"
         if self.runtime.is_fake:
             Path(backup_path).write_text(self._read_smb_conf())
         else:
-            subprocess.run(['sudo', 'cp', self.smb_conf_path, backup_path], check=True)
-        logger.info(f"Created backup of smb.conf at {backup_path}")
+            subprocess.run(["sudo", "cp", self.smb_conf_path, backup_path], check=True)
+        logger.info("Created backup of smb.conf at %s", backup_path)
         return backup_path
 
     def _read_smb_conf(self):
-        """Read the current smb.conf file"""
+        """Read the current smb.conf file."""
         try:
-            with open(self.smb_conf_path, 'r') as f:
-                return f.read()
+            with open(self.smb_conf_path, "r") as handle:
+                return handle.read()
         except FileNotFoundError:
             return self._get_default_config()
 
     def _get_default_config(self):
-        """Get default SMB configuration"""
+        """Get default SMB configuration."""
         return """#
 # Sample configuration file for the Samba suite for Debian GNU/Linux.
 #
 # This is the main Samba configuration file. You should read the
 # smb.conf(5) manual page in order to understand the options listed
-# here. Samba has a huge number of configurable options most of which 
+# here. Samba has a huge number of configurable options most of which
 # are not shown in this example
 #
 # Some options that are often worth tuning have been included as
@@ -55,8 +103,8 @@ class SMBManager:
 #    enough to be mentioned here
 #
 # NOTE: Whenever you modify this file you should run the command
-# "testparm" to check that you have not made any basic syntactic 
-# errors. 
+# "testparm" to check that you have not made any basic syntactic
+# errors.
 
 #======================= Global Settings =======================
 
@@ -102,7 +150,7 @@ class SMBManager:
 # Server role. Defines in which mode Samba will operate. Possible
 # values are "standalone server", "member server", "classic primary
 # domain controller", "classic backup domain controller", "active
-# directory domain controller". 
+# directory domain controller".
 #
 # Most people will want "standalone server" or "member server".
 # Running as "active directory domain controller" will require first
@@ -137,7 +185,7 @@ class SMBManager:
 #
 # The following settings only takes effect if 'server role = classic
 # primary domain controller', 'server role = classic backup domain controller'
-# or 'domain logons' is set 
+# or 'domain logons' is set
 #
 
 # It specifies the location of the user's
@@ -166,13 +214,13 @@ class SMBManager:
 # password; please adapt to your needs
 ; add user script = /usr/sbin/useradd --create-home %u
 
-# This allows machine accounts to be created on the domain controller via the 
-# SAMR RPC pipe.  
+# This allows machine accounts to be created on the domain controller via the
+# SAMR RPC pipe.
 # The following assumes a "machines" group exists on the system
 ; add machine script  = /usr/sbin/useradd -g machines -c "%u machine account" -d /var/lib/samba -s /bin/false %u
 
 # This allows Unix groups to be created on the domain controller via the SAMR
-# RPC pipe.  
+# RPC pipe.
 ; add group script = /usr/sbin/addgroup --force-badname %g
 
 ############ Misc ############
@@ -245,290 +293,367 @@ class SMBManager:
 """
 
     def _write_smb_conf(self, content):
-        """Write content to smb.conf"""
-        # Create backup first
+        """Write content to smb.conf."""
         self._create_backup()
-        
-        # Write new configuration
-        with open(self.smb_conf_path, 'w') as f:
-            f.write(content)
-        
-        # Set proper permissions
+        with open(self.smb_conf_path, "w") as handle:
+            handle.write(content)
         os.chmod(self.smb_conf_path, 0o644)
 
     def _restart_services(self):
-        """Restart SMB services"""
+        """Restart SMB services."""
         if self.runtime.is_fake:
-            self.fake_state.set_smb_services('active', 'active')
+            self.fake_state.set_smb_services("active", "active")
             logger.info("Fake mode: marked SMB services as active")
             return True
         try:
-            subprocess.run(['sudo', 'systemctl', 'restart', 'smbd'], check=True)
-            subprocess.run(['sudo', 'systemctl', 'restart', 'nmbd'], check=True)
+            subprocess.run(["sudo", "systemctl", "restart", "smbd"], check=True)
+            subprocess.run(["sudo", "systemctl", "restart", "nmbd"], check=True)
             logger.info("SMB services restarted successfully")
             return True
-        except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to restart SMB services: {e}")
+        except subprocess.CalledProcessError as exc:
+            logger.error("Failed to restart SMB services: %s", exc)
             return False
 
+    def _parse_share_block(self, block_lines, *, managed, marker_name=None):
+        share_name = None
+        share_data = {
+            "path": "",
+            "writable": False,
+            "public": False,
+            "comment": "",
+            "valid_users": [],
+        }
+
+        for raw_line in block_lines:
+            stripped = raw_line.strip()
+            if not stripped or stripped.startswith("#") or stripped.startswith(";"):
+                continue
+
+            section_name = _extract_section_name(stripped)
+            if section_name is not None:
+                if share_name is not None:
+                    raise SMBConfigError(
+                        "SimpleSaferServer only supports one share section per managed block."
+                    )
+                share_name = section_name
+                continue
+
+            if share_name is None:
+                continue
+
+            if "=" not in stripped:
+                continue
+
+            key, value = stripped.split("=", 1)
+            key = key.strip().lower()
+            value = value.strip()
+
+            if key in {"writeable", "writable"}:
+                share_data["writable"] = value.lower() in {"yes", "true", "1"}
+            elif key == "public":
+                share_data["public"] = value.lower() in {"yes", "true", "1"}
+            elif key == "path":
+                share_data["path"] = value
+            elif key == "comment":
+                share_data["comment"] = value.strip('"')
+            elif key == "valid users":
+                share_data["valid_users"] = [user for user in value.split() if user != "%S"]
+
+        if share_name is None:
+            raise SMBConfigError("Failed to find a Samba share section inside a managed block.")
+
+        if marker_name is not None and share_name != marker_name:
+            raise SMBConfigError(
+                "Managed share markers do not match the enclosed share name for '{}'.".format(marker_name)
+            )
+
+        return ParsedShare(name=share_name, managed=managed, **share_data)
+
+    def _parse_smb_conf(self, content: str) -> Tuple[List[str], List[ParsedShare]]:
+        lines = content.splitlines(keepends=True)
+        shares = []
+        index = 0
+
+        while index < len(lines):
+            stripped = lines[index].strip()
+
+            if stripped.startswith(MANAGED_SHARE_BEGIN_PREFIX):
+                marker_name = stripped[len(MANAGED_SHARE_BEGIN_PREFIX):].strip()
+                if not marker_name:
+                    raise SMBConfigError("Managed share marker is missing a share name.")
+
+                start_line = index
+                index += 1
+
+                while index < len(lines):
+                    end_line = lines[index].strip()
+                    if end_line.startswith(MANAGED_SHARE_BEGIN_PREFIX):
+                        raise SMBConfigError(
+                            "Nested SimpleSaferServer share markers were found in smb.conf."
+                        )
+                    if end_line == f"{MANAGED_SHARE_END_PREFIX}{marker_name}":
+                        break
+                    index += 1
+
+                if index >= len(lines):
+                    raise SMBConfigError(
+                        "Managed share '{}' is missing its END marker in smb.conf.".format(marker_name)
+                    )
+
+                block_end = index + 1
+                share = self._parse_share_block(
+                    lines[start_line + 1:index],
+                    managed=True,
+                    marker_name=marker_name,
+                )
+                share.start_line = start_line
+                share.end_line = block_end
+                share.raw_text = "".join(lines[start_line:block_end])
+                shares.append(share)
+                index = block_end
+                continue
+
+            section_name = _extract_section_name(stripped)
+            if section_name and section_name.lower() not in SYSTEM_SHARE_NAMES:
+                start_line = index
+                index += 1
+
+                while index < len(lines):
+                    current = lines[index].strip()
+                    if current.startswith(MANAGED_SHARE_BEGIN_PREFIX):
+                        break
+                    if _extract_section_name(current) is not None:
+                        break
+                    index += 1
+
+                share = self._parse_share_block(lines[start_line:index], managed=False)
+                share.start_line = start_line
+                share.end_line = index
+                share.raw_text = "".join(lines[start_line:index])
+                shares.append(share)
+                continue
+
+            index += 1
+
+        return lines, shares
+
+    def _load_shares(self):
+        return self._parse_smb_conf(self._read_smb_conf())
+
+    def _find_share_record(self, shares, name, *, managed=None):
+        matches = [
+            share for share in shares
+            if share.name == name and (managed is None or share.managed == managed)
+        ]
+        if len(matches) > 1:
+            raise SMBConfigError(
+                "Multiple Samba shares named '{}' were found, so SimpleSaferServer cannot act safely. "
+                "See {} for manual cleanup guidance.".format(name, SMB_DOCS_URL)
+            )
+        return matches[0] if matches else None
+
+    def _validate_share_input(self, name, path):
+        if not name or not path:
+            raise ValueError("Share name and path are required")
+        if not VALID_SHARE_NAME_RE.match(name):
+            raise ValueError(
+                "Share name may only contain letters, numbers, hyphens, and underscores."
+            )
+        if not os.path.exists(path):
+            raise ValueError(f"Path {path} does not exist")
+
+    def _render_managed_share_block(self, name, path, writable=True, comment="", valid_users=None):
+        valid_users = valid_users or []
+        lines = [
+            f"{MANAGED_SHARE_BEGIN_PREFIX}{name}\n",
+            f"[{name}]\n",
+            f"   path = {path}\n",
+            f"   writeable = {'Yes' if writable else 'No'}\n",
+            "   create mask = 0777\n",
+            "   directory mask = 0777\n",
+            "   public = no\n",
+            f"   comment = {comment}\n",
+        ]
+        if valid_users:
+            lines.append(f"   valid users = {' '.join(valid_users)}\n")
+        lines.append(f"{MANAGED_SHARE_END_PREFIX}{name}\n")
+        return lines
+
+    def _append_managed_block(self, lines, block_lines):
+        new_lines = list(lines)
+        if new_lines and not new_lines[-1].endswith("\n"):
+            new_lines[-1] = new_lines[-1] + "\n"
+        if new_lines and new_lines[-1].strip():
+            new_lines.append("\n")
+        new_lines.extend(block_lines)
+        return new_lines
+
+    def list_managed_shares(self):
+        _, shares = self._load_shares()
+        return [share.as_dict() for share in shares if share.managed]
+
+    def list_unmanaged_shares(self):
+        _, shares = self._load_shares()
+        return [share.as_dict() for share in shares if not share.managed]
+
+    def get_managed_share(self, name):
+        _, shares = self._load_shares()
+        share = self._find_share_record(shares, name, managed=True)
+        return share.as_dict() if share else None
+
+    def create_managed_share(self, name, path, writable=True, comment="", valid_users=None):
+        self._validate_share_input(name, path)
+
+        lines, shares = self._load_shares()
+        if self._find_share_record(shares, name) is not None:
+            raise ValueError(
+                "Share '{}' already exists. SimpleSaferServer will not overwrite an existing unmanaged "
+                "share with the same name. See {} for manual conversion guidance.".format(name, SMB_DOCS_URL)
+            )
+
+        block_lines = self._render_managed_share_block(name, path, writable, comment, valid_users)
+        new_lines = self._append_managed_block(lines, block_lines)
+        self._write_smb_conf("".join(new_lines))
+
+        if not self._restart_services():
+            raise Exception("Failed to restart SMB services")
+
+        return True
+
+    def update_managed_share(self, old_name, new_name, path, writable=True, comment="", valid_users=None):
+        self._validate_share_input(new_name, path)
+
+        lines, shares = self._load_shares()
+        share = self._find_share_record(shares, old_name, managed=True)
+        if share is None:
+            if self._find_share_record(shares, old_name, managed=False) is not None:
+                raise ValueError(
+                    "Share '{}' is not managed by SimpleSaferServer, so it cannot be edited here. "
+                    "See {} for manual conversion guidance.".format(old_name, SMB_DOCS_URL)
+                )
+            raise ValueError(f"Share {old_name} not found")
+
+        conflict = self._find_share_record(shares, new_name)
+        if conflict is not None and not (conflict.managed and conflict.name == old_name):
+            raise ValueError(
+                "Share '{}' already exists. SimpleSaferServer will not overwrite an unmanaged share "
+                "with the same name. See {} for manual conversion guidance.".format(new_name, SMB_DOCS_URL)
+            )
+
+        new_lines = list(lines)
+        replacement = self._render_managed_share_block(new_name, path, writable, comment, valid_users)
+        new_lines[share.start_line:share.end_line] = replacement
+        self._write_smb_conf("".join(new_lines))
+
+        if not self._restart_services():
+            raise Exception("Failed to restart SMB services")
+
+        return True
+
+    def delete_managed_share(self, name):
+        lines, shares = self._load_shares()
+        share = self._find_share_record(shares, name, managed=True)
+        if share is None:
+            if self._find_share_record(shares, name, managed=False) is not None:
+                raise ValueError(
+                    "Share '{}' is not managed by SimpleSaferServer, so it cannot be deleted here. "
+                    "See {} for manual conversion guidance.".format(name, SMB_DOCS_URL)
+                )
+            raise ValueError(f"Share {name} not found")
+
+        new_lines = list(lines)
+        del new_lines[share.start_line:share.end_line]
+        self._write_smb_conf("".join(new_lines))
+
+        if not self._restart_services():
+            raise Exception("Failed to restart SMB services")
+
+        return True
+
+    def ensure_default_backup_share(self, mount_point, admin_username, fake_mode_comment=None, comment=None):
+        if comment is None and self.runtime.is_fake and fake_mode_comment is not None:
+            comment = fake_mode_comment
+        elif comment is None and self.runtime.is_fake:
+            comment = "Fake-mode backup share"
+        elif comment is None:
+            comment = "Default backup share created by SimpleSaferServer setup"
+
+        unmanaged_backup = self._find_share_record(self._load_shares()[1], "backup", managed=False)
+        if unmanaged_backup is not None:
+            raise ValueError(
+                "An unmanaged Samba share named 'backup' already exists. SimpleSaferServer will not overwrite it. "
+                "Convert it manually or remove it first. See {} for manual conversion guidance.".format(SMB_DOCS_URL)
+            )
+
+        managed_backup = self.get_managed_share("backup")
+        if managed_backup is not None:
+            return self.update_managed_share(
+                "backup",
+                "backup",
+                mount_point,
+                writable=True,
+                comment=comment,
+                valid_users=[admin_username],
+            )
+
+        return self.create_managed_share(
+            "backup",
+            mount_point,
+            writable=True,
+            comment=comment,
+            valid_users=[admin_username],
+        )
+
+    # Compatibility wrappers for older call sites that still expect the old
+    # names while the rest of the codebase is migrating to explicit ownership.
     def get_shares(self):
-        """Get all shares from smb.conf"""
-        try:
-            content = self._read_smb_conf()
-            shares = []
-            lines = content.split('\n')
-            current_share = None
-            
-            for line in lines:
-                line = line.strip()
-                
-                # Check for share section headers [share_name]
-                if line.startswith('[') and line.endswith(']') and not line.startswith('[global]'):
-                    share_name = line[1:-1]  # Remove brackets
-                    # Exclude system shares
-                    if share_name not in ['homes', 'printers', 'print$']:
-                        current_share = {
-                            'name': share_name, 
-                            'path': '', 
-                            'writable': False, 
-                            'public': False, 
-                            'comment': '',
-                            'valid_users': []
-                        }
-                        shares.append(current_share)
-                elif current_share and line and not line.startswith('#'):
-                    # Parse share configuration
-                    if '=' in line:
-                        key, value = line.split('=', 1)
-                        key = key.strip()
-                        value = value.strip()
-                        
-                        if key == 'path':
-                            current_share['path'] = value
-                        elif key == 'writeable' or key == 'writable':
-                            current_share['writable'] = value.lower() in ['yes', 'true', '1']
-                        elif key == 'public':
-                            current_share['public'] = value.lower() in ['yes', 'true', '1']
-                        elif key == 'comment':
-                            current_share['comment'] = value.strip('"')
-                        elif key == 'valid users':
-                            # Parse valid users list
-                            users = value.split()
-                            current_share['valid_users'] = [u for u in users if u != '%S']
-            
-            return shares
-        except Exception as e:
-            logger.error(f"Error reading SMB shares: {e}")
-            return []
+        return self.list_managed_shares()
 
     def add_share(self, name, path, writable=True, comment="", valid_users=None):
-        """Add a new share"""
-        try:
-            # Validation
-            if not name or not path:
-                raise ValueError("Share name and path are required")
-            
-            # Check if path exists
-            if not os.path.exists(path):
-                raise ValueError(f"Path {path} does not exist")
-            
-            # Check if share already exists
-            existing_shares = self.get_shares()
-            if any(share['name'] == name for share in existing_shares):
-                raise ValueError(f"Share {name} already exists")
-            
-            # Read current configuration
-            content = self._read_smb_conf()
-            
-            # Add share configuration
-            share_config = f"""
-[{name}]
-   path = {path}
-   writeable = {'Yes' if writable else 'No'}
-   create mask = 0777
-   directory mask = 0777
-   public = no
-   comment = {comment}
-"""
-            
-            # Add valid users if specified
-            if valid_users:
-                users_str = ' '.join(valid_users)
-                share_config += f"   valid users = {users_str}\n"
-            
-            # Append to end of file
-            content += share_config
-            
-            # Write updated configuration
-            self._write_smb_conf(content)
-            
-            # Restart services
-            if not self._restart_services():
-                raise Exception("Failed to restart SMB services")
-            
-            return True
-        except Exception as e:
-            logger.error(f"Error adding SMB share: {e}")
-            raise
+        return self.create_managed_share(name, path, writable, comment, valid_users)
 
     def update_share(self, old_name, new_name, path, writable=True, comment="", valid_users=None):
-        """Update an existing share"""
-        try:
-            # Validation
-            if not new_name or not path:
-                raise ValueError("Share name and path are required")
-            
-            # Check if path exists
-            if not os.path.exists(path):
-                raise ValueError(f"Path {path} does not exist")
-            
-            # Check if new name conflicts with existing shares
-            existing_shares = self.get_shares()
-            if any(share['name'] == new_name and share['name'] != old_name for share in existing_shares):
-                raise ValueError(f"Share {new_name} already exists")
-            
-            # Read current configuration
-            content = self._read_smb_conf()
-            lines = content.split('\n')
-            
-            # Find and replace the share section
-            new_lines = []
-            in_share_section = False
-            share_found = False
-            
-            for line in lines:
-                if f'[{old_name}]' in line:
-                    in_share_section = True
-                    share_found = True
-                    # Add new share configuration
-                    new_lines.append(f"[{new_name}]")
-                    new_lines.append(f"   path = {path}")
-                    new_lines.append(f"   writeable = {'Yes' if writable else 'No'}")
-                    new_lines.append(f"   create mask = 0777")
-                    new_lines.append(f"   directory mask = 0777")
-                    new_lines.append(f"   public = no")
-                    new_lines.append(f"   comment = {comment}")
-                    
-                    # Add valid users if specified
-                    if valid_users:
-                        users_str = ' '.join(valid_users)
-                        new_lines.append(f"   valid users = {users_str}")
-                    
-                    new_lines.append("")
-                elif in_share_section and line.strip() and not line.startswith('   '):
-                    # End of share section
-                    in_share_section = False
-                    new_lines.append(line)
-                elif not in_share_section:
-                    new_lines.append(line)
-            
-            if not share_found:
-                raise ValueError(f"Share {old_name} not found")
-            
-            # Write updated configuration
-            self._write_smb_conf('\n'.join(new_lines))
-            
-            # Restart services
-            if not self._restart_services():
-                raise Exception("Failed to restart SMB services")
-            
-            return True
-        except Exception as e:
-            logger.error(f"Error updating SMB share: {e}")
-            raise
+        return self.update_managed_share(old_name, new_name, path, writable, comment, valid_users)
 
     def delete_share(self, name):
-        """Delete a share"""
-        try:
-            # Read current configuration
-            content = self._read_smb_conf()
-            lines = content.split('\n')
-            
-            # Remove the share section
-            new_lines = []
-            in_share_section = False
-            share_found = False
-            
-            for line in lines:
-                if f'[{name}]' in line:
-                    in_share_section = True
-                    share_found = True
-                    continue  # Skip this line
-                elif in_share_section and line.strip() and not line.startswith('   '):
-                    # End of share section
-                    in_share_section = False
-                    new_lines.append(line)
-                elif not in_share_section:
-                    new_lines.append(line)
-            
-            if not share_found:
-                raise ValueError(f"Share {name} not found")
-            
-            # Write updated configuration
-            self._write_smb_conf('\n'.join(new_lines))
-            
-            # Restart services
-            if not self._restart_services():
-                raise Exception("Failed to restart SMB services")
-            
-            return True
-        except Exception as e:
-            logger.error(f"Error deleting SMB share: {e}")
-            raise
+        return self.delete_managed_share(name)
 
     def get_share_users(self, share_name):
-        """Get users who have access to a specific share"""
-        try:
-            shares = self.get_shares()
-            for share in shares:
-                if share['name'] == share_name:
-                    return share.get('valid_users', [])
+        share = self.get_managed_share(share_name)
+        if not share:
             return []
-        except Exception as e:
-            logger.error(f"Error getting share users: {e}")
-            return []
+        return share.get("valid_users", [])
 
     def update_share_users(self, share_name, users):
-        """Update the list of users who have access to a share"""
-        try:
-            shares = self.get_shares()
-            share = None
-            
-            for s in shares:
-                if s['name'] == share_name:
-                    share = s
-                    break
-            
-            if not share:
-                raise ValueError(f"Share {share_name} not found")
-            
-            # Update the share with new user list
-            return self.update_share(
-                share_name, 
-                share_name, 
-                share['path'], 
-                share['writable'], 
-                share['comment'], 
-                users
-            )
-        except Exception as e:
-            logger.error(f"Error updating share users: {e}")
-            raise
+        share = self.get_managed_share(share_name)
+        if not share:
+            if self._find_share_record(self._load_shares()[1], share_name, managed=False) is not None:
+                raise ValueError(
+                    "Share '{}' is not managed by SimpleSaferServer, so its users cannot be edited here. "
+                    "See {} for manual conversion guidance.".format(share_name, SMB_DOCS_URL)
+                )
+            raise ValueError(f"Share {share_name} not found")
+
+        return self.update_managed_share(
+            share_name,
+            share_name,
+            share["path"],
+            share["writable"],
+            share["comment"],
+            users,
+        )
 
     def get_service_status(self):
-        """Get SMB service status"""
+        """Get SMB service status."""
         if self.runtime.is_fake:
             return self.fake_state.get_smb_services()
         try:
-            smbd_result = subprocess.run(['systemctl', 'is-active', 'smbd'], 
-                                       capture_output=True, text=True)
-            nmbd_result = subprocess.run(['systemctl', 'is-active', 'nmbd'], 
-                                       capture_output=True, text=True)
-            
+            smbd_result = subprocess.run(["systemctl", "is-active", "smbd"], capture_output=True, text=True)
+            nmbd_result = subprocess.run(["systemctl", "is-active", "nmbd"], capture_output=True, text=True)
             return {
-                'smbd': smbd_result.stdout.strip(),
-                'nmbd': nmbd_result.stdout.strip()
+                "smbd": smbd_result.stdout.strip(),
+                "nmbd": nmbd_result.stdout.strip(),
             }
-        except Exception as e:
-            logger.error(f"Error getting service status: {e}")
-            return {'smbd': 'error', 'nmbd': 'error'} 
+        except Exception as exc:
+            logger.error("Error getting service status: %s", exc)
+            return {"smbd": "error", "nmbd": "error"}

--- a/smb_manager.py
+++ b/smb_manager.py
@@ -1,7 +1,9 @@
 import logging
 import os
 import re
+import shutil
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -11,7 +13,10 @@ from runtime import get_fake_state, get_runtime
 
 logger = logging.getLogger(__name__)
 
-SMB_DOCS_URL = "https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/network_file_sharing.md"
+SMB_DOCS_URL = (
+    "https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/network_file_sharing.md"
+    "#manual-conversion-unmanaged-share-to-simplesaferserver-managed-share"
+)
 MANAGED_SHARE_BEGIN_PREFIX = "# BEGIN SimpleSaferServer share: "
 MANAGED_SHARE_END_PREFIX = "# END SimpleSaferServer share: "
 SYSTEM_SHARE_NAMES = {"global", "homes", "printers", "print$"}
@@ -52,6 +57,10 @@ def _extract_section_name(line: str) -> Optional[str]:
     if stripped.startswith("[") and stripped.endswith("]") and len(stripped) > 2:
         return stripped[1:-1].strip()
     return None
+
+
+def _contains_control_characters(value: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 for char in value)
 
 
 class SMBManager:
@@ -299,6 +308,76 @@ class SMBManager:
             handle.write(content)
         os.chmod(self.smb_conf_path, 0o644)
 
+    def _validate_smb_conf_candidate(self, candidate_path: Path):
+        validator = shutil.which("testparm")
+        if validator:
+            command = [validator, "-s", str(candidate_path)]
+        else:
+            validator = shutil.which("smbd")
+            if not validator:
+                raise RuntimeError(
+                    "Could not validate smb.conf because neither 'testparm' nor 'smbd' is available."
+                )
+            command = [validator, "-t", "-s", str(candidate_path)]
+
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            details = result.stderr.strip() or result.stdout.strip() or "unknown validation error"
+            raise SMBConfigError(f"Samba configuration validation failed: {details}")
+
+    def _restore_smb_conf_backup(self, backup_path: Path):
+        shutil.copy2(backup_path, self.smb_conf_path)
+        os.chmod(self.smb_conf_path, 0o644)
+
+    def _commit_smb_conf(self, content: str):
+        if self.runtime.is_fake:
+            self._write_smb_conf(content)
+            if not self._restart_services():
+                raise Exception("Failed to restart SMB services")
+            return
+
+        live_path = Path(self.smb_conf_path)
+        backup_path = Path(self._create_backup())
+        temp_path = None
+        replaced_live_config = False
+
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                delete=False,
+                dir=str(live_path.parent),
+                prefix=f"{live_path.name}.",
+                suffix=".tmp",
+            ) as handle:
+                handle.write(content)
+                temp_path = Path(handle.name)
+
+            os.chmod(temp_path, 0o644)
+            # Validate the candidate before replacing the live file so Samba is
+            # never pointed at a config we already know is broken.
+            self._validate_smb_conf_candidate(temp_path)
+            os.replace(temp_path, live_path)
+            replaced_live_config = True
+            temp_path = None
+
+            if not self._restart_services():
+                raise RuntimeError("Failed to restart SMB services")
+        except Exception as original_error:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink()
+
+            if replaced_live_config:
+                try:
+                    self._restore_smb_conf_backup(backup_path)
+                    self._restart_services()
+                except Exception as rollback_error:
+                    logger.error(
+                        "Failed to restore smb.conf after SMB update error: %s",
+                        rollback_error,
+                    )
+
+            raise original_error
+
     def _restart_services(self):
         """Restart SMB services."""
         if self.runtime.is_fake:
@@ -455,15 +534,45 @@ class SMBManager:
     def _validate_share_input(self, name, path):
         if not name or not path:
             raise ValueError("Share name and path are required")
-        if not VALID_SHARE_NAME_RE.match(name):
+        if not isinstance(name, str) or _contains_control_characters(name) or not VALID_SHARE_NAME_RE.fullmatch(name):
             raise ValueError(
                 "Share name may only contain letters, numbers, hyphens, and underscores."
             )
-        if not os.path.exists(path):
-            raise ValueError(f"Path {path} does not exist")
+        if not isinstance(path, str) or _contains_control_characters(path):
+            raise ValueError("Share path contains unsupported control characters.")
+        if not os.path.isdir(path):
+            raise ValueError(f"Path {path} must be an existing directory")
+
+    def _validate_renderable_share_field(self, field_name, value):
+        if not isinstance(value, str):
+            raise ValueError(f"{field_name} must be a string.")
+        if _contains_control_characters(value):
+            raise ValueError(f"{field_name} contains unsupported control characters.")
+        return value
+
+    def _validate_valid_users(self, valid_users):
+        validated_users = []
+        for username in valid_users or []:
+            if not isinstance(username, str):
+                raise ValueError("Share usernames must be strings.")
+            if _contains_control_characters(username) or not VALID_SHARE_NAME_RE.fullmatch(username):
+                raise ValueError(
+                    "Share usernames may only contain letters, numbers, hyphens, and underscores."
+                )
+            validated_users.append(username)
+        return validated_users
 
     def _render_managed_share_block(self, name, path, writable=True, comment="", valid_users=None):
-        valid_users = valid_users or []
+        name = self._validate_renderable_share_field("Share name", name)
+        if not VALID_SHARE_NAME_RE.fullmatch(name):
+            raise ValueError(
+                "Share name may only contain letters, numbers, hyphens, and underscores."
+            )
+
+        path = self._validate_renderable_share_field("Share path", path)
+        comment = self._validate_renderable_share_field("Share comment", comment)
+        valid_users = self._validate_valid_users(valid_users or [])
+
         lines = [
             f"{MANAGED_SHARE_BEGIN_PREFIX}{name}\n",
             f"[{name}]\n",
@@ -513,10 +622,7 @@ class SMBManager:
 
         block_lines = self._render_managed_share_block(name, path, writable, comment, valid_users)
         new_lines = self._append_managed_block(lines, block_lines)
-        self._write_smb_conf("".join(new_lines))
-
-        if not self._restart_services():
-            raise Exception("Failed to restart SMB services")
+        self._commit_smb_conf("".join(new_lines))
 
         return True
 
@@ -543,10 +649,7 @@ class SMBManager:
         new_lines = list(lines)
         replacement = self._render_managed_share_block(new_name, path, writable, comment, valid_users)
         new_lines[share.start_line:share.end_line] = replacement
-        self._write_smb_conf("".join(new_lines))
-
-        if not self._restart_services():
-            raise Exception("Failed to restart SMB services")
+        self._commit_smb_conf("".join(new_lines))
 
         return True
 
@@ -563,10 +666,7 @@ class SMBManager:
 
         new_lines = list(lines)
         del new_lines[share.start_line:share.end_line]
-        self._write_smb_conf("".join(new_lines))
-
-        if not self._restart_services():
-            raise Exception("Failed to restart SMB services")
+        self._commit_smb_conf("".join(new_lines))
 
         return True
 

--- a/templates/network_file_sharing.html
+++ b/templates/network_file_sharing.html
@@ -5,166 +5,8 @@
 
 {% block extra_css %}
 <style>
-  .unmanaged-shares-trigger {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--sp-2);
-    min-height: 2.35rem;
-    padding: 0.55rem 0.95rem;
-    border-radius: 999px;
-    border: 1px solid hsla(38, 90%, 55%, 0.28);
-    background:
-      linear-gradient(135deg, hsla(38, 90%, 55%, 0.18), hsla(38, 90%, 55%, 0.08));
-    color: var(--warning-text);
-    box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.04);
-    transition:
-      transform var(--dur-fast) var(--ease-default),
-      border-color var(--dur-fast) var(--ease-default),
-      background var(--dur-fast) var(--ease-default);
-  }
-
-  .unmanaged-shares-trigger:hover {
-    transform: translateY(-1px);
-    border-color: hsla(38, 90%, 55%, 0.48);
-    background:
-      linear-gradient(135deg, hsla(38, 90%, 55%, 0.24), hsla(38, 90%, 55%, 0.12));
-  }
-
-  .unmanaged-shares-trigger i {
-    color: var(--warning);
-  }
-
-  .unmanaged-shares-modal {
-    max-width: 680px;
-  }
-
   .unmanaged-shares-modal .modal-body {
     white-space: normal;
-  }
-
-  .unmanaged-shares-stack {
-    display: grid;
-    gap: var(--sp-4);
-  }
-
-  .unmanaged-shares-lead {
-    font-size: var(--text-md);
-    line-height: 1.65;
-    color: var(--text-secondary);
-  }
-
-  .unmanaged-shares-callout {
-    display: grid;
-    gap: var(--sp-3);
-    padding: var(--sp-4);
-    border-radius: var(--radius-lg);
-    border: 1px solid hsla(38, 90%, 55%, 0.18);
-    background:
-      linear-gradient(180deg, hsla(220, 16%, 16%, 0.96), hsla(220, 14%, 13%, 0.96));
-  }
-
-  .unmanaged-shares-callout-header {
-    display: flex;
-    align-items: center;
-    gap: var(--sp-3);
-  }
-
-  .unmanaged-shares-callout-icon {
-    width: 2rem;
-    height: 2rem;
-    border-radius: 999px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--warning-subtle);
-    color: var(--warning);
-    flex-shrink: 0;
-  }
-
-  .unmanaged-shares-callout-title {
-    font-size: var(--text-sm);
-    font-weight: var(--weight-semi);
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--warning-text);
-  }
-
-  .unmanaged-shares-callout p {
-    color: var(--text-primary);
-    line-height: 1.7;
-  }
-
-  .unmanaged-shares-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1.15fr) minmax(220px, 0.85fr);
-    gap: var(--sp-4);
-    align-items: start;
-  }
-
-  .unmanaged-shares-section-label {
-    margin-bottom: var(--sp-2);
-    font-size: var(--text-xs);
-    font-weight: var(--weight-semi);
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--text-muted);
-  }
-
-  .unmanaged-shares-name-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--sp-2);
-    min-height: 2.5rem;
-  }
-
-  .unmanaged-shares-name-pill {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.55rem 0.8rem;
-    border-radius: 999px;
-    border: 1px solid var(--border-default);
-    background: hsla(220, 18%, 18%, 0.9);
-    color: var(--text-primary);
-    font-family: var(--font-mono);
-    font-size: var(--text-xs);
-  }
-
-  .unmanaged-shares-support-note {
-    display: grid;
-    gap: var(--sp-2);
-    padding: var(--sp-4);
-    border-radius: var(--radius-lg);
-    background: hsla(220, 18%, 16%, 0.82);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .unmanaged-shares-support-note p {
-    color: var(--text-secondary);
-    line-height: 1.65;
-  }
-
-  .unmanaged-shares-actions {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: var(--sp-3);
-    padding-top: var(--sp-1);
-  }
-
-  .unmanaged-shares-actions .btn {
-    min-width: 0;
-  }
-
-  .unmanaged-shares-actions-note {
-    font-size: var(--text-xs);
-    color: var(--text-muted);
-  }
-
-  @media (max-width: 720px) {
-    .unmanaged-shares-grid {
-      grid-template-columns: 1fr;
-    }
   }
 </style>
 {% endblock %}
@@ -220,7 +62,7 @@
     <div class="d-flex items-center gap-2 flex-wrap">
       <h2 style="font-size: var(--text-lg); margin: 0;">SMB Shares</h2>
       <button
-        class="btn btn-sm unmanaged-shares-trigger d-none"
+        class="btn btn-secondary btn-sm d-none"
         id="unmanagedSharesBtn"
         data-modal-target="unmanagedSharesModal"
         type="button">
@@ -414,62 +256,39 @@
 
 <!-- Unmanaged Shares Modal -->
 <div class="modal-overlay" id="unmanagedSharesModal">
-  <div class="modal-container unmanaged-shares-modal">
+  <div class="modal-container modal-lg unmanaged-shares-modal">
     <div class="modal-header">
       <h5>Unmanaged SMB Shares</h5>
       <button class="modal-close" data-modal-close><i class="fas fa-xmark"></i></button>
     </div>
     <div class="modal-body">
-      <div class="unmanaged-shares-stack">
-        <p class="unmanaged-shares-lead">
-          SimpleSaferServer found Samba share definitions in <code>/etc/samba/smb.conf</code> that are still active,
-          but are not marked as SimpleSaferServer-managed. For safety, they stay read-only here.
-        </p>
+      <p class="text-secondary mb-4">
+        SimpleSaferServer found Samba share definitions in <code>/etc/samba/smb.conf</code> that are still active,
+        but are not marked as SimpleSaferServer-managed. They remain read-only here.
+      </p>
 
-        <div class="unmanaged-shares-callout">
-          <div class="unmanaged-shares-callout-header">
-            <span class="unmanaged-shares-callout-icon">
-              <i class="fas fa-circle-info"></i>
-            </span>
-            <div class="unmanaged-shares-callout-title">Manual conversion required</div>
-          </div>
-          <p>
-            Convert a share manually only if it fits the SimpleSaferServer-managed format. The app supports a share
-            name, path, writable state, comment, and valid users list, and it writes the rest of the managed block in
-            a fixed format on purpose.
-          </p>
-        </div>
-
-        <div class="unmanaged-shares-grid">
-          <div>
-            <div class="unmanaged-shares-section-label">Detected unmanaged shares</div>
-            <div id="unmanagedSharesList" class="unmanaged-shares-name-list">
-              <span class="text-muted">No unmanaged shares detected.</span>
-            </div>
-          </div>
-
-          <div class="unmanaged-shares-support-note">
-            <div class="unmanaged-shares-section-label">What SimpleSaferServer supports</div>
-            <p>
-              Managed shares are intentionally limited so the app can update them safely later without guessing about
-              unrelated Samba directives.
-            </p>
-          </div>
-        </div>
-
-        <div class="unmanaged-shares-actions">
-          <a
-            href="{{ smb_docs_url }}"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="btn btn-warning btn-sm">
-            <i class="fas fa-book-open me-1"></i> Open Manual Conversion Guide
-          </a>
-          <div class="unmanaged-shares-actions-note">
-            The guide opens directly to the manual conversion section.
-          </div>
-        </div>
+      <div class="table-container mb-4">
+        <table>
+          <thead>
+            <tr>
+              <th>Share Name</th>
+            </tr>
+          </thead>
+          <tbody id="unmanagedSharesList">
+            <tr>
+              <td class="text-muted">No unmanaged shares detected.</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
+
+      <a
+        href="{{ smb_docs_url }}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="btn btn-secondary btn-sm">
+        <i class="fas fa-book-open me-1"></i> Open Manual Conversion Guide
+      </a>
     </div>
     <div class="modal-footer">
       <button class="btn btn-secondary" data-modal-close>Close</button>
@@ -640,20 +459,22 @@ function renderUnmanagedShareState(hasUnmanagedShares, count, names) {
 
   if (!hasUnmanagedShares || !count) {
     button.classList.add('d-none');
-    list.innerHTML = '<span class="text-muted">No unmanaged shares detected.</span>';
+    list.innerHTML = '<tr><td class="text-muted">No unmanaged shares detected.</td></tr>';
     return;
   }
 
   label.textContent = `${count} unmanaged share${count === 1 ? '' : 's'} detected`;
   button.classList.remove('d-none');
 
-  // Keep the modal list simple because unsupported Samba directives can vary
-  // widely, and the docs are the canonical place for manual conversion steps.
+  // Keep the modal list plain and table-based so it matches the rest of the UI
+  // and stays readable even if we revisit this flow months from now.
   names.forEach(function(name) {
-    const item = document.createElement('span');
-    item.className = 'unmanaged-shares-name-pill';
-    item.textContent = name;
-    list.appendChild(item);
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.className = 'fw-medium';
+    cell.textContent = name;
+    row.appendChild(cell);
+    list.appendChild(row);
   });
 }
 

--- a/templates/network_file_sharing.html
+++ b/templates/network_file_sharing.html
@@ -51,7 +51,17 @@
 <!-- SMB Shares -->
 <section>
   <div class="d-flex items-center justify-between mb-4">
-    <h2 style="font-size: var(--text-lg); margin: 0;">SMB Shares</h2>
+    <div class="d-flex items-center gap-2 flex-wrap">
+      <h2 style="font-size: var(--text-lg); margin: 0;">SMB Shares</h2>
+      <button
+        class="btn btn-outline-warning btn-sm d-none"
+        id="unmanagedSharesBtn"
+        data-modal-target="unmanagedSharesModal"
+        type="button">
+        <i class="fas fa-triangle-exclamation me-1"></i>
+        <span id="unmanagedSharesBtnLabel">Unmanaged shares detected</span>
+      </button>
+    </div>
     <button class="btn btn-primary btn-sm" data-modal-target="addShareModal">
       <i class="fas fa-plus me-1"></i> Add Share
     </button>
@@ -235,6 +245,46 @@
     </div>
   </div>
 </div>
+
+<!-- Unmanaged Shares Modal -->
+<div class="modal-overlay" id="unmanagedSharesModal">
+  <div class="modal-container">
+    <div class="modal-header">
+      <h5>Unmanaged SMB Shares</h5>
+      <button class="modal-close" data-modal-close><i class="fas fa-xmark"></i></button>
+    </div>
+    <div class="modal-body">
+      <p class="mb-3">
+        SimpleSaferServer detected Samba share definitions in <code>/etc/samba/smb.conf</code> that are not marked as
+        SimpleSaferServer-managed. They remain active in Samba, but SimpleSaferServer will not edit or remove them.
+      </p>
+      <div class="alert alert-warning mb-4">
+        <i class="fas fa-circle-info"></i>
+        <span>
+          To manage a share here, convert it manually into the SimpleSaferServer-managed format described in the
+          documentation. SimpleSaferServer-managed shares support only a share name, path, writable state, comment,
+          and valid users list.
+        </span>
+      </div>
+      <div class="mb-4">
+        <div class="form-label">Detected unmanaged shares</div>
+        <ul id="unmanagedSharesList" class="mb-0 ps-4">
+          <li class="text-muted">No unmanaged shares detected.</li>
+        </ul>
+      </div>
+      <a
+        href="{{ smb_docs_url }}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="btn btn-secondary btn-sm">
+        <i class="fas fa-book-open me-1"></i> Open Conversion Documentation
+      </a>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-primary" data-modal-close>Close</button>
+    </div>
+  </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}
@@ -242,6 +292,7 @@
 let shares = [];
 let currentDeleteShare = null;
 let allUsers = [];
+let unmanagedShareNames = [];
 
 document.addEventListener('DOMContentLoaded', function() {
   loadShares();
@@ -377,9 +428,41 @@ function loadShares() {
     .then(data => {
       if (data.error) { showAlert('Error loading shares: ' + data.error, 'danger'); return; }
       shares = data.shares;
+      unmanagedShareNames = data.unmanaged_share_names || [];
+      renderUnmanagedShareState(
+        Boolean(data.unmanaged_shares_detected),
+        data.unmanaged_share_count || unmanagedShareNames.length,
+        unmanagedShareNames
+      );
       renderSharesTable();
     })
     .catch(() => showAlert('Failed to load shares', 'danger'));
+}
+
+function renderUnmanagedShareState(hasUnmanagedShares, count, names) {
+  const button = document.getElementById('unmanagedSharesBtn');
+  const label = document.getElementById('unmanagedSharesBtnLabel');
+  const list = document.getElementById('unmanagedSharesList');
+  if (!button || !label || !list) return;
+
+  list.innerHTML = '';
+
+  if (!hasUnmanagedShares || !count) {
+    button.classList.add('d-none');
+    list.innerHTML = '<li class="text-muted">No unmanaged shares detected.</li>';
+    return;
+  }
+
+  label.textContent = `${count} unmanaged share${count === 1 ? '' : 's'} detected`;
+  button.classList.remove('d-none');
+
+  // Keep the modal list simple because unsupported Samba directives can vary
+  // widely, and the docs are the canonical place for manual conversion steps.
+  names.forEach(function(name) {
+    const item = document.createElement('li');
+    item.textContent = name;
+    list.appendChild(item);
+  });
 }
 
 function loadUsers() {
@@ -439,7 +522,7 @@ function renderSharesTable() {
     td.colSpan = 6;
     td.className = 'text-center text-muted';
     td.style.padding = 'var(--sp-6)';
-    td.textContent = 'No shares configured';
+    td.textContent = 'No SimpleSaferServer-managed shares configured';
     tr.appendChild(td);
     tbody.appendChild(tr);
     return;

--- a/templates/network_file_sharing.html
+++ b/templates/network_file_sharing.html
@@ -3,6 +3,172 @@
 {% block title %}File Sharing — SimpleSaferServer{% endblock %}
 {% block header %}Network File Sharing{% endblock %}
 
+{% block extra_css %}
+<style>
+  .unmanaged-shares-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-2);
+    min-height: 2.35rem;
+    padding: 0.55rem 0.95rem;
+    border-radius: 999px;
+    border: 1px solid hsla(38, 90%, 55%, 0.28);
+    background:
+      linear-gradient(135deg, hsla(38, 90%, 55%, 0.18), hsla(38, 90%, 55%, 0.08));
+    color: var(--warning-text);
+    box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.04);
+    transition:
+      transform var(--dur-fast) var(--ease-default),
+      border-color var(--dur-fast) var(--ease-default),
+      background var(--dur-fast) var(--ease-default);
+  }
+
+  .unmanaged-shares-trigger:hover {
+    transform: translateY(-1px);
+    border-color: hsla(38, 90%, 55%, 0.48);
+    background:
+      linear-gradient(135deg, hsla(38, 90%, 55%, 0.24), hsla(38, 90%, 55%, 0.12));
+  }
+
+  .unmanaged-shares-trigger i {
+    color: var(--warning);
+  }
+
+  .unmanaged-shares-modal {
+    max-width: 680px;
+  }
+
+  .unmanaged-shares-modal .modal-body {
+    white-space: normal;
+  }
+
+  .unmanaged-shares-stack {
+    display: grid;
+    gap: var(--sp-4);
+  }
+
+  .unmanaged-shares-lead {
+    font-size: var(--text-md);
+    line-height: 1.65;
+    color: var(--text-secondary);
+  }
+
+  .unmanaged-shares-callout {
+    display: grid;
+    gap: var(--sp-3);
+    padding: var(--sp-4);
+    border-radius: var(--radius-lg);
+    border: 1px solid hsla(38, 90%, 55%, 0.18);
+    background:
+      linear-gradient(180deg, hsla(220, 16%, 16%, 0.96), hsla(220, 14%, 13%, 0.96));
+  }
+
+  .unmanaged-shares-callout-header {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+  }
+
+  .unmanaged-shares-callout-icon {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--warning-subtle);
+    color: var(--warning);
+    flex-shrink: 0;
+  }
+
+  .unmanaged-shares-callout-title {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semi);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--warning-text);
+  }
+
+  .unmanaged-shares-callout p {
+    color: var(--text-primary);
+    line-height: 1.7;
+  }
+
+  .unmanaged-shares-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(220px, 0.85fr);
+    gap: var(--sp-4);
+    align-items: start;
+  }
+
+  .unmanaged-shares-section-label {
+    margin-bottom: var(--sp-2);
+    font-size: var(--text-xs);
+    font-weight: var(--weight-semi);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+
+  .unmanaged-shares-name-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-2);
+    min-height: 2.5rem;
+  }
+
+  .unmanaged-shares-name-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.55rem 0.8rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-default);
+    background: hsla(220, 18%, 18%, 0.9);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .unmanaged-shares-support-note {
+    display: grid;
+    gap: var(--sp-2);
+    padding: var(--sp-4);
+    border-radius: var(--radius-lg);
+    background: hsla(220, 18%, 16%, 0.82);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .unmanaged-shares-support-note p {
+    color: var(--text-secondary);
+    line-height: 1.65;
+  }
+
+  .unmanaged-shares-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--sp-3);
+    padding-top: var(--sp-1);
+  }
+
+  .unmanaged-shares-actions .btn {
+    min-width: 0;
+  }
+
+  .unmanaged-shares-actions-note {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 720px) {
+    .unmanaged-shares-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 <!-- System Status - compact inline, no card -->
 <div class="d-flex items-center justify-between mb-6 flex-wrap gap-3" id="systemStatusArea">
@@ -54,7 +220,7 @@
     <div class="d-flex items-center gap-2 flex-wrap">
       <h2 style="font-size: var(--text-lg); margin: 0;">SMB Shares</h2>
       <button
-        class="btn btn-outline-warning btn-sm d-none"
+        class="btn btn-sm unmanaged-shares-trigger d-none"
         id="unmanagedSharesBtn"
         data-modal-target="unmanagedSharesModal"
         type="button">
@@ -248,40 +414,65 @@
 
 <!-- Unmanaged Shares Modal -->
 <div class="modal-overlay" id="unmanagedSharesModal">
-  <div class="modal-container">
+  <div class="modal-container unmanaged-shares-modal">
     <div class="modal-header">
       <h5>Unmanaged SMB Shares</h5>
       <button class="modal-close" data-modal-close><i class="fas fa-xmark"></i></button>
     </div>
     <div class="modal-body">
-      <p class="mb-3">
-        SimpleSaferServer detected Samba share definitions in <code>/etc/samba/smb.conf</code> that are not marked as
-        SimpleSaferServer-managed. They remain active in Samba, but SimpleSaferServer will not edit or remove them.
-      </p>
-      <div class="alert alert-warning mb-4">
-        <i class="fas fa-circle-info"></i>
-        <span>
-          To manage a share here, convert it manually into the SimpleSaferServer-managed format described in the
-          documentation. SimpleSaferServer-managed shares support only a share name, path, writable state, comment,
-          and valid users list.
-        </span>
+      <div class="unmanaged-shares-stack">
+        <p class="unmanaged-shares-lead">
+          SimpleSaferServer found Samba share definitions in <code>/etc/samba/smb.conf</code> that are still active,
+          but are not marked as SimpleSaferServer-managed. For safety, they stay read-only here.
+        </p>
+
+        <div class="unmanaged-shares-callout">
+          <div class="unmanaged-shares-callout-header">
+            <span class="unmanaged-shares-callout-icon">
+              <i class="fas fa-circle-info"></i>
+            </span>
+            <div class="unmanaged-shares-callout-title">Manual conversion required</div>
+          </div>
+          <p>
+            Convert a share manually only if it fits the SimpleSaferServer-managed format. The app supports a share
+            name, path, writable state, comment, and valid users list, and it writes the rest of the managed block in
+            a fixed format on purpose.
+          </p>
+        </div>
+
+        <div class="unmanaged-shares-grid">
+          <div>
+            <div class="unmanaged-shares-section-label">Detected unmanaged shares</div>
+            <div id="unmanagedSharesList" class="unmanaged-shares-name-list">
+              <span class="text-muted">No unmanaged shares detected.</span>
+            </div>
+          </div>
+
+          <div class="unmanaged-shares-support-note">
+            <div class="unmanaged-shares-section-label">What SimpleSaferServer supports</div>
+            <p>
+              Managed shares are intentionally limited so the app can update them safely later without guessing about
+              unrelated Samba directives.
+            </p>
+          </div>
+        </div>
+
+        <div class="unmanaged-shares-actions">
+          <a
+            href="{{ smb_docs_url }}"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="btn btn-warning btn-sm">
+            <i class="fas fa-book-open me-1"></i> Open Manual Conversion Guide
+          </a>
+          <div class="unmanaged-shares-actions-note">
+            The guide opens directly to the manual conversion section.
+          </div>
+        </div>
       </div>
-      <div class="mb-4">
-        <div class="form-label">Detected unmanaged shares</div>
-        <ul id="unmanagedSharesList" class="mb-0 ps-4">
-          <li class="text-muted">No unmanaged shares detected.</li>
-        </ul>
-      </div>
-      <a
-        href="{{ smb_docs_url }}"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="btn btn-secondary btn-sm">
-        <i class="fas fa-book-open me-1"></i> Open Conversion Documentation
-      </a>
     </div>
     <div class="modal-footer">
-      <button class="btn btn-primary" data-modal-close>Close</button>
+      <button class="btn btn-secondary" data-modal-close>Close</button>
     </div>
   </div>
 </div>
@@ -449,7 +640,7 @@ function renderUnmanagedShareState(hasUnmanagedShares, count, names) {
 
   if (!hasUnmanagedShares || !count) {
     button.classList.add('d-none');
-    list.innerHTML = '<li class="text-muted">No unmanaged shares detected.</li>';
+    list.innerHTML = '<span class="text-muted">No unmanaged shares detected.</span>';
     return;
   }
 
@@ -459,7 +650,8 @@ function renderUnmanagedShareState(hasUnmanagedShares, count, names) {
   // Keep the modal list simple because unsupported Samba directives can vary
   // widely, and the docs are the canonical place for manual conversion steps.
   names.forEach(function(name) {
-    const item = document.createElement('li');
+    const item = document.createElement('span');
+    item.className = 'unmanaged-shares-name-pill';
     item.textContent = name;
     list.appendChild(item);
   });

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -1,4 +1,6 @@
 import unittest
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -412,6 +414,67 @@ class BackupDriveSetupTests(unittest.TestCase):
         mock_restore_fstab_backup.assert_called_once_with('/tmp/fstab.backup', runtime=runtime)
         self.assertEqual(mock_reload_mount_units.call_count, 2)
         mock_run.assert_not_called()
+
+    @patch('backup_drive_setup.get_fake_state')
+    @patch('backup_drive_setup.restore_fstab_backup')
+    @patch('backup_drive_setup._reload_systemd_mount_units')
+    @patch('backup_drive_setup.update_managed_fstab')
+    def test_fake_mode_rollback_restores_share_via_update_managed_share(
+        self,
+        mock_update_fstab,
+        mock_reload_mount_units,
+        mock_restore_fstab_backup,
+        mock_get_fake_state,
+    ):
+        with tempfile.TemporaryDirectory() as tempdir:
+            data_dir = Path(tempdir)
+            selected_path = data_dir / 'selected-backup'
+            selected_path.mkdir()
+
+            runtime = SimpleNamespace(
+                is_fake=True,
+                data_dir=data_dir,
+                default_mount_point='/media/backup',
+            )
+            fake_state = MagicMock()
+            mock_get_fake_state.return_value = fake_state
+            mock_update_fstab.return_value = '/tmp/fstab.backup'
+
+            config_manager = MagicMock()
+            config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', 'OLD-USB']
+            config_manager.set_value.side_effect = [None, None, RuntimeError('boom')]
+
+            smb_manager = MagicMock()
+            smb_manager.get_managed_share.return_value = {
+                'name': 'backup',
+                'path': '/media/backup',
+                'writable': True,
+                'comment': 'Managed backup share',
+                'valid_users': ['admin'],
+            }
+
+            with self.assertRaisesRegex(RuntimeError, 'boom'):
+                backup_drive_setup.apply_backup_drive_configuration(
+                    '/dev/fakebackup1',
+                    str(selected_path),
+                    True,
+                    config_manager,
+                    smb_manager,
+                    runtime=runtime,
+                )
+
+        self.assertGreaterEqual(smb_manager.update_managed_share.call_count, 2)
+        self.assertEqual(
+            smb_manager.update_managed_share.call_args_list[-1].kwargs,
+            {
+                'old_name': 'backup',
+                'new_name': 'backup',
+                'path': '/media/backup',
+                'writable': True,
+                'comment': 'Managed backup share',
+                'valid_users': ['admin'],
+            },
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -285,7 +285,7 @@ class BackupDriveSetupTests(unittest.TestCase):
         config_manager = MagicMock()
         config_manager.get_value.side_effect = ['/media/backup', '', '']
         smb_manager = MagicMock()
-        smb_manager.get_shares.return_value = []
+        smb_manager.get_managed_share.return_value = None
 
         mock_get_mount.return_value = None
         mock_get_uuid.return_value = 'UUID-1'
@@ -337,7 +337,7 @@ class BackupDriveSetupTests(unittest.TestCase):
         config_manager = MagicMock()
         config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', '1234:5678']
         smb_manager = MagicMock()
-        smb_manager.get_shares.return_value = []
+        smb_manager.get_managed_share.return_value = None
 
         mock_get_mount.return_value = None
         mock_get_uuid.return_value = 'UUID-1'
@@ -384,7 +384,7 @@ class BackupDriveSetupTests(unittest.TestCase):
         config_manager = MagicMock()
         config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', '1234:5678']
         smb_manager = MagicMock()
-        smb_manager.get_shares.return_value = []
+        smb_manager.get_managed_share.return_value = None
 
         mock_get_mount.return_value = None
         mock_get_uuid.return_value = 'UUID-1'

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -5,6 +5,7 @@ import types
 from unittest.mock import MagicMock, patch
 
 from flask import Flask
+from smb_manager import SMB_DOCS_URL
 
 
 class SetupWizardTests(unittest.TestCase):
@@ -245,6 +246,42 @@ class SetupWizardTests(unittest.TestCase):
     def test_get_partition_node_sda_disk(self):
         # Another standard disk to confirm the letter-ending branch.
         self.assertEqual(self.setup_wizard.get_partition_node('/dev/sda'), '/dev/sda1')
+
+    def test_setup_smb_share_uses_shared_manager_logic(self):
+        smb_manager = MagicMock()
+        user_manager = MagicMock()
+        user_manager.users = {'admin': {}}
+        user_manager.user_exists_in_samba.return_value = True
+
+        with patch.object(self.setup_wizard, 'smb_manager', smb_manager):
+            with patch.object(self.setup_wizard, 'user_manager', user_manager):
+                ok, err = self.setup_wizard.setup_smb_share({
+                    'backup': {'mount_point': '/media/backup'},
+                    'system': {'username': 'admin'},
+                })
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        smb_manager.ensure_default_backup_share.assert_called_once_with('/media/backup', 'admin')
+
+    def test_setup_smb_share_surfaces_unmanaged_backup_guidance(self):
+        smb_manager = MagicMock()
+        smb_manager.ensure_default_backup_share.side_effect = ValueError(
+            f"An unmanaged Samba share named 'backup' already exists. See {SMB_DOCS_URL}"
+        )
+        user_manager = MagicMock()
+        user_manager.users = {'admin': {}}
+        user_manager.user_exists_in_samba.return_value = True
+
+        with patch.object(self.setup_wizard, 'smb_manager', smb_manager):
+            with patch.object(self.setup_wizard, 'user_manager', user_manager):
+                ok, err = self.setup_wizard.setup_smb_share({
+                    'backup': {'mount_point': '/media/backup'},
+                    'system': {'username': 'admin'},
+                })
+
+        self.assertFalse(ok)
+        self.assertIn(SMB_DOCS_URL, err)
 
     # ------------------------------------------------------------------
     # format_drive — disk path validation, partprobe, and partition poll
@@ -516,4 +553,3 @@ class SetupWizardTests(unittest.TestCase):
         data = response.get_json()
         self.assertEqual(data['success'], False)
         self.assertIn('did not appear', data['error'])
-

--- a/tests/test_smb_manager.py
+++ b/tests/test_smb_manager.py
@@ -1,0 +1,215 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import smb_manager
+
+
+class SMBManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        self.runtime = SimpleNamespace(
+            samba_dir=self.root / "samba",
+            samba_backup_dir=self.root / "samba-backups",
+            is_fake=True,
+        )
+        self.runtime.samba_dir.mkdir(parents=True, exist_ok=True)
+        self.runtime.samba_backup_dir.mkdir(parents=True, exist_ok=True)
+        self.fake_state = SimpleNamespace(
+            set_smb_services=lambda smbd, nmbd: None,
+            get_smb_services=lambda: {"smbd": "active", "nmbd": "active"},
+        )
+
+        patcher = patch.object(smb_manager, "get_fake_state", return_value=self.fake_state)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.manager = smb_manager.SMBManager(runtime=self.runtime)
+
+    def _write_conf(self, content):
+        (self.runtime.samba_dir / "smb.conf").write_text(content)
+
+    def test_list_managed_and_unmanaged_shares_in_mixed_config(self):
+        self._write_conf(
+            "\n".join(
+                [
+                    "[global]",
+                    "   workgroup = WORKGROUP",
+                    "",
+                    "# BEGIN SimpleSaferServer share: backup",
+                    "[backup]",
+                    "   path = /media/backup",
+                    "   writeable = Yes",
+                    "   comment = Managed backup share",
+                    "   valid users = admin",
+                    "# END SimpleSaferServer share: backup",
+                    "",
+                    "[media]",
+                    "   path = /srv/media",
+                    "   guest ok = yes",
+                    "",
+                ]
+            )
+        )
+
+        managed = self.manager.list_managed_shares()
+        unmanaged = self.manager.list_unmanaged_shares()
+
+        self.assertEqual([share["name"] for share in managed], ["backup"])
+        self.assertEqual([share["name"] for share in unmanaged], ["media"])
+        self.assertEqual(managed[0]["path"], "/media/backup")
+
+    def test_malformed_managed_marker_raises_clear_error(self):
+        self._write_conf(
+            "\n".join(
+                [
+                    "[global]",
+                    "   workgroup = WORKGROUP",
+                    "",
+                    "# BEGIN SimpleSaferServer share: backup",
+                    "[backup]",
+                    "   path = /media/backup",
+                    "",
+                ]
+            )
+        )
+
+        with self.assertRaises(smb_manager.SMBConfigError):
+            self.manager.list_managed_shares()
+
+    def test_create_managed_share_writes_wrapped_block(self):
+        share_path = self.root / "share"
+        share_path.mkdir()
+
+        self.manager.create_managed_share(
+            "backup",
+            str(share_path),
+            writable=True,
+            comment="Managed by tests",
+            valid_users=["admin"],
+        )
+
+        content = (self.runtime.samba_dir / "smb.conf").read_text()
+        self.assertIn("# BEGIN SimpleSaferServer share: backup", content)
+        self.assertIn("[backup]", content)
+        self.assertIn(f"   path = {share_path}", content)
+        self.assertIn("# END SimpleSaferServer share: backup", content)
+
+    def test_update_managed_share_preserves_unmanaged_block(self):
+        old_path = self.root / "old-share"
+        old_path.mkdir()
+        new_path = self.root / "new-share"
+        new_path.mkdir()
+        self._write_conf(
+            "\n".join(
+                [
+                    "[global]",
+                    "   workgroup = WORKGROUP",
+                    "",
+                    "[media]",
+                    "   path = /srv/media",
+                    "   guest ok = yes",
+                    "",
+                    "# BEGIN SimpleSaferServer share: backup",
+                    "[backup]",
+                    f"   path = {old_path}",
+                    "   writeable = Yes",
+                    "   comment = Old comment",
+                    "   valid users = admin",
+                    "# END SimpleSaferServer share: backup",
+                    "",
+                ]
+            )
+        )
+
+        self.manager.update_managed_share(
+            "backup",
+            "backup",
+            str(new_path),
+            writable=False,
+            comment="Updated comment",
+            valid_users=["admin", "operator"],
+        )
+
+        content = (self.runtime.samba_dir / "smb.conf").read_text()
+        self.assertIn("[media]\n   path = /srv/media\n   guest ok = yes\n", content)
+        self.assertIn(f"   path = {new_path}", content)
+        self.assertIn("   writeable = No", content)
+        self.assertIn("   valid users = admin operator", content)
+
+    def test_delete_managed_share_only_removes_owned_block(self):
+        self._write_conf(
+            "\n".join(
+                [
+                    "[global]",
+                    "   workgroup = WORKGROUP",
+                    "",
+                    "# BEGIN SimpleSaferServer share: backup",
+                    "[backup]",
+                    "   path = /media/backup",
+                    "   writeable = Yes",
+                    "# END SimpleSaferServer share: backup",
+                    "",
+                    "[media]",
+                    "   path = /srv/media",
+                    "",
+                ]
+            )
+        )
+
+        self.manager.delete_managed_share("backup")
+
+        content = (self.runtime.samba_dir / "smb.conf").read_text()
+        self.assertNotIn("[backup]", content)
+        self.assertIn("[media]", content)
+
+    def test_ensure_default_backup_share_updates_existing_managed_share(self):
+        old_path = self.root / "old-backup"
+        old_path.mkdir()
+        new_path = self.root / "new-backup"
+        new_path.mkdir()
+        self._write_conf(
+            "\n".join(
+                [
+                    "# BEGIN SimpleSaferServer share: backup",
+                    "[backup]",
+                    f"   path = {old_path}",
+                    "   writeable = Yes",
+                    "   comment = Original",
+                    "   valid users = admin",
+                    "# END SimpleSaferServer share: backup",
+                    "",
+                ]
+            )
+        )
+
+        self.manager.ensure_default_backup_share(str(new_path), "admin")
+
+        share = self.manager.get_managed_share("backup")
+        self.assertEqual(share["path"], str(new_path))
+        self.assertEqual(share["valid_users"], ["admin"])
+
+    def test_ensure_default_backup_share_rejects_unmanaged_backup_share(self):
+        share_path = self.root / "backup"
+        share_path.mkdir()
+        self._write_conf(
+            "\n".join(
+                [
+                    "[backup]",
+                    f"   path = {share_path}",
+                    "   guest ok = yes",
+                    "",
+                ]
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "unmanaged Samba share named 'backup'"):
+            self.manager.ensure_default_backup_share(str(share_path), "admin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_smb_manager.py
+++ b/tests/test_smb_manager.py
@@ -268,6 +268,29 @@ class SMBManagerTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "is not managed by SimpleSaferServer"):
             self.manager.get_share_users("media")
 
+    def test_get_share_users_uses_existing_snapshot_without_second_lookup(self):
+        share_path = self.root / "managed-share"
+        share_path.mkdir()
+        self._write_conf(
+            "\n".join(
+                [
+                    "# BEGIN SimpleSaferServer share: backup",
+                    "[backup]",
+                    f"   path = {share_path}",
+                    "   writeable = Yes",
+                    "   comment = Managed backup share",
+                    "   valid users = admin",
+                    "# END SimpleSaferServer share: backup",
+                    "",
+                ]
+            )
+        )
+
+        # This guards the helper against reloading the config after it has
+        # already validated ownership from a consistent snapshot.
+        with patch.object(self.manager, "get_managed_share", side_effect=AssertionError("unexpected second lookup")):
+            self.assertEqual(self.manager.get_share_users("backup"), ["admin"])
+
     def test_restart_failure_restores_previous_live_config(self):
         runtime = SimpleNamespace(
             samba_dir=self.root / "real-samba",

--- a/tests/test_smb_manager.py
+++ b/tests/test_smb_manager.py
@@ -210,6 +210,65 @@ class SMBManagerTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unmanaged Samba share named 'backup'"):
             self.manager.ensure_default_backup_share(str(share_path), "admin")
 
+    def test_create_managed_share_rejects_comment_with_newline_injection(self):
+        share_path = self.root / "share-with-comment"
+        share_path.mkdir()
+
+        with self.assertRaisesRegex(ValueError, "Share comment contains unsupported control characters"):
+            self.manager.create_managed_share(
+                "backup",
+                str(share_path),
+                comment="Looks fine\nguest ok = yes",
+                valid_users=["admin"],
+            )
+
+    def test_create_managed_share_rejects_non_directory_path(self):
+        file_path = self.root / "not-a-directory"
+        file_path.write_text("hello")
+
+        with self.assertRaisesRegex(ValueError, "must be an existing directory"):
+            self.manager.create_managed_share("backup", str(file_path))
+
+    def test_create_managed_share_rejects_whitespace_in_valid_users(self):
+        share_path = self.root / "share-with-users"
+        share_path.mkdir()
+
+        with self.assertRaisesRegex(ValueError, "Share usernames may only contain"):
+            self.manager.create_managed_share(
+                "backup",
+                str(share_path),
+                valid_users=["admin user"],
+            )
+
+    def test_restart_failure_restores_previous_live_config(self):
+        runtime = SimpleNamespace(
+            samba_dir=self.root / "real-samba",
+            samba_backup_dir=self.root / "real-samba-backups",
+            is_fake=False,
+        )
+        runtime.samba_dir.mkdir(parents=True, exist_ok=True)
+        runtime.samba_backup_dir.mkdir(parents=True, exist_ok=True)
+        manager = smb_manager.SMBManager(runtime=runtime)
+        live_path = runtime.samba_dir / "smb.conf"
+        original_content = "[global]\n   workgroup = WORKGROUP\n"
+        live_path.write_text(original_content)
+
+        share_path = self.root / "real-share"
+        share_path.mkdir()
+        backup_path = runtime.samba_backup_dir / "smb.conf.backup.test"
+
+        def fake_backup():
+            backup_path.write_text(live_path.read_text())
+            return str(backup_path)
+
+        with patch.object(manager, "_create_backup", side_effect=fake_backup):
+            with patch.object(manager, "_validate_smb_conf_candidate", return_value=None):
+                with patch.object(manager, "_restart_services", side_effect=[False, True]):
+                    with self.assertRaisesRegex(RuntimeError, "Failed to restart SMB services"):
+                        manager.create_managed_share("backup", str(share_path))
+
+        self.assertEqual(live_path.read_text(), original_content)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_smb_manager.py
+++ b/tests/test_smb_manager.py
@@ -81,6 +81,22 @@ class SMBManagerTests(unittest.TestCase):
         with self.assertRaises(smb_manager.SMBConfigError):
             self.manager.list_managed_shares()
 
+    def test_stray_end_marker_raises_clear_error(self):
+        self._write_conf(
+            "\n".join(
+                [
+                    "[global]",
+                    "   workgroup = WORKGROUP",
+                    "",
+                    "# END SimpleSaferServer share: backup",
+                    "",
+                ]
+            )
+        )
+
+        with self.assertRaisesRegex(smb_manager.SMBConfigError, "END marker"):
+            self.manager.list_managed_shares()
+
     def test_create_managed_share_writes_wrapped_block(self):
         share_path = self.root / "share"
         share_path.mkdir()
@@ -316,6 +332,35 @@ class SMBManagerTests(unittest.TestCase):
             with patch.object(manager, "_validate_smb_conf_candidate", return_value=None):
                 with patch.object(manager, "_restart_services", side_effect=[False, True]):
                     with self.assertRaisesRegex(RuntimeError, "Failed to restart SMB services"):
+                        manager.create_managed_share("backup", str(share_path))
+
+        self.assertEqual(live_path.read_text(), original_content)
+
+    def test_rollback_restart_failure_raises_rollback_error(self):
+        runtime = SimpleNamespace(
+            samba_dir=self.root / "rollback-samba",
+            samba_backup_dir=self.root / "rollback-samba-backups",
+            is_fake=False,
+        )
+        runtime.samba_dir.mkdir(parents=True, exist_ok=True)
+        runtime.samba_backup_dir.mkdir(parents=True, exist_ok=True)
+        manager = smb_manager.SMBManager(runtime=runtime)
+        live_path = runtime.samba_dir / "smb.conf"
+        original_content = "[global]\n   workgroup = WORKGROUP\n"
+        live_path.write_text(original_content)
+
+        share_path = self.root / "rollback-share"
+        share_path.mkdir()
+        backup_path = runtime.samba_backup_dir / "smb.conf.backup.rollback"
+
+        def fake_backup():
+            backup_path.write_text(live_path.read_text())
+            return str(backup_path)
+
+        with patch.object(manager, "_create_backup", side_effect=fake_backup):
+            with patch.object(manager, "_validate_smb_conf_candidate", return_value=None):
+                with patch.object(manager, "_restart_services", side_effect=[False, False]):
+                    with self.assertRaisesRegex(RuntimeError, "Failed to roll back smb.conf"):
                         manager.create_managed_share("backup", str(share_path))
 
         self.assertEqual(live_path.read_text(), original_content)

--- a/tests/test_smb_manager.py
+++ b/tests/test_smb_manager.py
@@ -240,6 +240,34 @@ class SMBManagerTests(unittest.TestCase):
                 valid_users=["admin user"],
             )
 
+    def test_create_managed_share_rejects_string_valid_users_input(self):
+        share_path = self.root / "share-string-users"
+        share_path.mkdir()
+
+        with self.assertRaisesRegex(ValueError, "valid_users must be a sequence of usernames"):
+            self.manager.create_managed_share(
+                "backup",
+                str(share_path),
+                valid_users="admin",
+            )
+
+    def test_get_share_users_rejects_unmanaged_share(self):
+        share_path = self.root / "unmanaged-share"
+        share_path.mkdir()
+        self._write_conf(
+            "\n".join(
+                [
+                    "[media]",
+                    f"   path = {share_path}",
+                    "   guest ok = yes",
+                    "",
+                ]
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "is not managed by SimpleSaferServer"):
+            self.manager.get_share_users("media")
+
     def test_restart_failure_restores_previous_live_config(self):
         runtime = SimpleNamespace(
             samba_dir=self.root / "real-samba",

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -22,6 +22,14 @@ class UninstallScriptTests(unittest.TestCase):
             raise AssertionError(result.stderr or result.stdout)
         return result.stdout
 
+    def run_bash_raw(self, snippet):
+        return subprocess.run(
+            ["bash", "-lc", snippet],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
     def test_collect_samba_users_reads_current_users_json_shape(self):
         with tempfile.TemporaryDirectory() as tempdir:
             users_path = Path(tempdir) / "users.json"
@@ -104,6 +112,38 @@ class UninstallScriptTests(unittest.TestCase):
         self.assertNotIn("[backup]", content)
         self.assertIn("[media]", content)
         self.assertIn("guest ok = yes", content)
+
+    def test_cleanup_managed_smb_shares_rejects_malformed_markers(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            smb_conf_path = Path(tempdir) / "smb.conf"
+            original = textwrap.dedent(
+                """\
+                [global]
+                   workgroup = WORKGROUP
+
+                  # BEGIN SimpleSaferServer share: backup
+                [backup]
+                   path = /media/backup
+                  # END SimpleSaferServer share: media
+                """
+            )
+            smb_conf_path.write_text(original)
+
+            result = self.run_bash_raw(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    SMB_CONF="{smb_conf_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            content = smb_conf_path.read_text()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("markers are malformed", result.stdout)
+        self.assertEqual(content, original)
 
 
 if __name__ == "__main__":

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -47,6 +47,23 @@ class UninstallScriptTests(unittest.TestCase):
 
         self.assertEqual(output.strip().splitlines(), ["alice", "bob"])
 
+    def test_collect_samba_users_fails_on_invalid_json(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            users_path = Path(tempdir) / "users.json"
+            users_path.write_text("{ definitely not valid json")
+
+            result = self.run_bash_raw(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    USERS_FILE="{users_path}"
+                    collect_samba_users
+                    """
+                )
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+
     def test_remove_managed_fstab_entries_only_removes_tagged_lines(self):
         with tempfile.TemporaryDirectory() as tempdir:
             fstab_path = Path(tempdir) / "fstab"
@@ -112,6 +129,34 @@ class UninstallScriptTests(unittest.TestCase):
         self.assertNotIn("[backup]", content)
         self.assertIn("[media]", content)
         self.assertIn("guest ok = yes", content)
+
+    def test_cleanup_managed_smb_shares_allows_empty_result_when_only_managed_blocks_exist(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            smb_conf_path = Path(tempdir) / "smb.conf"
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    """\
+                    # BEGIN SimpleSaferServer share: backup
+                    [backup]
+                       path = /media/backup
+                    # END SimpleSaferServer share: backup
+                    """
+                )
+            )
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    SMB_CONF="{smb_conf_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            content = smb_conf_path.read_text()
+
+        self.assertEqual(content, "")
 
     def test_cleanup_managed_smb_shares_rejects_malformed_markers(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,110 @@
+import json
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UNINSTALL_SCRIPT = REPO_ROOT / "uninstall.sh"
+
+
+class UninstallScriptTests(unittest.TestCase):
+    def run_bash(self, snippet):
+        result = subprocess.run(
+            ["bash", "-lc", snippet],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(result.stderr or result.stdout)
+        return result.stdout
+
+    def test_collect_samba_users_reads_current_users_json_shape(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            users_path = Path(tempdir) / "users.json"
+            users_path.write_text(json.dumps({"alice": {"is_admin": True}, "bob": {"is_admin": False}}))
+
+            output = self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    USERS_FILE="{users_path}"
+                    collect_samba_users
+                    """
+                )
+            )
+
+        self.assertEqual(output.strip().splitlines(), ["alice", "bob"])
+
+    def test_remove_managed_fstab_entries_only_removes_tagged_lines(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            fstab_path = Path(tempdir) / "fstab"
+            fstab_path.write_text(
+                textwrap.dedent(
+                    """\
+                    # comment
+                    UUID=keep /mnt/keep ext4 defaults 0 2
+                    UUID=drop /media/backup ntfs-3g defaults,nofail 0 0 # SimpleSaferServer managed backup drive
+                    UUID=legacy /media/legacy ntfs-3g defaults 0 0 # SimpleSaferServer
+                    """
+                )
+            )
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    remove_managed_fstab_entries "{fstab_path}"
+                    """
+                )
+            )
+
+            content = fstab_path.read_text()
+
+        self.assertIn("UUID=keep /mnt/keep ext4 defaults 0 2", content)
+        self.assertNotIn("UUID=drop /media/backup", content)
+        self.assertNotIn("UUID=legacy /media/legacy", content)
+
+    def test_cleanup_managed_smb_shares_leaves_unmanaged_blocks(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            smb_conf_path = Path(tempdir) / "smb.conf"
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    """\
+                    [global]
+                       workgroup = WORKGROUP
+
+                    # BEGIN SimpleSaferServer share: backup
+                    [backup]
+                       path = /media/backup
+                    # END SimpleSaferServer share: backup
+
+                    [media]
+                       path = /srv/media
+                       guest ok = yes
+                    """
+                )
+            )
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    SMB_CONF="{smb_conf_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            content = smb_conf_path.read_text()
+
+        self.assertNotIn("[backup]", content)
+        self.assertIn("[media]", content)
+        self.assertIn("guest ok = yes", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -u
+
 # Color codes
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -7,153 +9,268 @@ YELLOW='\033[1;33m'
 BLUE='\033[1;34m'
 NC='\033[0m' # No Color
 
-clear
-echo -e "${BLUE}==============================================="
-echo -e "   SimpleSaferServer Uninstaller"
-echo -e "===============================================${NC}\n"
-
-# Check if running as root
-if [ "$EUID" -ne 0 ]; then 
-    echo -e "${RED}ERROR:${NC} Please run as root (sudo)"
-    exit 1
-fi
-
-echo "Starting SimpleSaferServer uninstallation..."
-
-# Create backup of current smb.conf before uninstalling
+APP_DIR="/opt/SimpleSaferServer"
+CONFIG_DIR="/etc/SimpleSaferServer"
+USERS_FILE="$CONFIG_DIR/users.json"
+DATA_DIR="/var/lib/SimpleSaferServer"
+LOG_DIR="/var/log/SimpleSaferServer"
+SYSTEMD_DIR="/etc/systemd/system"
 SMB_CONF="/etc/samba/smb.conf"
-if [ -f "$SMB_CONF" ]; then
-    TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-    CURRENT_BACKUP="/etc/samba/smb.conf.uninstall_backup.${TIMESTAMP}"
-    echo "Creating backup of current smb.conf: $CURRENT_BACKUP"
-    cp "$SMB_CONF" "$CURRENT_BACKUP"
-    echo "Backup created successfully."
+TMP_DIR=""
+FSTAB_MARKER="SimpleSaferServer managed backup drive"
+LEGACY_FSTAB_MARKER="SimpleSaferServer"
+MANAGED_SHARE_BEGIN_PREFIX="# BEGIN SimpleSaferServer share: "
+MANAGED_SHARE_END_PREFIX="# END SimpleSaferServer share: "
+SCRIPT_FILES=(
+  check_mount.sh
+  check_health.sh
+  check_health.py
+  backup_cloud.sh
+  predict_health.py
+  log_alert.py
+  import_legacy.py
+)
+
+# The installer writes rclone config where the root-owned scheduled tasks can
+# read it later, so the uninstaller needs to look there instead of under /etc.
+ROOT_HOME="$(getent passwd root 2>/dev/null | cut -d: -f6)"
+if [ -z "$ROOT_HOME" ]; then
+    ROOT_HOME="/root"
 fi
+RCLONE_CONFIG_DIR="$ROOT_HOME/.config/rclone"
+RCLONE_CONFIG_PATH="$RCLONE_CONFIG_DIR/rclone.conf"
 
-# Stop and disable background systemd services and timers
-for svc in check_mount check_health backup_cloud; do
-    echo "Stopping and disabling $svc.service and $svc.timer..."
-    systemctl stop ${svc}.timer 2>/dev/null
-    systemctl stop ${svc}.service 2>/dev/null
-    systemctl disable ${svc}.timer 2>/dev/null
-    systemctl disable ${svc}.service 2>/dev/null
-    rm -f /etc/systemd/system/${svc}.service
-    rm -f /etc/systemd/system/${svc}.timer
-    echo "$svc.service and $svc.timer removed."
-done
-
-# Stop and remove the web UI systemd service
-WEB_SERVICE="simple_safer_server_web.service"
-echo "Stopping and disabling $WEB_SERVICE..."
-systemctl stop $WEB_SERVICE 2>/dev/null
-systemctl disable $WEB_SERVICE 2>/dev/null
-rm -f /etc/systemd/system/$WEB_SERVICE
-
-# Clean up SMB configuration
-echo "Cleaning up SMB configuration..."
-if [ -f "$SMB_CONF" ]; then
-    # Remove SimpleSaferServer shares and configurations
-    echo "Removing SimpleSaferServer shares and configurations..."
-    
-    # Create a clean version without SimpleSaferServer blocks
-    awk '
-    /^# BEGIN SimpleSaferServer$/ { in_block = 1; next }
-    /^# END SimpleSaferServer$/ { in_block = 0; next }
-    !in_block { print }
-    ' "$SMB_CONF" > /tmp/smb.conf.clean
-    
-    # Also remove any standalone SimpleSaferServer shares that might exist
-    # (in case the new SMB manager was used)
-    awk '
-    /^\[backup\]$/ { in_share = 1; next }
-    /^\[.*\]$/ { in_share = 0; print; next }
-    !in_share { print }
-    ' /tmp/smb.conf.clean > /tmp/smb.conf.final
-    
-    # Restore the default 'map to guest = bad user' if it was removed
-    if ! grep -q "map to guest = bad user" /tmp/smb.conf.final; then
-        # Find the [global] section and add the default line after it
-        sed '/^\[global\]$/a\   map to guest = bad user' /tmp/smb.conf.final > /tmp/smb.conf.restored
-        mv /tmp/smb.conf.restored /tmp/smb.conf.final
+setup_temp_dir() {
+    if [ -z "$TMP_DIR" ]; then
+        TMP_DIR="$(mktemp -d)"
     fi
-    
-    mv /tmp/smb.conf.final "$SMB_CONF"
-    echo "SimpleSaferServer configurations removed from smb.conf."
-    
-    # Restart SMB services
-    echo "Restarting SMB services..."
-    systemctl restart smbd 2>/dev/null
-    systemctl restart nmbd 2>/dev/null
-    echo "SMB services restarted."
-fi
+}
 
-# Remove scripts from /opt/SimpleSaferServer/scripts/
-echo "Removing scripts from /opt/SimpleSaferServer/scripts..."
-for script in check_mount.sh check_health.sh backup_cloud.sh predict_health.py log_alert.py; do
-  rm -f /opt/SimpleSaferServer/scripts/$script
-  echo "/opt/SimpleSaferServer/scripts/$script removed."
-done
+cleanup() {
+    if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
+        rm -rf "$TMP_DIR"
+    fi
+    TMP_DIR=""
+}
 
-# Remove model files from legacy and new locations
-rm -f /usr/local/bin/xgb_model.json
-rm -f /usr/local/bin/optimal_threshold_xgb.pkl
-echo "/usr/local/bin/xgb_model.json and /usr/local/bin/optimal_threshold_xgb.pkl removed if present."
-echo "Removing /opt/SimpleSaferServer/harddrive_model/ and its contents..."
-if [ -d /opt/SimpleSaferServer/harddrive_model ]; then
-    rm -rf /opt/SimpleSaferServer/harddrive_model
-    echo "/opt/SimpleSaferServer/harddrive_model/ removed."
-else
-    echo "/opt/SimpleSaferServer/harddrive_model/ not found."
-fi
+collect_samba_users() {
+    if [ ! -f "$USERS_FILE" ]; then
+        return 0
+    fi
 
-# Remove the application directory
-echo "Removing application files..."
-rm -rf /opt/SimpleSaferServer
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$USERS_FILE" <<'PY'
+import json
+import sys
 
-# Remove configuration files
-echo "Removing configuration files..."
-rm -rf /etc/SimpleSaferServer
+path = sys.argv[1]
 
-# Remove user data
-echo "Removing user data..."
-rm -rf /var/lib/SimpleSaferServer
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    raise SystemExit(0)
 
-# Remove log files
-echo "Removing log files..."
-rm -rf /var/log/SimpleSaferServer
+if isinstance(data, dict):
+    for username in data.keys():
+        if isinstance(username, str) and username.strip():
+            print(username)
+elif isinstance(data, list):
+    for item in data:
+        if isinstance(item, dict):
+            username = item.get("username")
+            if isinstance(username, str) and username.strip():
+                print(username)
+PY
+        return 0
+    fi
 
-# Remove Python virtual environment (legacy support)
-echo "Removing Python virtual environment..."
-rm -rf /opt/SimpleSaferServer/venv
+    # Keep a low-tech fallback because older recovery environments sometimes
+    # have Samba installed but not a working Python runtime.
+    sed -n 's/^[[:space:]]*"\([^"]\+\)"[[:space:]]*:.*/\1/p' "$USERS_FILE"
+}
 
-# Remove the user (legacy, safe to keep)
-echo "Removing SimpleSaferServer user..."
-userdel -r SimpleSaferServer 2>/dev/null
+backup_file_if_present() {
+    local path="$1"
+    local label="$2"
+    local timestamp=""
+    local backup_path=""
 
-echo "Removing SimpleSaferServer group..."
-groupdel SimpleSaferServer 2>/dev/null
+    if [ ! -f "$path" ]; then
+        return 0
+    fi
 
-# Remove SimpleSaferServer users from Samba
-echo "Removing SimpleSaferServer users from Samba..."
-# Get list of users from the JSON file if it exists
-if [ -f "/etc/SimpleSaferServer/users.json" ]; then
-    # Extract usernames from the JSON file and remove them from Samba
-    grep -o '"username": "[^"]*"' /etc/SimpleSaferServer/users.json | cut -d'"' -f4 | while read username; do
-        echo "Removing Samba user: $username"
-        smbpasswd -x "$username" 2>/dev/null || true
+    timestamp=$(date +"%Y%m%d_%H%M%S")
+    backup_path="${path}.${label}.${timestamp}"
+    cp "$path" "$backup_path"
+    echo "Created backup: $backup_path"
+}
+
+remove_systemd_unit() {
+    local unit="$1"
+
+    systemctl stop "$unit" 2>/dev/null || true
+    systemctl disable "$unit" 2>/dev/null || true
+    rm -f "$SYSTEMD_DIR/$unit"
+}
+
+remove_managed_fstab_entries() {
+    local original="${1:-/etc/fstab}"
+    local updated=""
+
+    setup_temp_dir
+    updated="$TMP_DIR/fstab.updated"
+
+    if [ ! -f "$original" ]; then
+        return 0
+    fi
+
+    echo "Removing SimpleSaferServer-managed /etc/fstab entries..."
+    backup_file_if_present "$original" "uninstall_backup"
+
+    awk -v marker="$FSTAB_MARKER" -v legacy="$LEGACY_FSTAB_MARKER" '
+    function trim(value) {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+        return value
+    }
+
+    {
+        if ($0 ~ /^[[:space:]]*#/ || index($0, "#") == 0) {
+            print
+            next
+        }
+
+        comment = trim(substr($0, index($0, "#") + 1))
+        if (comment == marker || comment == legacy) {
+            next
+        }
+
+        print
+    }
+    ' "$original" > "$updated"
+
+    mv "$updated" "$original"
+    chmod 644 "$original"
+}
+
+cleanup_managed_smb_shares() {
+    local cleaned=""
+
+    if [ ! -f "$SMB_CONF" ]; then
+        return 0
+    fi
+
+    setup_temp_dir
+    cleaned="$TMP_DIR/smb.conf.cleaned"
+
+    echo "Removing SimpleSaferServer-managed Samba shares..."
+    backup_file_if_present "$SMB_CONF" "uninstall_backup"
+
+    awk -v begin_prefix="$MANAGED_SHARE_BEGIN_PREFIX" -v end_prefix="$MANAGED_SHARE_END_PREFIX" '
+    BEGIN {
+        in_managed_share = 0
+    }
+
+    {
+        if (index($0, begin_prefix) == 1) {
+            in_managed_share = 1
+            next
+        }
+
+        if (index($0, end_prefix) == 1) {
+            in_managed_share = 0
+            next
+        }
+
+        if (!in_managed_share) {
+            print
+        }
+    }
+    ' "$SMB_CONF" > "$cleaned"
+
+    mv "$cleaned" "$SMB_CONF"
+    chmod 644 "$SMB_CONF"
+    systemctl restart smbd 2>/dev/null || true
+    systemctl restart nmbd 2>/dev/null || true
+}
+
+main() {
+    trap cleanup EXIT
+    setup_temp_dir
+
+    clear
+    echo -e "${BLUE}==============================================="
+    echo -e "   SimpleSaferServer Uninstaller"
+    echo -e "===============================================${NC}\n"
+
+    if [ "$EUID" -ne 0 ]; then
+        echo -e "${RED}ERROR:${NC} Please run as root (sudo)"
+        exit 1
+    fi
+
+    echo "Starting SimpleSaferServer uninstallation..."
+
+    echo "Stopping and disabling systemd units..."
+    for svc in check_mount check_health backup_cloud; do
+        remove_systemd_unit "${svc}.timer"
+        remove_systemd_unit "${svc}.service"
     done
+    remove_systemd_unit "simple_safer_server_web.service"
+
+    remove_managed_fstab_entries
+    cleanup_managed_smb_shares
+
+    echo "Removing installed helper scripts..."
+    for script in "${SCRIPT_FILES[@]}"; do
+        rm -f "$APP_DIR/scripts/$script"
+        rm -f "/usr/local/bin/$script"
+        echo "Removed helper script if present: $script"
+    done
+
+    echo "Removing installed binary and legacy model artifacts..."
+    rm -f /usr/local/bin/hdsentinel
+    rm -f /usr/local/bin/xgb_model.json
+    rm -f /usr/local/bin/optimal_threshold_xgb.pkl
+    rm -rf "$APP_DIR/harddrive_model"
+
+    # Gather Samba usernames before deleting the config directory because the
+    # app stores the source of truth in users.json rather than in a manifest.
+    mapfile -t SAMBA_USERS < <(collect_samba_users)
+    if [ "${#SAMBA_USERS[@]}" -gt 0 ]; then
+        echo "Removing SimpleSaferServer users from Samba..."
+        for username in "${SAMBA_USERS[@]}"; do
+            echo "Removing Samba user: $username"
+            smbpasswd -x "$username" 2>/dev/null || true
+        done
+    else
+        echo "No SimpleSaferServer Samba users found in $USERS_FILE."
+    fi
+
+    echo "Removing application files and data..."
+    rm -rf "$APP_DIR"
+    rm -rf "$CONFIG_DIR"
+    rm -rf "$DATA_DIR"
+    rm -rf "$LOG_DIR"
+
+    echo "Removing SimpleSaferServer rclone configuration if present..."
+    rm -f "$RCLONE_CONFIG_PATH"
+    rmdir "$RCLONE_CONFIG_DIR" 2>/dev/null || true
+
+    echo "Removing legacy SimpleSaferServer user and group if present..."
+    userdel -r SimpleSaferServer 2>/dev/null || true
+    groupdel SimpleSaferServer 2>/dev/null || true
+
+    echo "Reloading systemd..."
+    systemctl daemon-reload 2>/dev/null || true
+
+    echo -e "${GREEN}Uninstallation complete!${NC}"
+    echo "SimpleSaferServer application files, services, timers, data, and managed mount entries have been removed."
+    echo "Shared system packages such as Samba, Python, and rclone were left installed."
+    echo "Samba user accounts created from SimpleSaferServer users were removed."
+    echo "Marker-wrapped SimpleSaferServer-managed Samba share blocks were removed from $SMB_CONF."
+    echo "Unmanaged or legacy untagged Samba share blocks were left untouched."
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    main "$@"
 fi
-
-# Remove any fstab entries related to SimpleSaferServer
-echo "Removing fstab entries..."
-# Create a temporary file without the SimpleSaferServer entries
-grep -v "SimpleSaferServer" /etc/fstab > /tmp/fstab.new
-# Replace the original fstab with the new one
-mv /tmp/fstab.new /etc/fstab
-
-# Reload systemd
-echo "Reloading systemd..."
-systemctl daemon-reload
-
-echo "Uninstallation complete!"
-echo "You can now run the install.sh script again to reinstall SimpleSaferServer." 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -16,7 +16,6 @@ DATA_DIR="/var/lib/SimpleSaferServer"
 LOG_DIR="/var/log/SimpleSaferServer"
 SYSTEMD_DIR="/etc/systemd/system"
 SMB_CONF="/etc/samba/smb.conf"
-TMP_DIR=""
 FSTAB_MARKER="SimpleSaferServer managed backup drive"
 LEGACY_FSTAB_MARKER="SimpleSaferServer"
 MANAGED_SHARE_BEGIN_PREFIX="# BEGIN SimpleSaferServer share: "
@@ -33,29 +32,34 @@ SCRIPT_FILES=(
 
 # The installer writes rclone config where the root-owned scheduled tasks can
 # read it later, so the uninstaller needs to look there instead of under /etc.
-ROOT_HOME="$(getent passwd root 2>/dev/null | cut -d: -f6)"
+ROOT_HOME=""
+if command -v getent >/dev/null 2>&1; then
+    ROOT_HOME="$(getent passwd root 2>/dev/null | cut -d: -f6 || true)"
+fi
 if [ -z "$ROOT_HOME" ]; then
     ROOT_HOME="/root"
 fi
 RCLONE_CONFIG_DIR="$ROOT_HOME/.config/rclone"
 RCLONE_CONFIG_PATH="$RCLONE_CONFIG_DIR/rclone.conf"
 
-setup_temp_dir() {
-    if [ -z "$TMP_DIR" ]; then
-        TMP_DIR="$(mktemp -d)"
-    fi
-}
+make_atomic_temp_file() {
+    local target_path="$1"
+    local target_dir=""
+    local target_name=""
 
-cleanup() {
-    if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
-        rm -rf "$TMP_DIR"
-    fi
-    TMP_DIR=""
+    target_dir="$(dirname -- "$target_path")"
+    target_name="$(basename -- "$target_path")"
+    mktemp "${target_dir}/.${target_name}.XXXXXX"
 }
 
 collect_samba_users() {
     if [ ! -f "$USERS_FILE" ]; then
         return 0
+    fi
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "ERROR: python3 is required to read $USERS_FILE during uninstall." >&2
+        return 1
     fi
 
     python3 - "$USERS_FILE" <<'PY'
@@ -68,7 +72,7 @@ try:
     with open(path, "r", encoding="utf-8") as handle:
         data = json.load(handle)
 except Exception:
-    raise SystemExit(0)
+    raise SystemExit(1)
 
 if isinstance(data, dict):
     for username in data.keys():
@@ -111,12 +115,11 @@ remove_managed_fstab_entries() {
     local original="${1:-/etc/fstab}"
     local updated=""
 
-    setup_temp_dir
-    updated="$TMP_DIR/fstab.updated"
-
     if [ ! -f "$original" ]; then
         return 0
     fi
+
+    updated="$(make_atomic_temp_file "$original")"
 
     echo "Removing SimpleSaferServer-managed /etc/fstab entries..."
     backup_file_if_present "$original" "uninstall_backup"
@@ -146,9 +149,8 @@ remove_managed_fstab_entries() {
         return 1
     fi
 
-    # Refuse to replace core system files only if the filtering step failed to
-    # produce the temporary output file at all. An empty file is valid when all
-    # entries were SimpleSaferServer-managed and have been removed.
+    # Allow intentionally empty results, but never replace a core config with a
+    # missing temp file if the rewrite step failed before producing output.
     if [ ! -f "$updated" ]; then
         rm -f "$updated"
         echo "ERROR: Refusing to replace $original because the generated file is missing."
@@ -174,8 +176,7 @@ cleanup_managed_smb_shares() {
         return 0
     fi
 
-    setup_temp_dir
-    cleaned="$TMP_DIR/smb.conf.cleaned"
+    cleaned="$(make_atomic_temp_file "$SMB_CONF")"
 
     echo "Removing SimpleSaferServer-managed Samba shares..."
     backup_file_if_present "$SMB_CONF" "uninstall_backup"
@@ -240,11 +241,11 @@ cleanup_managed_smb_shares() {
         return 1
     fi
 
-    # Keep the live Samba config untouched if the cleaned candidate was not
-    # produced as expected.
-    if [ ! -s "$cleaned" ]; then
+    # Allow smb.conf to become empty if every block was owned by
+    # SimpleSaferServer, but never replace it with a missing temp file.
+    if [ ! -f "$cleaned" ]; then
         rm -f "$cleaned"
-        echo "ERROR: Refusing to replace $SMB_CONF because the generated file is missing or empty."
+        echo "ERROR: Refusing to replace $SMB_CONF because the generated file is missing."
         return 1
     fi
 
@@ -264,9 +265,6 @@ cleanup_managed_smb_shares() {
 }
 
 main() {
-    trap cleanup EXIT
-    setup_temp_dir
-
     echo -e "${BLUE}==============================================="
     echo -e "   SimpleSaferServer Uninstaller"
     echo -e "===============================================${NC}\n"
@@ -303,7 +301,16 @@ main() {
 
     # Gather Samba usernames before deleting the config directory because the
     # app stores the source of truth in users.json rather than in a manifest.
-    mapfile -t SAMBA_USERS < <(collect_samba_users)
+    local samba_users_output=""
+    local -a SAMBA_USERS=()
+    if ! samba_users_output="$(collect_samba_users)"; then
+        echo "ERROR: Failed to read SimpleSaferServer users from $USERS_FILE."
+        exit 1
+    fi
+    if [ -n "$samba_users_output" ]; then
+        mapfile -t SAMBA_USERS <<< "$samba_users_output"
+    fi
+
     if [ "${#SAMBA_USERS[@]}" -gt 0 ]; then
         echo "Removing SimpleSaferServer users from Samba..."
         for username in "${SAMBA_USERS[@]}"; do

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -euo pipefail
 
 # Color codes
 RED='\033[0;31m'
@@ -128,7 +128,7 @@ remove_managed_fstab_entries() {
     echo "Removing SimpleSaferServer-managed /etc/fstab entries..."
     backup_file_if_present "$original" "uninstall_backup"
 
-    awk -v marker="$FSTAB_MARKER" -v legacy="$LEGACY_FSTAB_MARKER" '
+    if ! awk -v marker="$FSTAB_MARKER" -v legacy="$LEGACY_FSTAB_MARKER" '
     function trim(value) {
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
         return value
@@ -147,10 +147,30 @@ remove_managed_fstab_entries() {
 
         print
     }
-    ' "$original" > "$updated"
+    ' "$original" > "$updated"; then
+        rm -f "$updated"
+        echo "ERROR: Failed to rebuild $original while removing SimpleSaferServer-managed entries."
+        return 1
+    fi
 
-    mv "$updated" "$original"
-    chmod 644 "$original"
+    # Refuse to replace core system files with missing or empty temp output if
+    # the filtering step broke unexpectedly.
+    if [ ! -s "$updated" ]; then
+        rm -f "$updated"
+        echo "ERROR: Refusing to replace $original because the generated file is missing or empty."
+        return 1
+    fi
+
+    if ! mv "$updated" "$original"; then
+        rm -f "$updated"
+        echo "ERROR: Failed to replace $original."
+        return 1
+    fi
+
+    if ! chmod 644 "$original"; then
+        echo "ERROR: Failed to set permissions on $original."
+        return 1
+    fi
 }
 
 cleanup_managed_smb_shares() {
@@ -226,8 +246,25 @@ cleanup_managed_smb_shares() {
         return 1
     fi
 
-    mv "$cleaned" "$SMB_CONF"
-    chmod 644 "$SMB_CONF"
+    # Keep the live Samba config untouched if the cleaned candidate was not
+    # produced as expected.
+    if [ ! -s "$cleaned" ]; then
+        rm -f "$cleaned"
+        echo "ERROR: Refusing to replace $SMB_CONF because the generated file is missing or empty."
+        return 1
+    fi
+
+    if ! mv "$cleaned" "$SMB_CONF"; then
+        rm -f "$cleaned"
+        echo "ERROR: Failed to replace $SMB_CONF."
+        return 1
+    fi
+
+    if ! chmod 644 "$SMB_CONF"; then
+        echo "ERROR: Failed to set permissions on $SMB_CONF."
+        return 1
+    fi
+
     systemctl restart smbd 2>/dev/null || true
     systemctl restart nmbd 2>/dev/null || true
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -58,8 +58,7 @@ collect_samba_users() {
         return 0
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
-        python3 - "$USERS_FILE" <<'PY'
+    python3 - "$USERS_FILE" <<'PY'
 import json
 import sys
 
@@ -82,12 +81,6 @@ elif isinstance(data, list):
             if isinstance(username, str) and username.strip():
                 print(username)
 PY
-        return 0
-    fi
-
-    # Keep a low-tech fallback because older recovery environments sometimes
-    # have Samba installed but not a working Python runtime.
-    sed -n 's/^[[:space:]]*"\([^"]\+\)"[[:space:]]*:.*/\1/p' "$USERS_FILE"
 }
 
 backup_file_if_present() {
@@ -273,7 +266,6 @@ main() {
     trap cleanup EXIT
     setup_temp_dir
 
-    clear
     echo -e "${BLUE}==============================================="
     echo -e "   SimpleSaferServer Uninstaller"
     echo -e "===============================================${NC}\n"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -146,11 +146,12 @@ remove_managed_fstab_entries() {
         return 1
     fi
 
-    # Refuse to replace core system files with missing or empty temp output if
-    # the filtering step broke unexpectedly.
-    if [ ! -s "$updated" ]; then
+    # Refuse to replace core system files only if the filtering step failed to
+    # produce the temporary output file at all. An empty file is valid when all
+    # entries were SimpleSaferServer-managed and have been removed.
+    if [ ! -f "$updated" ]; then
         rm -f "$updated"
-        echo "ERROR: Refusing to replace $original because the generated file is missing or empty."
+        echo "ERROR: Refusing to replace $original because the generated file is missing."
         return 1
     fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -166,19 +166,42 @@ cleanup_managed_smb_shares() {
     echo "Removing SimpleSaferServer-managed Samba shares..."
     backup_file_if_present "$SMB_CONF" "uninstall_backup"
 
-    awk -v begin_prefix="$MANAGED_SHARE_BEGIN_PREFIX" -v end_prefix="$MANAGED_SHARE_END_PREFIX" '
+    if ! awk -v begin_prefix="$MANAGED_SHARE_BEGIN_PREFIX" -v end_prefix="$MANAGED_SHARE_END_PREFIX" '
     BEGIN {
         in_managed_share = 0
+        current_share_name = ""
+        bad = 0
     }
 
     {
-        if (index($0, begin_prefix) == 1) {
+        line = $0
+        sub(/^[[:space:]]+/, "", line)
+
+        if (index(line, begin_prefix) == 1) {
+            share_name = substr(line, length(begin_prefix) + 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", share_name)
+
+            if (in_managed_share || share_name == "") {
+                bad = 1
+                exit 1
+            }
+
             in_managed_share = 1
+            current_share_name = share_name
             next
         }
 
-        if (index($0, end_prefix) == 1) {
+        if (index(line, end_prefix) == 1) {
+            share_name = substr(line, length(end_prefix) + 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", share_name)
+
+            if (!in_managed_share || share_name == "" || share_name != current_share_name) {
+                bad = 1
+                exit 1
+            }
+
             in_managed_share = 0
+            current_share_name = ""
             next
         }
 
@@ -186,7 +209,22 @@ cleanup_managed_smb_shares() {
             print
         }
     }
+
+    END {
+        if (in_managed_share) {
+            bad = 1
+        }
+
+        if (bad) {
+            exit 1
+        }
+    }
     ' "$SMB_CONF" > "$cleaned"
+    then
+        rm -f "$cleaned"
+        echo "ERROR: Refusing to rewrite $SMB_CONF because the SimpleSaferServer share markers are malformed."
+        return 1
+    fi
 
     mv "$cleaned" "$SMB_CONF"
     chmod 644 "$SMB_CONF"
@@ -218,7 +256,7 @@ main() {
     remove_systemd_unit "simple_safer_server_web.service"
 
     remove_managed_fstab_entries
-    cleanup_managed_smb_shares
+    cleanup_managed_smb_shares || exit 1
 
     echo "Removing installed helper scripts..."
     for script in "${SCRIPT_FILES[@]}"; do


### PR DESCRIPTION
## Summary
- Introduce marker-wrapped, SimpleSaferServer-managed Samba share blocks so the app can safely identify, edit, and remove only its own shares.
- Update the network file sharing UI, API, setup flow, migration path, and backup-drive sync logic to use managed-share operations and detect unmanaged Samba shares.
- Expand uninstall behavior and documentation to make the ownership boundary explicit and avoid touching unmanaged or legacy Samba configuration.
- Add tests covering managed share parsing, conflict handling, setup flow behavior, uninstall cleanup, and backup share synchronization.

## Testing
- Ran/added unit coverage for `smb_manager` managed-share parsing and CRUD behavior.
- Ran/added unit coverage for setup wizard and legacy migration backup-share provisioning paths.
- Ran/added uninstall tests to verify managed Samba blocks are removed while unmanaged blocks are preserved.
- Not run: full integration or manual Samba service validation on a live system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI shows unmanaged Samba shares in a modal; management actions apply only to marker-wrapped shares.

* **Documentation**
  * Uninstall and file-sharing docs clarify what is removed vs preserved, document marker format and conversion steps, and warn about unmanaged-share behavior.

* **Bug Fixes / Reliability**
  * Safer, validated managed-share writes with atomic updates, clearer error guidance linking to docs, and improved backup-share handling.

* **Tests**
  * Added/updated tests for Samba parsing, managed-share CRUD, uninstall cleanup, and setup flows.

* **Chores**
  * Reworked uninstaller to marker-scoped, safer cleanup and backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->