### PR TITLE
Enable Nmbd by default, install wsdd2, fully rework smb file handling

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -5,7 +5,10 @@ The Dashboard is the main interface for monitoring and managing the system. It p
 ## Status Indicators
 Four cards display real-time status:
 - **Storage**: Shows drive connection status, used/total storage, and usage percentage.
-- **Network File Sharing**: Shows if network file sharing is enabled (SMB status).
+- **Network File Sharing**: Summarizes `smbd`, `nmbd`, and `wsdd2`. The tile is operational when
+  `smbd` is active and discovery services are either active or unavailable (not installed), partial
+  when `smbd` is active but at least one discovery service is inactive, and down
+  when `smbd` is not active.
 - **Hard Drive Health**: Shows the last drive-health summary remembered by the running web process.
   Dashboard load does not probe SMART or HDSentinel. Use the tile refresh button when you want a
   live drive-health probe. When both SMART failure risk and drive temperature are available, the

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -175,7 +175,7 @@ Manual recovery rules:
 - Update `/etc/SimpleSaferServer/config.conf` only if you know the correct `mount_point`, `uuid`, and `usb_id`.
 - Update only the SimpleSaferServer-managed `/etc/fstab` entry.
 - Run `sudo systemctl daemon-reload` after manually changing `/etc/fstab` so systemd forgets the old generated mount unit state.
-- If the mount point changes, also check `/etc/samba/smb.conf`.
+- If the mount point changes, also check `/etc/samba/simple_safer_server_shares.conf` (see [Network File Sharing](network_file_sharing.md)).
 - Do not modify unrelated `/etc/fstab` entries.
 - Back up `/etc/fstab` before editing it manually.
 
@@ -183,7 +183,8 @@ Important file locations:
 
 - App config: `/etc/SimpleSaferServer/config.conf`
 - Managed mount entry: `/etc/fstab`
-- Samba share config: `/etc/samba/smb.conf`
+- Samba main config: `/etc/samba/smb.conf` (includes SimpleSaferServer wiring)
+- Managed share config: `/etc/samba/simple_safer_server_shares.conf`
 
 Example managed `/etc/fstab` entry:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,6 +27,15 @@ curl -fsSL https://sss.chrismin13.com/install.sh | sudo bash -s -- --unsupported
 That override only bypasses the OS-family block. Missing APT/systemd tools, package install
 failures, and service setup failures still stop the install.
 
+The installer prepares SimpleSaferServer-owned Samba include files in `/etc/samba` and starts
+`smbd` as the required file-serving daemon. It also tries to enable `nmbd` for older Windows
+NetBIOS discovery and installs `wsdd2` when the package is available for modern Windows Network
+discovery. Discovery-service problems are reported in the installer summary but do not block Samba
+file serving when `smbd` is active. If `smbd` enable or start commands fail but the service is
+active afterward, the installer continues with a warning so you can fix reboot persistence or
+service state before relying on the server. If `smbd` is not active, the installer stops and points
+you to `systemctl status smbd` and `journalctl -u smbd --no-pager`.
+
 After the installer finishes, open the printed Web UI URL and complete the setup wizard.
 
 For step-by-step installation without the automated installer, use the

--- a/docs/manual_install.md
+++ b/docs/manual_install.md
@@ -8,6 +8,9 @@ This guide explains how to manually install SimpleSaferServer on a clean Debian 
 
 - Run `sudo apt-get update`.
 - Run `sudo apt-get install -y git python3 python3-pip python3-venv smartmontools samba msmtp rsync curl unzip fdisk ntfs-3g unattended-upgrades`.
+- Optionally run `sudo apt-get install -y wsdd2` for modern Windows Network discovery. Continue
+  without it if your distro release does not provide the package; `smbd` is the required
+  file-serving daemon, while `nmbd` and `wsdd2` are discovery helpers.
 
 ## 2. Install rclone
 
@@ -93,6 +96,23 @@ Install the extracted binary:
 
 ## 8. Set Up the Systemd Service
 
+- Prepare the SimpleSaferServer-owned Samba include layout before starting the web service:
+  ```bash
+  cd /opt/SimpleSaferServer
+  sudo ./venv/bin/python -c "import sys; sys.path.insert(0, '/opt/SimpleSaferServer'); from simple_safer_server.services.samba_layout import SambaLayoutService; SambaLayoutService().ensure_layout()"
+  ```
+  The explicit working directory and import path match the automated installer because the app is
+  copied into `/opt/SimpleSaferServer` rather than installed as a Python package.
+  This creates or refreshes `/etc/samba/simple_safer_server_globals.conf` and
+  `/etc/samba/simple_safer_server_shares.conf` without creating the default `backup` share. The Web
+  UI setup flow creates that share later after it knows the backup mount point.
+- Enable and start Samba file serving: `sudo systemctl enable smbd && sudo systemctl start smbd`.
+- Confirm `smbd` is active with `sudo systemctl is-active smbd`. Do not continue until it reports
+  `active`; SimpleSaferServer depends on this daemon to serve files.
+- Best-effort discovery services can be started with `sudo systemctl enable nmbd wsdd2` and
+  `sudo systemctl start nmbd wsdd2`. Warnings or inactive states for these services mean network
+  discovery may be degraded, but existing SMB clients can still connect directly when `smbd` is
+  active.
 - Copy `simple_safer_server_web.service` to `/etc/systemd/system/simple_safer_server_web.service`.
 - `simple_safer_server_web.service` runs the package module entrypoint with `ExecStart=/opt/SimpleSaferServer/venv/bin/python -m simple_safer_server --host=0.0.0.0 --port=5000 --no-debug`, so `/opt/SimpleSaferServer/venv` must exist before you start the service.
 - The module entrypoint is `simple_safer_server/__main__.py`; it starts the built-in Flask server path, so the `WEB_THREADS` variable has no effect on this systemd unit.

--- a/docs/network_file_sharing.md
+++ b/docs/network_file_sharing.md
@@ -4,12 +4,17 @@ The Network File Sharing page manages Samba shares and Samba service status.
 It also includes the server name. This is the name you'll use to find this
 server on your network. Scheduled task alert emails include it in the subject.
 
-SimpleSaferServer now distinguishes between two kinds of Samba shares:
+SimpleSaferServer distinguishes between two kinds of Samba shares:
 
-- **SimpleSaferServer-managed shares**: share blocks wrapped with explicit SimpleSaferServer ownership markers in `smb.conf`
-- **Unmanaged shares**: any non-system Samba share blocks that exist in `smb.conf` without those markers
+- **SimpleSaferServer-managed shares**: share sections in `/etc/samba/simple_safer_server_shares.conf`
+- **Unmanaged Samba Shares**: non-system shares Samba loads from the Effective Samba Config after
+  SimpleSaferServer-owned include blocks are excluded
 
 That ownership split matters because SimpleSaferServer only edits shares that it can identify safely.
+Use the Web UI for normal SimpleSaferServer share changes so the app can validate Samba, publish
+the owned file safely, and restart the required service path.
+If a publish fails after the owned shares file is replaced, SimpleSaferServer restores the previous
+owned shares file and restarts `smbd` so Samba is asked to return to the last known-good share set.
 
 ## What the Page Shows
 
@@ -17,28 +22,65 @@ That ownership split matters because SimpleSaferServer only edits shares that it
 - **Add Share**: creates a new SimpleSaferServer-managed share
 - **Edit Share**: updates a SimpleSaferServer-managed share
 - **Delete Share**: removes a SimpleSaferServer-managed share
-- **Unmanaged share warning**: appears when SimpleSaferServer detects other non-system Samba shares in `smb.conf`
+- **Unmanaged share warning**: appears when SimpleSaferServer detects other non-system Samba shares
+  in Samba's Effective Config, or when that Effective Config cannot be verified on page load
 - **Server Name**: changes the OS hostname, SimpleSaferServer's stored server name,
   and the local hostname entry used by the server itself
-- **Restart Services**: restarts `smbd` and `nmbd`
+- **Restart Services**: restarts `smbd`, `nmbd`, and `wsdd2`
   Restarting Samba disconnects anyone who is currently connected to a share, so active file copies or other SMB activity will drop.
+
+The technical service row tracks three file-sharing services:
+
+- `SMB Daemon (smbd)`: serves file shares
+- `NetBIOS Discovery (nmbd)`: helps older Windows network browsing find this server
+- `Windows Discovery (wsdd2)`: helps modern Windows network browsing find this server
+
+The overall status is `Operational` when `smbd` is active and both discovery services are either
+active or unavailable (not installed). It is `Partial` when `smbd` is active but at least one
+discovery service is inactive or in an error state. It is `Down` when `smbd`
+is not active, because direct file serving is unavailable.
 
 Changing the server name also restarts Samba discovery/services so the new name is
 advertised without rebooting. Connected file-sharing clients may need to reconnect.
 
-If unmanaged shares are detected, the page shows a small warning button with the count.
+If Unmanaged Samba Shares are detected, the page shows a small warning button with the count.
 That button opens a modal that:
 
 - lists the unmanaged share names
 - explains that SimpleSaferServer will not edit or remove them
 - links to this document for manual conversion guidance
 
+If the page cannot verify Unmanaged Samba Shares, it shows the same compact warning control with a
+verification failure message. The managed-share table can still load because it comes from the
+SimpleSaferServer-owned shares file, but the absence of unmanaged names should not be treated as a
+clean Samba config until verification succeeds.
+
 ## SimpleSaferServer-Managed Share Format
 
-A SimpleSaferServer-managed share uses wrapper comments like this:
+SimpleSaferServer has a dedicated Samba layout helper for install, update, setup,
+and share-management paths. That helper owns these include files when those paths
+prepare the Samba layout:
+
+- `/etc/samba/simple_safer_server_globals.conf`
+- `/etc/samba/simple_safer_server_shares.conf`
+
+The helper wires those files into `/etc/samba/smb.conf` with small
+SimpleSaferServer marker-wrapped include blocks. It validates the effective Samba
+configuration before publishing the layout and restores the original files if
+validation fails.
+
+File paths are the ownership boundary:
+
+- `/etc/samba/smb.conf` remains the system/admin-owned Samba entrypoint.
+- `/etc/samba/simple_safer_server_globals.conf` is owned by SimpleSaferServer and may be refreshed
+  by install, update, setup, and share-management paths.
+- `/etc/samba/simple_safer_server_shares.conf` is owned by SimpleSaferServer and contains only
+  SimpleSaferServer-managed shares.
+
+A SimpleSaferServer-managed share is a normal Samba share section in
+`/etc/samba/simple_safer_server_shares.conf`:
 
 ```ini
-# BEGIN SimpleSaferServer share: backup
 [backup]
    path = /media/backup
    writeable = Yes
@@ -47,16 +89,16 @@ A SimpleSaferServer-managed share uses wrapper comments like this:
    public = no
    comment = Default backup share created by SimpleSaferServer setup
    valid users = admin
-# END SimpleSaferServer share: backup
 ```
 
-Those wrapper comments are the ownership markers.
-They are what let SimpleSaferServer:
+The file path is the ownership marker. Comments in the file are only human guidance, so changing
+or deleting comments does not change whether SimpleSaferServer treats a share as managed.
+This lets SimpleSaferServer:
 
 - show only its own shares in the editable table
 - update only the shares it owns
 - delete only the shares it owns
-- remove only its managed share blocks during uninstall
+- remove only its owned include file during uninstall
 
 ## Supported SimpleSaferServer Share Settings
 
@@ -80,6 +122,9 @@ Those defaults are intentional. They keep the managed share format narrow and pr
 
 SimpleSaferServer is not a general Samba configuration editor.
 If a share depends on other Samba directives, keep managing it manually outside the app.
+Unsupported manual directives in the SimpleSaferServer shares file do not block the shares table,
+but editing that share in the Web UI rewrites the share in the supported format and may drop those
+unsupported directives.
 
 Examples of settings that SimpleSaferServer does not preserve or manage:
 
@@ -100,15 +145,22 @@ Examples of settings that SimpleSaferServer does not preserve or manage:
 
 ## Why Unmanaged Shares Are Hidden From Editing
 
-An unmanaged share may contain Samba options that the SimpleSaferServer UI does not understand.
+An Unmanaged Samba Share may contain Samba options that the SimpleSaferServer UI does not understand.
 If the app tried to import and rewrite those blocks automatically, it could silently remove or change settings that still matter.
 
 SimpleSaferServer therefore takes the safer path:
 
-- detect unmanaged shares
+- ask Samba to parse the Effective Samba Config
+- detect non-system shares that are not from the SimpleSaferServer-owned shares file
 - warn the user that they exist
 - leave them active in Samba
 - refuse to edit or remove them
+
+The inspection writes a stripped candidate config under the volatile runtime directory and runs
+Samba validation against that candidate. The candidate removes only the SimpleSaferServer global and
+shares include marker blocks, so shares loaded from other administrator-owned include files are
+still detected. If Samba cannot produce the effective config, share create and rename paths fail
+closed instead of guessing whether a name is safe.
 
 ## Manual Conversion: Unmanaged Share to SimpleSaferServer-Managed Share
 
@@ -117,9 +169,9 @@ If the share depends on unsupported Samba directives, leave it unmanaged and mai
 
 ### Conversion Steps
 
-1. Back up `/etc/samba/smb.conf`.
-2. Find the unmanaged share block that you want to convert.
-3. Replace it with the SimpleSaferServer-managed wrapper format.
+1. Back up `/etc/samba/smb.conf` and `/etc/samba/simple_safer_server_shares.conf`.
+2. Find the unmanaged share block or include file that defines the share you want to convert.
+3. Remove it from the unmanaged config source and add it to `/etc/samba/simple_safer_server_shares.conf`.
 4. Keep only the supported share settings.
 5. Restart Samba.
 6. Reload the Network File Sharing page and confirm the share appears in the managed table.
@@ -136,10 +188,9 @@ Suppose you currently have this unmanaged share:
    valid users = admin
 ```
 
-Convert it to:
+Move it to `/etc/samba/simple_safer_server_shares.conf` as:
 
 ```ini
-# BEGIN SimpleSaferServer share: backup
 [backup]
    path = /media/backup
    writeable = Yes
@@ -148,14 +199,13 @@ Convert it to:
    public = no
    comment = Backup share
    valid users = admin
-# END SimpleSaferServer share: backup
 ```
 
 Then restart Samba.
 Restarting Samba disconnects anyone who is currently connected to a share, so active file copies or other SMB activity will drop:
 
 ```bash
-sudo systemctl restart smbd nmbd
+sudo systemctl restart smbd nmbd wsdd2
 ```
 
 Reload the Network File Sharing page after that.
@@ -164,28 +214,33 @@ Reload the Network File Sharing page after that.
 
 During setup, SimpleSaferServer tries to create or refresh the default `backup` share using the same ownership-aware SMB logic as the main UI.
 
-If an unmanaged share named `[backup]` already exists:
+If an Unmanaged Samba Share named `[backup]` already exists anywhere Samba loads it:
 
 - setup does not overwrite it
-- setup reports a clear error
-- the user must either remove that unmanaged share manually or convert it into the SimpleSaferServer-managed format first
+- setup reports `Samba share "backup" already exists. Rename or remove it, then retry.`
+- the user must either rename/remove that unmanaged share manually or convert it into the SimpleSaferServer shares file first
 
 This is intentional. Ownership by share name alone is not safe enough.
 
 ## Uninstall Behavior
 
-The uninstaller removes only marker-wrapped SimpleSaferServer-managed share blocks from `/etc/samba/smb.conf`.
+The uninstaller removes the SimpleSaferServer include blocks from `smb.conf` when the main config
+can be safely rewritten. It deletes the SimpleSaferServer-owned Samba include files independently,
+including when `smb.conf` is missing or its SimpleSaferServer marker blocks are malformed.
 
 It does not remove:
 
 - unmanaged share blocks
-- legacy untagged share blocks
 - unrelated Samba configuration
+- shared packages or services such as Samba, `wsdd2`, Python, or rclone
 
-That means older or manually maintained Samba shares survive uninstall unless they have been converted into the marker-wrapped SimpleSaferServer-managed format.
+That means manually maintained Samba shares survive uninstall unless they were moved into
+`/etc/samba/simple_safer_server_shares.conf`.
 
 ## Operational Notes
 
 - The page still shows Samba service status for the whole system, not just SimpleSaferServer-managed shares.
 - The folder picker only helps choose a filesystem path. It does not validate advanced Samba semantics.
-- If you manually edit a SimpleSaferServer-managed share block, keep the wrapper markers and the supported field set intact so the app can still recognize it later.
+- If you manually edit a SimpleSaferServer-managed share, keep it as a normal share section in
+  `/etc/samba/simple_safer_server_shares.conf`; unsupported directives may be overwritten by later
+  Web UI edits.

--- a/docs/network_file_sharing.md
+++ b/docs/network_file_sharing.md
@@ -12,9 +12,10 @@ SimpleSaferServer distinguishes between two kinds of Samba shares:
 
 That ownership split matters because SimpleSaferServer only edits shares that it can identify safely.
 Use the Web UI for normal SimpleSaferServer share changes so the app can validate Samba, publish
-the owned file safely, and restart the required service path.
+the owned file safely, and gracefully reload the configuration (falling back to a full restart 
+only if the reload fails or the daemon is inactive).
 If a publish fails after the owned shares file is replaced, SimpleSaferServer restores the previous
-owned shares file and restarts `smbd` so Samba is asked to return to the last known-good share set.
+owned shares file and reloads or restarts `smbd` so Samba returns to the last known-good share set.
 
 ## What the Page Shows
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -21,10 +21,22 @@ The uninstaller removes:
 - Disable Schedule restore timer state, helper script, and disabled-timer data
 - the SimpleSaferServer-managed `/etc/fstab` entry
 - Samba users synced from SimpleSaferServer accounts
-- marker-wrapped SimpleSaferServer-managed Samba share blocks
+- SimpleSaferServer include blocks in `/etc/samba/smb.conf`
+- SimpleSaferServer-owned Samba files:
+  `/etc/samba/simple_safer_server_globals.conf` and
+  `/etc/samba/simple_safer_server_shares.conf`
 
-The uninstaller does not remove shared system packages such as Samba, Python, or rclone. It also
-leaves unmanaged or legacy untagged Samba share blocks in `/etc/samba/smb.conf` for safety.
+The owned Samba files are deleted even if `/etc/samba/smb.conf` is missing or has malformed
+SimpleSaferServer include markers. Malformed markers prevent the uninstaller from rewriting
+`smb.conf`, but they do not block cleanup of files that SimpleSaferServer owns by path. When
+markers are malformed, the uninstaller prints a warning with exact manual recovery steps.
+
+After successful cleanup, the uninstaller restarts `smbd` so the running service matches the
+rewritten config. Active Samba file transfers will be interrupted. Discovery services (`nmbd`,
+`wsdd2`) are not restarted because they are shared system services.
+
+The uninstaller does not remove shared system packages or services such as Samba, `wsdd2`, Python,
+or rclone. It also leaves unmanaged Samba share blocks in `/etc/samba/smb.conf` for safety.
 
 If SimpleSaferServer configured Ubuntu Pro Livepatch, uninstall warns that Ubuntu Pro and Livepatch
 state are retained. Review that host-level subscription/security state manually after uninstall.

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
         <div class="note">
             <i class="fa-solid fa-circle-info"></i> <strong>Note:</strong> Run as <code>root</code> or with <code>sudo</code> on a clean Debian or Ubuntu based system.<br>
             The installer checks for APT, dpkg, systemd, and Debian/Ubuntu OS-family metadata before installing packages. Derivatives continue with a warning when they expose Debian/Ubuntu ancestry.<br>
-            The script will install all dependencies, set up the service, and print your Web UI address.<br>
+            The script installs core dependencies, prepares SimpleSaferServer-owned Samba include files, optionally installs <code>wsdd2</code> discovery support, sets up the service, and prints your Web UI address.<br>
             The management Web UI is admin-only, and the first account created during setup becomes the initial administrator.
         </div>
         <hr>
@@ -185,9 +185,12 @@
         <p class="note">
             <i class="fa-solid fa-circle-info"></i>
             This removes SimpleSaferServer files, services, timers, app data, the managed <code>/etc/fstab</code> entry,
-            and marker-wrapped SimpleSaferServer-managed Samba share blocks.
-            Shared system packages such as Samba, Python, and rclone stay installed.
-            Unmanaged or legacy untagged Samba share blocks stay in <code>/etc/samba/smb.conf</code> for safety.
+            Samba users synced from SimpleSaferServer accounts, SimpleSaferServer include blocks in <code>/etc/samba/smb.conf</code>,
+            and the owned Samba files under <code>/etc/samba</code>. Owned Samba files are still removed when
+            <code>smb.conf</code> cannot be rewritten safely.
+            Active Samba file transfers will be interrupted when <code>smbd</code> is restarted.
+            Shared system packages and services such as Samba, <code>wsdd2</code>, Python, and rclone stay installed.
+            Unmanaged Samba share blocks stay in <code>/etc/samba/smb.conf</code> for safety.
             <strong>This process is irreversible.</strong>
         </p>
         <div class="text-center mt-4">

--- a/install.sh
+++ b/install.sh
@@ -386,6 +386,103 @@ install_hdsentinel() {
     echo -e "${GREEN}✔ HDSentinel installed to $HDSENTINEL_BIN.${NC}\n"
 }
 
+install_optional_wsdd2() {
+    echo -e "${YELLOW}Installing optional wsdd2 discovery support...${NC}"
+    if DEBIAN_FRONTEND=noninteractive apt-get install -y wsdd2; then
+        echo -e "${GREEN}✔ wsdd2 installed for modern Windows Network discovery.${NC}\n"
+    else
+        # wsdd2 is absent on some supported Debian-family releases. Samba file
+        # serving must still install cleanly when only discovery is degraded.
+        echo -e "${YELLOW}wsdd2 is unavailable or could not be installed. Continuing without modern Windows discovery.${NC}\n"
+    fi
+}
+
+configure_samba_discovery_services() {
+    local smbd_state=""
+    local nmbd_state=""
+    local wsdd2_state=""
+    local smbd_enable_failed=0
+    local smbd_start_failed=0
+    local nmbd_enable_failed=0
+    local nmbd_start_failed=0
+    local wsdd2_enable_failed=0
+    local wsdd2_start_failed=0
+
+    echo -e "${YELLOW}Configuring Samba file sharing and discovery services...${NC}"
+
+    # smbd is the required file-serving daemon. Enable/start failures are not
+    # fatal by themselves because a unit can still be active after a manual
+    # start or distro-specific boot policy; the final active state is the gate.
+    if ! systemctl enable smbd; then
+        smbd_enable_failed=1
+    fi
+    if ! systemctl start smbd; then
+        smbd_start_failed=1
+    fi
+    if ! systemctl is-active --quiet smbd; then
+        echo -e "${RED}ERROR: smbd is not active after start.${NC}"
+        echo -e "${RED}Samba file serving is required, so installation cannot continue safely.${NC}"
+        echo -e "${RED}Run 'systemctl status smbd' and 'journalctl -u smbd --no-pager' to inspect the failure, then rerun the installer after smbd can start.${NC}"
+        return 1
+    fi
+    if [ "$smbd_enable_failed" -eq 1 ]; then
+        echo -e "${YELLOW}WARNING: smbd is active, but systemctl enable smbd failed. File sharing works now, but it may not survive reboot until boot enablement is fixed.${NC}"
+    fi
+    if [ "$smbd_start_failed" -eq 1 ]; then
+        echo -e "${YELLOW}WARNING: smbd is active, but systemctl start smbd failed. File sharing works now, but review the service state before relying on it.${NC}"
+    fi
+
+    if ! systemctl enable nmbd; then
+        nmbd_enable_failed=1
+    fi
+    if ! systemctl start nmbd; then
+        nmbd_start_failed=1
+    fi
+    if [ "$nmbd_enable_failed" -eq 1 ] || [ "$nmbd_start_failed" -eq 1 ]; then
+        echo -e "${YELLOW}nmbd could not be enabled or started. Continuing with legacy NetBIOS discovery degraded.${NC}"
+    fi
+    if ! systemctl is-active --quiet nmbd; then
+        echo -e "${YELLOW}nmbd is not active. Legacy NetBIOS discovery may be unavailable.${NC}"
+    fi
+
+    # Try the packaged unit directly. Missing wsdd2 units are non-fatal because
+    # wsdd2 is optional and package availability varies by distro release.
+    if ! systemctl enable wsdd2; then
+        wsdd2_enable_failed=1
+    fi
+    if ! systemctl start wsdd2; then
+        wsdd2_start_failed=1
+    fi
+    if [ "$wsdd2_enable_failed" -eq 1 ] || [ "$wsdd2_start_failed" -eq 1 ]; then
+        echo -e "${YELLOW}wsdd2 could not be enabled or started. Continuing with modern Windows discovery degraded.${NC}"
+    fi
+    if ! systemctl is-active --quiet wsdd2; then
+        echo -e "${YELLOW}wsdd2 is not active or unavailable. Modern Windows Network discovery may be unavailable.${NC}"
+    fi
+
+    if systemctl is-active --quiet smbd; then
+        smbd_state="active"
+    else
+        smbd_state="inactive"
+    fi
+    if systemctl is-active --quiet nmbd; then
+        nmbd_state="active"
+    else
+        nmbd_state="inactive"
+    fi
+    if systemctl is-active --quiet wsdd2; then
+        wsdd2_state="active"
+    else
+        wsdd2_state="inactive"
+    fi
+
+    echo -e "${BLUE}Samba service summary:${NC}"
+    echo -e "  smbd: ${smbd_state}"
+    echo -e "  nmbd: ${nmbd_state}"
+    echo -e "  wsdd2: ${wsdd2_state}"
+    echo -e "${GREEN}✔ Samba service setup complete.${NC}\n"
+}
+
 # 1. Install system dependencies and the base Python runtime using apt.
 #    The app itself runs from a dedicated virtualenv so older Debian releases
 #    are not blocked by missing distro packages like python3-flask-socketio.
@@ -396,6 +493,7 @@ echo "msmtp msmtp/apply_apparmor boolean true" | debconf-set-selections
 DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python3-venv python3-flask python3-psutil python3-cryptography smartmontools samba msmtp curl unzip rsync fdisk ntfs-3g unattended-upgrades
 
 echo -e "${GREEN}✔ System and Python dependencies installed.${NC}\n"
+install_optional_wsdd2
 
 PYTHON_RUNTIME_VERSION="$(python_runtime_version)"
 if python_requires_legacy_requirements; then
@@ -457,7 +555,7 @@ install_hdsentinel
 echo -e "${YELLOW}Step 4: Copying application files...${NC}"
 mkdir -p "$APP_DIR"
 mkdir -p "$DATA_DIR"
-rsync -a --delete --exclude='venv' --exclude='__pycache__' --exclude='*.pyc' --exclude='*.pyo' --exclude='*.log' --exclude='telemetry.csv' --exclude='harddrive_model' --exclude='static' --exclude='templates' ./ "$APP_DIR/"
+rsync -a --delete --exclude='venv' --exclude='__pycache__' --exclude='*.pyc' --exclude='*.pyo' --exclude='*.log' --exclude='telemetry.csv' --exclude='harddrive_model' --exclude='/static' --exclude='/templates' ./ "$APP_DIR/"
 echo -e "${GREEN}✔ Application files copied.${NC}\n"
 
 # 5. Copy static and templates directories
@@ -505,16 +603,41 @@ if ! same_file harddrive_model "$MODEL_DIR"; then
 fi
 echo -e "${GREEN}✔ Model files copied.${NC}\n"
 
-# 9. Install/refresh systemd service for Flask app
-echo -e "${YELLOW}Step 9: Setting up systemd service...${NC}"
+# 9. Prepare the SSS-owned Samba include layout and discovery services.
+echo -e "${YELLOW}Step 9: Preparing Samba file sharing and discovery...${NC}"
+if "$VENV_DIR/bin/python3" -c "
+import sys
+sys.path.insert(0, '$APP_DIR')
+from simple_safer_server.services.runtime import get_runtime
+from simple_safer_server.services.samba_layout import SambaLayoutService
+
+rt = get_runtime()
+SambaLayoutService(runtime=rt).ensure_layout()
+"; then
+  echo -e "${GREEN}✔ Samba include layout prepared.${NC}"
+else
+  echo -e "${RED}ERROR: Failed to prepare the SimpleSaferServer Samba include layout.${NC}"
+  echo -e "${RED}Samba must validate before installation can continue safely.${NC}"
+  exit 1
+fi
+if configure_samba_discovery_services; then
+  echo -e "${GREEN}✔ Required Samba file serving is active.${NC}"
+else
+  echo -e "${RED}ERROR: Failed to start required Samba file serving.${NC}"
+  echo -e "${RED}Fix smbd with 'systemctl status smbd' and 'journalctl -u smbd --no-pager', then rerun the installer.${NC}"
+  exit 1
+fi
+
+# 10. Install/refresh systemd service for Flask app
+echo -e "${YELLOW}Step 10: Setting up systemd service...${NC}"
 cp simple_safer_server_web.service "$SERVICE_FILE"
 systemctl daemon-reload
 systemctl enable simple_safer_server_web.service
 systemctl restart simple_safer_server_web.service
 echo -e "${GREEN}✔ Systemd service enabled and started.${NC}\n"
 
-# 10. Refresh procedurally generated background services
-echo -e "${YELLOW}Step 10: Refreshing procedural background services...${NC}"
+# 11. Refresh procedurally generated background services
+echo -e "${YELLOW}Step 11: Refreshing procedural background services...${NC}"
 if "$VENV_DIR/bin/python3" -c "
 import sys
 sys.path.insert(0, '$APP_DIR')
@@ -547,8 +670,8 @@ else
   exit 1
 fi
 
-# 11. Open port 5000 in firewall if active
-echo -e "${YELLOW}Step 11: Configuring firewall (if active)...${NC}"
+# 12. Open port 5000 in firewall if active
+echo -e "${YELLOW}Step 12: Configuring firewall (if active)...${NC}"
 if command -v ufw >/dev/null 2>&1 && ufw status | grep -q 'Status: active'; then
   ufw allow 5000/tcp
 echo -e "${GREEN}✔ Port 5000 opened in ufw.${NC}"
@@ -564,7 +687,7 @@ echo -e "${YELLOW}No active firewall detected or configured. Skipping firewall s
 fi
 echo
 
-# 12. Print all network interface IPs for user access
+# 13. Print all network interface IPs for user access
 echo -e "${BLUE}===============================================${NC}"
 echo -e "${BLUE}  SimpleSaferServer Web UI Access URLs${NC}"
 echo -e "${BLUE}===============================================${NC}"

--- a/install.sh
+++ b/install.sh
@@ -472,8 +472,10 @@ configure_samba_discovery_services() {
     fi
     if systemctl is-active --quiet wsdd2; then
         wsdd2_state="active"
-    else
+    elif systemctl cat wsdd2 >/dev/null 2>&1; then
         wsdd2_state="inactive"
+    else
+        wsdd2_state="unavailable"
     fi
 
     echo -e "${BLUE}Samba service summary:${NC}"

--- a/install.sh
+++ b/install.sh
@@ -416,8 +416,20 @@ configure_samba_discovery_services() {
     if ! systemctl enable smbd; then
         smbd_enable_failed=1
     fi
-    if ! systemctl start smbd; then
-        smbd_start_failed=1
+    # If smbd is already active, we attempt a graceful config reload first
+    # using smbcontrol. This avoids dropping active user connections.
+    # If the reload fails, we fall back to systemctl restart.
+    # If smbd is inactive, we perform a normal systemctl start.
+    if systemctl is-active --quiet smbd; then
+        if ! smbcontrol smbd reload-config >/dev/null 2>&1; then
+            if ! systemctl restart smbd; then
+                smbd_start_failed=1
+            fi
+        fi
+    else
+        if ! systemctl start smbd; then
+            smbd_start_failed=1
+        fi
     fi
     if ! systemctl is-active --quiet smbd; then
         echo -e "${RED}ERROR: smbd is not active after start.${NC}"
@@ -429,7 +441,7 @@ configure_samba_discovery_services() {
         echo -e "${YELLOW}WARNING: smbd is active, but systemctl enable smbd failed. File sharing works now, but it may not survive reboot until boot enablement is fixed.${NC}"
     fi
     if [ "$smbd_start_failed" -eq 1 ]; then
-        echo -e "${YELLOW}WARNING: smbd is active, but systemctl start smbd failed. File sharing works now, but review the service state before relying on it.${NC}"
+        echo -e "${YELLOW}WARNING: smbd is active, but reload/restart failed. File sharing works now, but review the service state before relying on it.${NC}"
     fi
 
     if ! systemctl enable nmbd; then

--- a/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/PRD.md
+++ b/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/PRD.md
@@ -1,0 +1,315 @@
+# Samba Discovery and Config Ownership PRD
+
+## Problem Statement
+
+SimpleSaferServer currently assumes that installing the `samba` package leaves both `smbd` and
+`nmbd` installed, enabled, and active. On Ubuntu 26.04, the `samba` package installs `/usr/sbin/nmbd`
+and `nmbd.service`, but systemd skips `nmbd.service` because Samba's `ExecCondition` says NetBIOS is
+not configured. The app then reports file sharing as partial or broken even though the daemon exists.
+
+The current Samba ownership model is also too broad and too comment-dependent. SimpleSaferServer
+writes managed share blocks directly into `/etc/samba/smb.conf` and treats marker comments as the
+ownership boundary. That makes uninstall and future config changes harder than necessary, and it
+forces the app to edit a system/admin-owned file for every share change.
+
+Administrators need SimpleSaferServer to configure Samba discovery predictably, support modern
+Windows network discovery through `wsdd2` where available, keep legacy NetBIOS discovery enabled
+where Samba supports it, and avoid overwriting existing Samba configuration. The Web UI should track
+the actual state of `smbd`, `nmbd`, and `wsdd2` without adding complicated diagnostics.
+
+## Solution
+
+Move SimpleSaferServer's Samba ownership boundary from comments in `smb.conf` to owned include files.
+The main Samba config remains the system/admin-owned entrypoint. SimpleSaferServer only inserts
+small marker-wrapped include blocks into `smb.conf`:
+
+- a global include inside `[global]`, late before the first non-global section
+- a shares include at the end of the file
+
+SimpleSaferServer owns two files:
+
+- `/etc/samba/simple_safer_server_globals.conf`
+- `/etc/samba/simple_safer_server_shares.conf`
+
+The globals file is generated from a repository template and may be refreshed during install/update
+paths. It contains only defensible global policy that SimpleSaferServer depends on:
+
+- `map to guest = never`
+- `disable netbios = no`
+
+The shares file is the source of truth for SimpleSaferServer-managed shares. Any share section in
+that file is managed by SimpleSaferServer. Comments in the file are for human guidance only, not
+ownership detection. Manual edits should not crash the app, but unsupported Samba directives may be
+overwritten the next time that share is edited in the Web UI.
+
+Add an idempotent Samba layout helper that can safely auto-heal the owned layout during explicit
+install/update/setup/share-management paths. It should create missing owned files, refresh the
+globals template, ensure include placement, validate the effective Samba config with `testparm`, and
+roll back if validation or required service restart fails. It should not run on ordinary app startup
+or status polling.
+
+Install `wsdd2` as an optional discovery dependency where available. Do not support a custom `wsdd`
+systemd wrapper for older distros. `smbd` is required; `nmbd` and `wsdd2` are desired discovery
+services. The Web UI should track all three. Overall file-sharing status is operational only when
+all three are active, partial when `smbd` is active but discovery is incomplete, and down when
+`smbd` is not active.
+
+Uninstall removes only SimpleSaferServer-owned Samba include blocks and owned files. It leaves
+shared packages and unrelated service state alone.
+
+## User Stories
+
+1. As an administrator, I want SimpleSaferServer to install Samba file sharing predictably, so that the backup share works after setup.
+2. As an administrator, I want `smbd` to be required and checked, so that the app does not claim file sharing works when the file-serving daemon is down.
+3. As an administrator, I want `nmbd` enabled when Samba supports it, so that older Windows network browsing paths can find the server.
+4. As an administrator, I want `wsdd2` installed when available, so that modern Windows Network discovery can find the server.
+5. As an administrator, I want installation to continue when `wsdd2` is unavailable, so that older Debian installs can still serve SMB shares.
+6. As an administrator, I want installation to continue when `nmbd` is inactive, so that legacy discovery issues do not block core file sharing.
+7. As an administrator, I want installation to fail if `smbd` cannot start, so that a non-working file server is not treated as installed.
+8. As an administrator, I want a concise installer service summary, so that I can see whether `smbd`, `nmbd`, and `wsdd2` are active.
+9. As an administrator, I want the Network File Sharing page to show `smbd`, `nmbd`, and `wsdd2`, so that discovery and file-serving state are visible in one place.
+10. As an administrator, I want the Dashboard file-sharing summary to include `wsdd2`, so that the dashboard matches the dedicated file-sharing page.
+11. As an administrator, I want `Windows Discovery (wsdd2)` labeled by purpose, so that I know it is for modern Windows Network discovery.
+12. As an administrator, I want `NetBIOS Discovery (nmbd)` labeled by purpose, so that I know it is for older Windows browsing paths.
+13. As an administrator, I want hover help for `wsdd2`, so that the UI explains the difference between modern and legacy discovery without adding a large panel.
+14. As an administrator, I want the Restart Services button to restart all three services, so that file sharing and discovery refresh together.
+15. As an administrator, I want `smbd` restart failure to fail the operation, so that the UI reports core file-sharing failure.
+16. As an administrator, I want `nmbd` or `wsdd2` restart failure to show as partial status, so that discovery problems do not roll back valid share edits.
+17. As an administrator, I want SimpleSaferServer to avoid overwriting existing Samba shares, so that installing the app does not break manually configured shares.
+18. As an administrator, I want setup completion to reject an existing unmanaged `backup` share, so that SimpleSaferServer does not silently override it.
+19. As an administrator, I want the existing `backup` share conflict message to be short, so that it fits in the setup notification.
+20. As an administrator, I want to fix a `backup` share conflict manually and retry Complete Setup, so that setup values are not lost.
+21. As an administrator, I want SimpleSaferServer-managed shares in a dedicated file, so that it is obvious which shares the app owns.
+22. As an administrator, I want the SSS shares file to be plain Samba config, so that I can inspect or manually edit it if needed.
+23. As an administrator, I want manual unsupported directives not to crash the Web UI, so that a hand-edited shares file remains recoverable.
+24. As an administrator, I accept that unsupported manual directives may be overwritten by Web UI edits, so that the app does not become a full Samba editor.
+25. As an administrator, I want comments in SSS-owned files to explain the behavior, so that future maintenance is easier.
+26. As an administrator, I want comments not to determine ownership, so that accidental comment edits do not confuse the app.
+27. As an administrator, I want uninstall to remove SSS-owned Samba files, so that app-owned config is cleaned up.
+28. As an administrator, I want uninstall to remove only SSS include lines from `smb.conf`, so that unrelated Samba config survives.
+29. As an administrator, I want uninstall to leave Samba and `wsdd2` packages installed, so that shared system packages are not unexpectedly removed.
+30. As an administrator, I want uninstall not to blindly disable `wsdd2`, so that a service I had enabled outside SSS is not turned off.
+31. As a future maintainer, I want one shared Samba layout helper, so that installer, setup, update, and share edits do not duplicate config-repair logic.
+32. As a future maintainer, I want the layout helper to be idempotent, so that running it during updates can auto-heal missing SSS wiring safely.
+33. As a future maintainer, I want auto-heal limited to explicit install paths, so that restarting the web app does not unexpectedly rewrite system config.
+34. As a future maintainer, I want full-config validation with `testparm`, so that SSS never publishes a broken Samba config knowingly.
+35. As a future maintainer, I want rollback behavior around Samba config writes, so that failed validation or required service restart does not leave partial edits.
+36. As a future maintainer, I want conflict checks to account for effective Samba config, so that user include files are respected.
+37. As a future maintainer, I want the normal app code to drop the legacy inline managed-share model, so that dead compatibility code does not burden maintenance.
+38. As a future maintainer, I want docs to describe file-based ownership, so that the Web UI and uninstall behavior match operator expectations.
+39. As a future maintainer, I want `index.html` documentation/uninstall copy checked, so that public docs match the new behavior.
+40. As a future maintainer, I want no `README.md` edits in this work, so that repository instructions are respected.
+
+## Implementation Decisions
+
+- Use file path ownership as the Samba management boundary.
+- SimpleSaferServer owns `/etc/samba/simple_safer_server_globals.conf`.
+- SimpleSaferServer owns `/etc/samba/simple_safer_server_shares.conf`.
+- Comments in Samba files are explanatory only and must not be used to determine share ownership.
+- Remove the old inline managed-share ownership model from normal application behavior.
+- Do not keep legacy compatibility for marker-wrapped shares in the main Samba config.
+- Main `smb.conf` should only be modified through small marker-wrapped include blocks.
+- The global include must be inserted inside `[global]`, as late as possible before the first non-global section.
+- The shares include must be inserted at the end of `smb.conf`.
+- The global include file should not contain a `[global]` header because it is included from inside the existing `[global]` section.
+- The shares include file should contain normal Samba share sections.
+- New installs and update paths should refresh the globals file from a repository template.
+- New installs and update paths should create the shares file with a header if it is missing.
+- The shares file should not be wholesale regenerated during install/update when it already exists.
+- The shares file header should state that the file is managed by SimpleSaferServer, normal edits should use the Web UI, and unsupported manual directives may be overwritten by Web UI edits.
+- The globals file header should state that the installer/setup/update paths may refresh it and that site-specific overrides belong in `smb.conf` after the SSS global include if the admin intentionally wants to override SSS defaults.
+- The initial globals template should include `map to guest = never`.
+- The initial globals template should include `disable netbios = no`.
+- Do not include `server role = standalone server` in the SSS globals template for this work.
+- Write SSS Samba config files as root-owned `0644` files.
+- Do not store secrets in the SSS Samba config files.
+- Use a shared Samba layout helper rather than duplicating parsing and insertion logic in Bash, setup routes, and the share manager.
+- The shared helper should be idempotent and safe to run repeatedly.
+- The shared helper should create or repair only SSS-owned files and SSS include blocks.
+- The shared helper should fail closed when it finds malformed SSS include marker blocks.
+- The shared helper should not rewrite unrelated `smb.conf` content.
+- The shared helper should validate the effective Samba config with `testparm`.
+- The shared helper should roll back changes when validation fails.
+- The shared helper should roll back share/config writes when `smbd` cannot restart after a publish.
+- Run the shared helper only during explicit install/update/setup/share-management paths.
+- Do not run auto-heal on app startup.
+- Do not run auto-heal on status polling.
+- Installer/update paths should prepare the Samba layout and services but should not create the default `backup` share.
+- Setup completion should create or update the default `backup` share after the backup mount point is known.
+- Setup completion should keep using persisted setup values so a failed `backup` share conflict can be fixed and retried.
+- The short setup notification for an unmanaged `backup` conflict should be: `Samba share "backup" already exists. Rename or remove it, then retry.`
+- Before creating a new managed share, reject the operation if that share name already exists outside the SSS shares file.
+- Before renaming a managed share, reject the operation if the new name exists outside the SSS shares file.
+- Use Samba's effective config where practical for conflict detection so non-SSS include files are respected.
+- Avoid treating SSS-owned shares as conflicts when editing existing SSS shares.
+- If effective-config conflict detection cannot prove safety, prefer rejecting the operation over relying on include precedence.
+- The app should parse the SSS shares file directly for list/create/update/delete operations.
+- The app should read only supported fields for Web UI display.
+- Manual unsupported directives in the SSS shares file should not crash the UI.
+- Editing a share through the Web UI may rewrite that share in the supported SSS format and drop unsupported directives.
+- If the SSS shares file is structurally malformed enough that share sections cannot be parsed safely, return a clear API error instead of crashing.
+- Install `wsdd2` as an optional dependency in a separate install attempt, not in the fatal core dependency command.
+- Do not install or manage `wsdd`.
+- Do not create a custom SimpleSaferServer systemd wrapper for `wsdd`.
+- If `wsdd2` is unavailable, warn and continue.
+- If `wsdd2` is installed, enable/start it best-effort and report its actual status.
+- Do not remove the `wsdd2` package on uninstall.
+- Do not blindly disable `wsdd2.service` on uninstall.
+- Enable/start `smbd` and fail install/setup/share publish when core file serving cannot run.
+- Enable/start `nmbd` and warn/partial if it is inactive or skipped.
+- Track `smbd`, `nmbd`, and `wsdd2` with a flat API response.
+- Use `unavailable` for `wsdd2` when the unit or service is missing.
+- Keep the restart API simple: fail when `smbd` fails; allow status polling to reveal partial discovery state.
+- The Network File Sharing page should show all three services.
+- The Dashboard file-sharing summary should include all three services.
+- Overall status should be `Operational` only when all three services are active.
+- Overall status should be `Partial` when `smbd` is active and either discovery service is not active or unavailable.
+- Overall status should be `Down` when `smbd` is not active.
+- The Restart Services button should restart all three services.
+- Service labels should be purpose-first with unit names in parentheses.
+- `SMB Daemon (smbd)` tooltip should say it serves file shares.
+- `NetBIOS Discovery (nmbd)` tooltip should say it helps older Windows network browsing find the server.
+- `Windows Discovery (wsdd2)` tooltip should say it helps modern Windows network browsing find the server.
+- Installer output may print a concise service summary after service setup.
+- Uninstall should remove SSS include marker blocks from `smb.conf`.
+- Uninstall should delete the SSS globals and shares files.
+- Uninstall should leave unmanaged Samba shares and unrelated Samba config alone.
+- Uninstall should leave shared packages installed.
+- Uninstall should leave non-SSS service state alone.
+- Update `docs/network_file_sharing.md` to describe file-based ownership, discovery services, conflict handling, and uninstall behavior.
+- Update install/manual install docs to mention optional `wsdd2` discovery support and SSS-owned Samba include files.
+- Update uninstall docs and public `index.html` uninstall copy to mention SSS-owned Samba include files.
+- Do not edit `README.md`.
+
+Major modules to build or modify:
+
+- Samba layout helper: own include placement, owned file creation, globals refresh, full-config validation, rollback, and idempotent auto-heal.
+- SMB manager: move share list/create/update/delete to the SSS shares file, use layout helper before write operations, and detect conflicts with unmanaged/effective shares.
+- SMB command adapter: add commands for `testparm`, service status, optional service availability, service restart/start/enable, and effective config inspection as needed.
+- Installer/update path: call the shared layout helper, optional-install `wsdd2`, enable/start services, and print concise service status.
+- Setup completion: ensure layout, create/update the default backup share from the configured mount point, fail only on `smbd` failure, and surface short conflict messages.
+- Network File Sharing API and template: return/show `wsdd2`, restart all three services, and update overall state logic.
+- Dashboard summary UI: include `wsdd2` in file-sharing health logic and details.
+- Uninstaller: remove SSS include blocks/files and update final messaging without removing packages or unrelated service state.
+- Documentation: update network file sharing, install, manual install, uninstall, and public documentation index copy.
+
+## Testing Decisions
+
+Good tests should verify external behavior and safety boundaries rather than private implementation
+details. The most important assertions are that SimpleSaferServer touches only the owned Samba
+surface, validates before publishing, does not overwrite existing user shares, fails when `smbd`
+cannot serve files, and degrades cleanly when discovery services are missing.
+
+Modules and behaviors to test:
+
+- Samba layout helper:
+  - Creates the globals file from the template with expected permissions.
+  - Creates the shares file with the expected header when missing.
+  - Inserts the global include inside `[global]` before the first non-global section.
+  - Inserts the shares include at the end of `smb.conf`.
+  - Does not duplicate include blocks when run repeatedly.
+  - Leaves unrelated `smb.conf` content unchanged.
+  - Fails closed when SSS include markers are malformed.
+  - Runs full-config validation with `testparm`.
+  - Rolls back when validation fails.
+- Share manager:
+  - Lists shares from the SSS shares file.
+  - Creates shares in the SSS shares file.
+  - Updates shares in the SSS shares file.
+  - Deletes shares from the SSS shares file.
+  - Does not rely on share marker comments for ownership.
+  - Rejects creating `backup` when a non-SSS `backup` share exists in effective Samba config.
+  - Rejects renaming a managed share to a name used outside the SSS shares file.
+  - Does not crash when unsupported directives are present in the SSS shares file.
+  - Returns a clear error when the SSS shares file is structurally malformed.
+  - Rolls back a published share change when `smbd` cannot restart.
+- Setup completion:
+  - Creates the default `backup` share only after setup has a mount point.
+  - Returns a short retryable error when an unmanaged `backup` share exists.
+  - Does not lose persisted setup values after a `backup` share conflict.
+  - Fails when `smbd` cannot start/restart.
+  - Does not fail solely because `nmbd` or `wsdd2` is unavailable.
+- Installer/update:
+  - Optional `wsdd2` install failure does not fail the installer.
+  - Core `smbd` failure does fail the relevant install/setup path.
+  - Service summary prints all three service states.
+  - The layout helper is invoked instead of duplicating Samba config edits in Bash where practical.
+- Service status API:
+  - Returns a flat object containing `smbd`, `nmbd`, and `wsdd2`.
+  - Returns `unavailable` for missing `wsdd2`.
+  - Preserves existing behavior for `smbd` and `nmbd` active/inactive states.
+- Restart API:
+  - Attempts to restart all three services.
+  - Fails when `smbd` restart fails.
+  - Allows non-fatal discovery restart failures to be reflected through status polling.
+- Network File Sharing UI:
+  - Shows badges for all three services.
+  - Shows `Operational` only when all three are active.
+  - Shows `Partial` when `smbd` is active and one discovery service is inactive/unavailable.
+  - Shows `Down` when `smbd` is inactive.
+  - Includes concise tooltips for `smbd`, `nmbd`, and `wsdd2`.
+- Dashboard UI:
+  - Includes `wsdd2` in file-sharing summary details.
+  - Uses the same overall state rules as the Network File Sharing page.
+- Uninstall:
+  - Removes only SSS include blocks from `smb.conf`.
+  - Deletes the SSS globals and shares files.
+  - Leaves unrelated include lines alone.
+  - Leaves unmanaged Samba share blocks alone.
+  - Leaves shared packages installed.
+  - Does not blindly disable `wsdd2.service`.
+  - Updates final uninstall messaging.
+- Documentation:
+  - Network File Sharing docs describe SSS-owned Samba files and discovery services.
+  - Install docs mention optional `wsdd2`.
+  - Manual install docs mention the layout/helper behavior.
+  - Uninstall docs mention owned Samba include files.
+  - Public `index.html` copy matches the new uninstall behavior.
+  - `README.md` is not modified.
+
+Prior art:
+
+- Existing `SMBManager` tests cover share parsing, create/update/delete safety, rollback, and
+  unmanaged-share rejection.
+- Existing uninstaller tests cover marker-based Samba cleanup and should be replaced with include
+  file cleanup tests.
+- Existing setup wizard tests cover default backup share creation and unmanaged `backup` guidance.
+- Existing Dashboard and Network File Sharing JavaScript already consume flat `smbd`/`nmbd` status
+  values and can be extended to `wsdd2`.
+- Existing development docs require system behavior behind services/adapters, validation/rollback
+  for system-owned files, related documentation updates, and uninstall checks.
+
+## Out of Scope
+
+- Supporting a custom `wsdd` systemd wrapper.
+- Installing or managing `wsdd`.
+- Installing both `wsdd` and `wsdd2`.
+- Removing Samba or `wsdd2` packages during uninstall.
+- Blindly disabling `wsdd2.service` during uninstall.
+- Persisting a separate manifest of whether SSS installed or enabled `wsdd2`.
+- Keeping legacy inline managed-share compatibility in normal app code.
+- Automatically migrating existing inline managed-share blocks from `smb.conf`.
+- Building a general Samba configuration editor.
+- Exposing every possible Samba share directive in the Web UI.
+- Preserving unsupported manual directives during Web UI share edits.
+- Adding a new visible setup step for Samba.
+- Failing setup/install solely because `nmbd` or `wsdd2` is inactive/unavailable.
+- Adding deep `nmbd` `ExecCondition` diagnostics to the UI.
+- Hiding `wsdd2` from the UI on systems where it is unavailable.
+- Running Samba layout auto-heal on ordinary app startup.
+- Running Samba layout auto-heal on status polling.
+- Changing the backup share name from `backup`.
+- Editing `README.md`.
+
+## Further Notes
+
+- The observed Ubuntu 26.04 install did install `/usr/sbin/nmbd`, `/usr/sbin/smbd`, `pdbedit`, and
+  `testparm`. `nmbd.service` existed but systemd skipped it due to Samba's `ExecCondition`.
+- On the same Ubuntu 26.04 host, `wsdd` was installed as a binary but did not provide a
+  `wsdd.service`. `wsdd2` was available from Ubuntu repositories but was not installed.
+- Modern Windows Network discovery is better served by WSD discovery (`wsdd2`) than by only relying
+  on NetBIOS (`nmbd`). `nmbd` remains useful for legacy browsing paths.
+- The public UI should keep the explanation lightweight: labels and tooltips are enough for the
+  first pass.
+- The implementation should prefer small, testable deep modules around Samba layout and service
+  orchestration instead of spreading Samba config edits through routes, installer Bash, and UI code.

--- a/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/01-establish-sss-owned-samba-layout.md
+++ b/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/01-establish-sss-owned-samba-layout.md
@@ -1,0 +1,35 @@
+# Establish SSS-Owned Samba Layout
+
+## What to build
+
+Create the shared Samba layout foundation that moves SimpleSaferServer ownership out of ordinary
+share marker comments and into SSS-owned include files.
+
+The completed slice should provide an idempotent helper that can be called by explicit
+install/update/setup/share-management paths. It should ensure the SSS globals file, SSS shares file,
+and marker-wrapped include lines exist in the correct places, validate the effective Samba config,
+and roll back when publishing a layout change would leave Samba broken.
+
+## Acceptance criteria
+
+- [ ] The helper creates the SSS globals file from a repository template.
+- [ ] The globals template includes only the agreed global policy: `map to guest = never` and `disable netbios = no`.
+- [ ] The globals file header explains that SimpleSaferServer may refresh the file and that site-specific overrides belong after the SSS global include if an admin intentionally wants to override SSS defaults.
+- [ ] The helper creates the SSS shares file with a header when the file is missing.
+- [ ] The shares file header says normal share changes should use the Web UI and unsupported manual directives may be overwritten by Web UI edits.
+- [ ] SSS-owned Samba config files are written root-owned with mode `0644` in real runtime paths.
+- [ ] The helper inserts the global include inside `[global]`, as late as possible before the first non-global section.
+- [ ] The helper inserts the shares include at the end of the main Samba config.
+- [ ] Running the helper repeatedly does not duplicate include blocks.
+- [ ] The helper leaves unrelated `smb.conf` content unchanged.
+- [ ] The helper fails closed when SSS include marker blocks are malformed.
+- [ ] The helper validates the effective Samba config with `testparm` before publishing changes.
+- [ ] The helper rolls back layout changes when validation fails.
+- [ ] The helper does not run from ordinary app startup or status polling.
+- [ ] Focused tests cover include placement, idempotency, malformed markers, file creation, permissions where practical, validation, and rollback.
+- [ ] No managed-share behavior is migrated in this slice beyond creating the empty SSS shares file.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/02-move-managed-shares-to-sss-shares-file.md
+++ b/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/02-move-managed-shares-to-sss-shares-file.md
@@ -1,0 +1,38 @@
+# Move Managed Shares To The SSS Shares File
+
+## What to build
+
+Move SimpleSaferServer-managed share behavior onto the SSS-owned shares file. A managed share is any
+share section in the SSS shares file. Comments may remain for human readability, but normal app code
+must not use share marker comments as the ownership boundary.
+
+The completed slice should make share listing, creation, update, deletion, and setup's default
+`backup` share use the SSS shares file. It should reject unsafe name conflicts with non-SSS Samba
+shares and keep the setup retry experience short and clear.
+
+## Acceptance criteria
+
+- [ ] Managed share listing reads shares from the SSS shares file.
+- [ ] Managed share creation writes new share sections to the SSS shares file.
+- [ ] Managed share update rewrites the selected share in the SSS shares file.
+- [ ] Managed share deletion removes the selected share from the SSS shares file.
+- [ ] Normal app behavior no longer treats marker comments in the main Samba config as managed-share ownership.
+- [ ] Before creating a new managed share, the app rejects the operation if that share name exists outside the SSS shares file.
+- [ ] Before renaming a managed share, the app rejects the operation if the new name exists outside the SSS shares file.
+- [ ] Conflict detection respects non-SSS includes where practical by using Samba's effective config or another equally safe effective-config check.
+- [ ] If conflict detection cannot prove safety, the operation is rejected instead of relying on include precedence.
+- [ ] Setup completion creates or updates the default `backup` share only after the configured mount point is known.
+- [ ] If an unmanaged `backup` share already exists, setup completion returns the short retryable message: `Samba share "backup" already exists. Rename or remove it, then retry.`
+- [ ] A failed unmanaged `backup` conflict does not clear persisted setup values.
+- [ ] Manual unsupported directives in the SSS shares file do not crash share listing or supported-field display.
+- [ ] Editing a share through the Web UI may rewrite that share in the supported SSS format and drop unsupported directives.
+- [ ] Structurally malformed SSS shares file content returns a clear API error instead of crashing.
+- [ ] Share writes ensure the SSS layout exists before editing the shares file.
+- [ ] Share writes validate the effective Samba config before publish.
+- [ ] Share writes roll back when validation fails or required `smbd` restart fails.
+- [ ] Focused tests cover SSS-file list/create/update/delete, unmanaged conflict rejection, setup `backup` conflict messaging, unsupported directive tolerance, malformed file errors, validation, and rollback.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+- Issue 1 - Establish SSS-owned Samba layout.

--- a/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/03-install-and-report-discovery-services.md
+++ b/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/03-install-and-report-discovery-services.md
@@ -1,0 +1,34 @@
+# Install And Report Discovery Services
+
+## What to build
+
+Update install/update behavior so SimpleSaferServer prepares the SSS Samba layout, treats `smbd` as
+the required file-serving daemon, treats `nmbd` as desired legacy discovery, and optionally installs
+and starts `wsdd2` for modern Windows Network discovery.
+
+The completed slice should keep core installation strict for `smbd` while allowing discovery
+degradation for `nmbd` and `wsdd2`. It should not create a custom `wsdd` service or install both WSD
+daemons.
+
+## Acceptance criteria
+
+- [ ] The install/update path invokes the shared Samba layout helper instead of duplicating Samba include edits in Bash where practical.
+- [ ] The install/update path prepares the SSS Samba layout but does not create the default `backup` share.
+- [ ] `wsdd2` is installed through a separate optional install attempt rather than the fatal core dependency command.
+- [ ] If `wsdd2` is unavailable or optional installation fails, the installer warns and continues.
+- [ ] The installer does not install or manage `wsdd`.
+- [ ] The installer does not create a custom SimpleSaferServer systemd wrapper for `wsdd`.
+- [ ] The install/update path enables and starts `smbd`.
+- [ ] The install/update path fails when `smbd` cannot become active.
+- [ ] The install/update path enables and starts `nmbd` best-effort.
+- [ ] The install/update path warns but continues when `nmbd` is inactive or skipped.
+- [ ] The install/update path enables and starts `wsdd2` best-effort when `wsdd2` is installed.
+- [ ] The install/update path warns but continues when `wsdd2` is unavailable or inactive.
+- [ ] Installer output includes a concise summary for `smbd`, `nmbd`, and `wsdd2`.
+- [ ] Existing non-discovery install behavior remains unchanged.
+- [ ] Focused tests or shell/static tests cover optional `wsdd2`, required `smbd`, best-effort `nmbd`, service summary output, and the helper call path.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+- Issue 1 - Establish SSS-owned Samba layout.

--- a/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/04-track-three-file-sharing-services-in-web-ui.md
+++ b/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/04-track-three-file-sharing-services-in-web-ui.md
@@ -1,0 +1,39 @@
+# Track Three File-Sharing Services In The Web UI
+
+## What to build
+
+Extend the file-sharing status and restart experience from two services to three: `smbd`, `nmbd`,
+and `wsdd2`.
+
+The completed slice should update the flat status API, restart behavior, Network File Sharing page,
+and Dashboard summary. It should label the services by purpose, keep explanations lightweight, and
+use the agreed operational rules: all three active is operational, `smbd` active with incomplete
+discovery is partial, and `smbd` inactive is down.
+
+## Acceptance criteria
+
+- [ ] The service status API returns a flat object containing `smbd`, `nmbd`, and `wsdd2`.
+- [ ] Missing `wsdd2` unit/service is reported as `unavailable`.
+- [ ] Existing `smbd` and `nmbd` status behavior remains compatible with current callers after the new field is added.
+- [ ] The restart API attempts to restart `smbd`, `nmbd`, and `wsdd2`.
+- [ ] The restart API fails when `smbd` restart fails.
+- [ ] `nmbd` or `wsdd2` restart failure does not trigger share rollback; status polling can show the partial state.
+- [ ] The Network File Sharing page shows `SMB Daemon (smbd)`.
+- [ ] The Network File Sharing page shows `NetBIOS Discovery (nmbd)`.
+- [ ] The Network File Sharing page shows `Windows Discovery (wsdd2)`.
+- [ ] The `smbd` hover/help text says it serves file shares.
+- [ ] The `nmbd` hover/help text says it helps older Windows network browsing find this server.
+- [ ] The `wsdd2` hover/help text says it helps modern Windows network browsing find this server.
+- [ ] Network File Sharing overall status is `Operational` only when all three services are active.
+- [ ] Network File Sharing overall status is `Partial` when `smbd` is active and `nmbd` or `wsdd2` is inactive/unavailable.
+- [ ] Network File Sharing overall status is `Down` when `smbd` is inactive.
+- [ ] Dashboard file-sharing summary includes `wsdd2` in its detail text.
+- [ ] Dashboard file-sharing summary uses the same operational/partial/down rules as the Network File Sharing page.
+- [ ] UI changes reuse existing Bunker service-status patterns and avoid a new explanation panel.
+- [ ] Focused API, service, and UI rendering tests cover all-three active, discovery partial, missing `wsdd2`, and `smbd` down cases.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+- Issue 2 - Move managed shares to the SSS shares file.
+- Issue 3 - Install and report discovery services.

--- a/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/05-clean-up-sss-owned-samba-config-on-uninstall.md
+++ b/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/05-clean-up-sss-owned-samba-config-on-uninstall.md
@@ -1,0 +1,30 @@
+# Clean Up SSS-Owned Samba Config On Uninstall
+
+## What to build
+
+Update uninstall behavior for the new Samba ownership model.
+
+The completed slice should remove only SimpleSaferServer-owned Samba include blocks and owned Samba
+files. It should leave unmanaged Samba config, shared packages, and non-SSS service state alone.
+
+## Acceptance criteria
+
+- [ ] Uninstall removes the SSS global include block from the main Samba config.
+- [ ] Uninstall removes the SSS shares include block from the main Samba config.
+- [ ] Uninstall deletes the SSS globals file.
+- [ ] Uninstall deletes the SSS shares file.
+- [ ] Uninstall leaves unrelated include lines in the main Samba config untouched.
+- [ ] Uninstall leaves unmanaged Samba share blocks untouched.
+- [ ] Uninstall leaves Samba packages installed.
+- [ ] Uninstall leaves `wsdd2` installed if present.
+- [ ] Uninstall does not blindly disable `wsdd2.service`.
+- [ ] Uninstall continues removing SimpleSaferServer-created Samba users according to existing user cleanup behavior.
+- [ ] Uninstall final messaging mentions that SSS-owned Samba include files were removed.
+- [ ] Uninstall final messaging mentions that shared packages/services such as Samba and `wsdd2` are left installed.
+- [ ] Malformed SSS include marker blocks fail closed instead of rewriting `smb.conf` dangerously.
+- [ ] Focused uninstall tests cover include block removal, owned file deletion, unrelated include preservation, unmanaged share preservation, malformed marker rejection, and final messaging.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+- Issue 1 - Establish SSS-owned Samba layout.

--- a/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/06-document-samba-ownership-and-discovery.md
+++ b/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/06-document-samba-ownership-and-discovery.md
@@ -1,0 +1,35 @@
+# Document Samba Ownership And Discovery
+
+## What to build
+
+Update operator-facing documentation and the public documentation index copy so it matches the new
+Samba ownership and discovery behavior.
+
+The completed slice should explain SSS-owned include files, the role of `smbd`, `nmbd`, and
+`wsdd2`, setup conflict behavior, manual-edit expectations, and uninstall cleanup. Do not edit the
+README.
+
+## Acceptance criteria
+
+- [ ] Network File Sharing docs describe SSS-owned Samba files and file-path ownership.
+- [ ] Network File Sharing docs explain that comments in SSS-owned files are for humans and are not the ownership boundary.
+- [ ] Network File Sharing docs explain that normal share changes should use the Web UI.
+- [ ] Network File Sharing docs explain that unsupported manual directives may be overwritten by Web UI edits.
+- [ ] Network File Sharing docs explain that existing shares outside the SSS shares file are unmanaged and will not be overwritten.
+- [ ] Network File Sharing docs explain the `backup` share conflict and retry behavior.
+- [ ] Network File Sharing docs explain `smbd`, `nmbd`, and `wsdd2` by purpose.
+- [ ] Install docs mention that `wsdd2` is optional modern Windows discovery support.
+- [ ] Manual install docs mention the SSS Samba layout/helper behavior and the optional `wsdd2` package.
+- [ ] Uninstall docs mention removal of SSS Samba include blocks and owned Samba files.
+- [ ] Uninstall docs state that shared packages such as Samba and `wsdd2` are left installed.
+- [ ] Public `index.html` uninstall copy matches the new owned-file cleanup behavior.
+- [ ] Existing documentation links in `index.html` remain valid.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+- Issue 1 - Establish SSS-owned Samba layout.
+- Issue 2 - Move managed shares to the SSS shares file.
+- Issue 3 - Install and report discovery services.
+- Issue 4 - Track three file-sharing services in the Web UI.
+- Issue 5 - Clean up SSS-owned Samba config on uninstall.

--- a/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/README.md
+++ b/planning-archive/nmbd-wsdd2/samba-discovery-config-redesign/issues/README.md
@@ -1,0 +1,43 @@
+# Samba Discovery and Config Ownership Issues
+
+These local issue files break the PRD into dependency-ordered AFK slices. They move
+SimpleSaferServer's Samba ownership boundary to SSS-owned include files, add optional modern Windows
+discovery through `wsdd2`, and update install, UI, uninstall, and docs behavior.
+
+## Breakdown
+
+1. **Establish SSS-owned Samba layout**
+   - **Type**: AFK
+   - **Blocked by**: None
+   - **User stories covered**: 21, 22, 25, 26, 31, 32, 33, 34, 35
+   - **File**: [01-establish-sss-owned-samba-layout.md](01-establish-sss-owned-samba-layout.md)
+
+2. **Move managed shares to the SSS shares file**
+   - **Type**: AFK
+   - **Blocked by**: Issue 1
+   - **User stories covered**: 17, 18, 19, 20, 23, 24, 36, 37
+   - **File**: [02-move-managed-shares-to-sss-shares-file.md](02-move-managed-shares-to-sss-shares-file.md)
+
+3. **Install and report discovery services**
+   - **Type**: AFK
+   - **Blocked by**: Issue 1
+   - **User stories covered**: 1, 2, 3, 4, 5, 6, 7, 8
+   - **File**: [03-install-and-report-discovery-services.md](03-install-and-report-discovery-services.md)
+
+4. **Track three file-sharing services in the Web UI**
+   - **Type**: AFK
+   - **Blocked by**: Issues 2 and 3
+   - **User stories covered**: 9, 10, 11, 12, 13, 14, 15, 16
+   - **File**: [04-track-three-file-sharing-services-in-web-ui.md](04-track-three-file-sharing-services-in-web-ui.md)
+
+5. **Clean up SSS-owned Samba config on uninstall**
+   - **Type**: AFK
+   - **Blocked by**: Issue 1
+   - **User stories covered**: 27, 28, 29, 30
+   - **File**: [05-clean-up-sss-owned-samba-config-on-uninstall.md](05-clean-up-sss-owned-samba-config-on-uninstall.md)
+
+6. **Document Samba ownership and discovery**
+   - **Type**: AFK
+   - **Blocked by**: Issues 1, 2, 3, 4, and 5
+   - **User stories covered**: 38, 39, 40
+   - **File**: [06-document-samba-ownership-and-discovery.md](06-document-samba-ownership-and-discovery.md)

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/PRD.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/PRD.md
@@ -1,0 +1,174 @@
+# Samba Effective Config Hardening PRD
+
+## Problem Statement
+
+The Samba discovery/config redesign moved SimpleSaferServer-managed shares into an owned shares
+file, but the implementation still has a few pre-submit safety gaps. Administrators need
+SimpleSaferServer to detect Unmanaged Samba Shares the same way Samba loads them, fail required
+`smbd` paths when core file serving cannot run, recover cleanly from failed share publishes, and
+remove owned Samba files during uninstall even when the main Samba config is missing.
+
+The current implementation validates Samba configs with `testparm`, but unmanaged-share conflict
+detection still scans the main Samba config text directly. That misses shares from non-SSS include
+files and can allow a SimpleSaferServer-Managed Share to be created with a name Samba already loads
+from another source. The installer also prepares Samba services without checking the required
+service setup function's return value, share-publish rollback restores the old shares file without
+restarting `smbd`, uninstall skips owned-file deletion when the main Samba config is absent, and
+manual install docs use an import command that can fail outside the app directory.
+
+## Solution
+
+Harden the Samba redesign before submission. Use Samba's own include-aware parsing for Unmanaged
+Samba Share detection by running `testparm` against a volatile stripped copy of the main Samba
+config with SimpleSaferServer-owned include blocks removed. Keep the SimpleSaferServer-owned shares
+file as the source of truth for SimpleSaferServer-Managed Shares. Treat write-safety verification as
+fail-closed, and present read/UI verification problems as controlled warnings or errors instead of
+pretending no unmanaged shares exist.
+
+Make share publishing rollback complete by restarting `smbd` after restoring the previous
+SimpleSaferServer-owned shares file. Make the installer honor required `smbd` failure while still
+warning loudly, rather than failing, when boot-enable commands fail but `smbd` is active. Split
+uninstall's include-block rewrite from owned-file deletion. Update manual install documentation so
+the Samba layout helper command works from a copied app directory.
+
+## User Stories
+
+1. As an administrator, I want SimpleSaferServer to detect Samba shares from non-SSS include files, so that the app does not create duplicate share names.
+2. As an administrator, I want setup to reject an unmanaged `backup` share loaded from any Samba include, so that setup does not silently override my manual Samba config.
+3. As an administrator, I want the Network File Sharing page to warn about Unmanaged Samba Shares from the Effective Samba Config, so that the UI matches what Samba actually loads.
+4. As an administrator, I want unmanaged-share verification failures to be visible, so that I do not mistake an inspection problem for a clean Samba config.
+5. As an administrator using SD-card storage, I want temporary Samba inspection files to live under the volatile runtime directory, so that ordinary verification does not add avoidable disk wear.
+6. As an administrator, I want share create and rename operations to fail closed when Samba's effective config cannot be inspected, so that SimpleSaferServer never relies on include precedence guesses.
+7. As an administrator, I want editing an existing SimpleSaferServer-Managed Share to keep using the owned shares file, so that ownership remains file-path based.
+8. As an administrator, I want deleting a SimpleSaferServer-Managed Share to avoid unnecessary unmanaged conflict checks, so that deletion stays focused on owned state.
+9. As an administrator, I want a failed share publish to restore the old shares file and restart `smbd`, so that rollback attempts to return file serving to the previous working state.
+10. As an administrator, I want rollback restart failures reported clearly, so that I know when Samba may still need manual recovery.
+11. As an administrator, I want add/edit/delete/restart failures to appear in the existing modal or toast notification flow, so that errors are actionable in the Web UI.
+12. As an administrator, I want the installer to stop when `smbd` is not active after service setup, so that a broken file server is not reported as a successful install.
+13. As an administrator, I want loud installer warnings when `smbd` is active but enabling it at boot fails, so that I can fix reboot persistence before relying on file sharing.
+14. As an administrator, I want discovery service failures to remain non-fatal, so that `nmbd` or `wsdd2` problems do not block direct SMB file serving.
+15. As an administrator, I want uninstall to delete SimpleSaferServer-owned Samba files even if the main Samba config is missing, so that app-owned config is cleaned up predictably.
+16. As an administrator, I want uninstall to avoid rewriting malformed main Samba config marker blocks, so that unrelated Samba config is not damaged.
+17. As an administrator, I want uninstall to leave shared Samba packages and unrelated service state alone, so that host-level services are not unexpectedly removed or disabled.
+18. As an administrator following manual install docs, I want the Samba layout helper command to work from the installed app directory, so that manual setup does not fail on Python import paths.
+19. As a future maintainer, I want one tested path for Unmanaged Samba Share detection, so that UI warnings and write safety cannot drift apart.
+20. As a future maintainer, I want the phrase Unmanaged Samba Share to mean include-aware Samba state, so that future code does not reintroduce direct `smb.conf` scanning.
+21. As a future maintainer, I want temporary effective-config inspection to use the runtime volatile directory, so that the no-SD-card-wear reasoning is preserved in code and tests.
+22. As a future maintainer, I want rollback tests to prove service recovery is attempted after restoring old config, so that publish failure handling remains operationally complete.
+23. As a future maintainer, I want installer tests to cover the top-level function return handling, so that required service failures cannot be accidentally ignored again.
+24. As a future maintainer, I want uninstall tests to cover missing main config plus owned-file deletion, so that cleanup is not coupled to one file's existence.
+25. As a future maintainer, I want manual install documentation checked with the same import-path assumptions as the installer, so that docs do not drift from code behavior.
+
+## Implementation Decisions
+
+- Keep file-path ownership as the Samba management boundary.
+- A SimpleSaferServer-Managed Share is still any share section sourced from the SimpleSaferServer-owned shares file.
+- An Unmanaged Samba Share is any non-system share that Samba can load after SimpleSaferServer-owned include blocks are excluded.
+- Do not use comments or legacy share marker blocks to determine SimpleSaferServer ownership.
+- Do not use direct main-config scanning as the authority for unmanaged-share write safety.
+- Add a deep, testable service/helper method for Unmanaged Samba Share inspection.
+- The unmanaged-share inspector should read the live main Samba config, remove only SimpleSaferServer-owned include marker blocks, write the stripped candidate under the volatile runtime directory, run `testparm -s` on that candidate, parse non-system section names from the output, and delete the candidate.
+- The volatile runtime directory is required for real-mode effective-config inspection. Do not fall back to `/tmp` for write-safety checks.
+- Effective-config inspection failures should fail create, rename, and setup default-share writes with a controlled operation/validation response.
+- The Network File Sharing page should use the same Unmanaged Samba Share detection path for its warning state. If inspection fails on this read path, return a controlled response that lets the UI show that unmanaged shares could not be verified.
+- Managed share listing, editing, and deletion should continue parsing the SimpleSaferServer-owned shares file directly.
+- Before creating a SimpleSaferServer-Managed Share, reject the target name if it appears as an Unmanaged Samba Share.
+- Before renaming a SimpleSaferServer-Managed Share, reject the new name if it appears as an Unmanaged Samba Share.
+- Updating an existing SimpleSaferServer-Managed Share without changing its name should not be blocked by that owned name appearing in the full live config.
+- Share publish rollback should restore the previous SimpleSaferServer-owned shares file and then restart the required `smbd` service path.
+- If rollback restart fails, expose a controlled operation error that states the share update failed and rollback could not restart `smbd`.
+- Existing frontend modal/toast behavior should surface these controlled API problem details without creating a new UI pattern.
+- The installer should check the return value from Samba service setup and exit when `smbd` is not active after service setup.
+- The installer should treat `smbd` active state as the hard requirement. Failed `enable` or `start` commands should warn loudly when final active state is still `active`.
+- Discovery services remain best-effort. `nmbd` and `wsdd2` enable/start/status failures should warn or show partial state, not fail install or share publish.
+- Uninstall should rewrite the main Samba config only when it exists.
+- Uninstall should delete SimpleSaferServer-owned Samba files regardless of whether the main Samba config exists.
+- Malformed SimpleSaferServer include marker blocks should still prevent rewriting the main Samba config.
+- Manual install docs should run the Samba layout helper from the installed app directory and insert the installed app path into `sys.path`, matching the automated installer's import assumptions.
+- Do not edit `README.md`.
+- Do not add startup auto-heal or status-polling writes.
+
+Major modules to build or modify:
+
+- Samba layout/helper service: expose reusable marker-block stripping or effective-config inspection behavior without duplicating parsing in unrelated modules.
+- SMB command adapter: support `testparm` effective config inspection as a first-class command shape.
+- SMB manager: use include-aware Unmanaged Samba Share detection for list warnings, create conflicts, rename conflicts, and setup default `backup` conflicts; complete rollback by restarting `smbd` after restore.
+- SMB routes/API response mapping: preserve controlled Problem Details so the existing UI can display actionable modal/toast errors.
+- Network File Sharing template: show a controlled verification warning if unmanaged-share inspection cannot be completed.
+- Installer script: check required Samba service setup return value and add loud `smbd` enable/start warnings when active state still passes.
+- Uninstaller script: split main-config rewrite from owned-file deletion.
+- Manual install docs: update the Samba layout helper command.
+
+## Testing Decisions
+
+Good tests should verify external behavior and safety boundaries rather than private implementation
+details. The important behavior is that SimpleSaferServer uses Samba's include-aware config loading
+for Unmanaged Samba Share detection, never overwrites a user share by name, avoids non-volatile temp
+writes for write-safety inspection, completes rollback service recovery, fails required `smbd`
+installer paths, and cleans up owned files on uninstall.
+
+Modules and behaviors to test:
+
+- Effective config / unmanaged-share inspection:
+  - Runs `testparm` against a stripped candidate config with SimpleSaferServer-owned include blocks removed.
+  - Uses the volatile runtime directory for the candidate file.
+  - Does not fall back to `/tmp` when the volatile runtime directory cannot be used for write safety.
+  - Parses non-system share names from `testparm` output.
+  - Respects non-SSS include files in the stripped config.
+  - Fails closed when marker blocks are malformed.
+  - Fails closed when `testparm` cannot run or returns failure.
+- SMB manager:
+  - Lists SimpleSaferServer-Managed Shares from the owned shares file.
+  - Lists/warns about Unmanaged Samba Shares from stripped effective config.
+  - Rejects create when the target name exists in stripped effective config.
+  - Rejects rename when the new name exists in stripped effective config.
+  - Rejects setup default `backup` when stripped effective config contains unmanaged `backup`.
+  - Allows updating an existing owned share without treating itself as unmanaged.
+  - Restores the old shares file after publish failure.
+  - Restarts `smbd` after rollback restore.
+  - Surfaces rollback restart failure as a controlled operation error.
+- API/UI:
+  - Add/edit/delete/restart failures continue displaying API detail text through existing modal/toast behavior.
+  - Unmanaged-share verification failure on page load is visible and not silently treated as zero unmanaged shares.
+- Installer:
+  - Top-level installer exits when Samba service setup returns failure.
+  - `smbd` inactive after start fails install.
+  - `smbd` enable/start command failure with final active state still active emits a loud warning and continues.
+  - `nmbd` and `wsdd2` failures remain non-fatal and are included in service summary behavior.
+- Uninstaller:
+  - Deletes SimpleSaferServer-owned Samba files when the main Samba config is missing.
+  - Removes include blocks when the main Samba config exists.
+  - Does not rewrite malformed marker blocks.
+  - Leaves unmanaged shares, unrelated include lines, shared packages, and non-SSS service state alone.
+- Documentation:
+  - Manual install command works from the installed app directory and mirrors automated installer import-path behavior.
+  - Network File Sharing docs match the Effective Samba Config and Unmanaged Samba Share terminology.
+
+Prior art:
+
+- Existing Samba layout tests cover marker placement, idempotency, malformed marker failure, validation, and rollback.
+- Existing SMB manager tests cover SSS-file list/create/update/delete, unmanaged conflict rejection, validation failure rollback, restart behavior, and service status.
+- Existing installer preflight/static tests cover optional `wsdd2`, required service behavior, service summary output, and helper invocation.
+- Existing uninstall tests cover include block removal, owned file deletion, malformed marker rejection, and service-state preservation.
+- Existing app factory/template tests cover Network File Sharing and Dashboard rendering behavior.
+
+## Out of Scope
+
+- Reworking the Samba ownership model beyond the existing SSS-owned include file design.
+- Supporting custom `wsdd` wrappers or installing `wsdd`.
+- Making SimpleSaferServer a general Samba editor.
+- Preserving unsupported manual directives when a SimpleSaferServer-Managed Share is edited through the Web UI.
+- Removing Samba, `wsdd2`, or other shared packages on uninstall.
+- Adding startup auto-heal or Samba config rewrites on ordinary status polling.
+- Editing `README.md`.
+
+## Further Notes
+
+This PRD is a follow-up to the Samba discovery/config redesign review. The core design remains
+sound; this work closes pre-submit gaps found during review. The agreed terminology is recorded in
+the root context glossary: SimpleSaferServer-Managed Share, Unmanaged Samba Share, and Effective
+Samba Config.
+
+The preferred implementation should keep the effective-config inspection logic deep and narrow:
+callers should ask for Unmanaged Samba Shares without knowing how marker stripping, volatile temp
+files, `testparm`, and output parsing are coordinated.

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/01-detect-unmanaged-samba-shares-from-effective-config.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/01-detect-unmanaged-samba-shares-from-effective-config.md
@@ -1,0 +1,29 @@
+# Detect Unmanaged Samba Shares From Effective Config
+
+## What to build
+
+Create the shared inspection path for Unmanaged Samba Shares. The completed slice should ask Samba
+to parse a stripped candidate config instead of scanning the main Samba config text directly. The
+candidate should remove only SimpleSaferServer-owned include blocks, live under the volatile runtime
+directory, be checked with `testparm`, and produce non-system share names that callers can use for
+warnings and write-safety decisions.
+
+## Acceptance criteria
+
+- [ ] Unmanaged Samba Share inspection removes the SimpleSaferServer global include block from the candidate config.
+- [ ] Unmanaged Samba Share inspection removes the SimpleSaferServer shares include block from the candidate config.
+- [ ] The stripped candidate config is written under the runtime volatile directory.
+- [ ] Real-mode write-safety inspection does not fall back to `/tmp` when the volatile runtime directory is unavailable.
+- [ ] The candidate config is deleted after inspection.
+- [ ] Inspection runs `testparm -s` or the existing adapter's equivalent effective-config command against the stripped candidate.
+- [ ] Inspection parses non-system share section names from Samba's effective output.
+- [ ] Shares from non-SimpleSaferServer include files are detected.
+- [ ] System sections such as `global`, `homes`, `printers`, and `print$` are not reported as Unmanaged Samba Shares.
+- [ ] Malformed SimpleSaferServer include marker blocks fail closed.
+- [ ] `testparm` failure or unavailable effective-config inspection fails closed for write-safety callers.
+- [ ] Focused tests cover volatile temp placement, marker stripping, included unmanaged shares, system-section filtering, malformed markers, command failure, and cleanup.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/02-use-effective-unmanaged-share-detection-in-smb-writes.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/02-use-effective-unmanaged-share-detection-in-smb-writes.md
@@ -1,0 +1,26 @@
+# Use Effective Unmanaged-Share Detection In SMB Writes
+
+## What to build
+
+Wire include-aware Unmanaged Samba Share detection into the SMB write paths. Creating a
+SimpleSaferServer-Managed Share, renaming one, and setup's default `backup` share creation should
+reject names that already exist as Unmanaged Samba Shares in Samba's Effective Samba Config. Owned
+share listing and editing should continue using the SimpleSaferServer-owned shares file as the
+ownership boundary.
+
+## Acceptance criteria
+
+- [ ] Managed share listing still reads SimpleSaferServer-Managed Shares from the owned shares file.
+- [ ] Creating a SimpleSaferServer-Managed Share rejects a target name found by effective Unmanaged Samba Share inspection.
+- [ ] Renaming a SimpleSaferServer-Managed Share rejects a new name found by effective Unmanaged Samba Share inspection.
+- [ ] Setup default `backup` share creation rejects unmanaged `backup` from effective Unmanaged Samba Share inspection.
+- [ ] Updating an existing SimpleSaferServer-Managed Share without renaming does not treat itself as unmanaged.
+- [ ] Deleting a SimpleSaferServer-Managed Share does not require an unmanaged-share conflict check.
+- [ ] Effective-config inspection failures fail create, rename, and setup default-share writes with controlled API-visible errors.
+- [ ] Existing short setup conflict text is preserved for unmanaged `backup`: `Samba share "backup" already exists. Rename or remove it, then retry.`
+- [ ] Focused tests cover create conflict, rename conflict, setup `backup` conflict, no-rename update, delete behavior, and inspection failure.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+- Issue 1 - Detect Unmanaged Samba Shares From Effective Config.

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/03-surface-unmanaged-share-verification-state-in-ui.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/03-surface-unmanaged-share-verification-state-in-ui.md
@@ -1,0 +1,24 @@
+# Surface Unmanaged-Share Verification State In The UI
+
+## What to build
+
+Update the Network File Sharing share-list path so the page's unmanaged-share warning uses the same
+Effective Samba Config inspection as write safety. If inspection cannot verify Unmanaged Samba
+Shares on a read/page-load path, the UI should show a controlled warning state instead of silently
+reporting zero unmanaged shares.
+
+## Acceptance criteria
+
+- [ ] The share-list API uses effective Unmanaged Samba Share inspection for unmanaged-share warning data.
+- [ ] The share-list API response can represent an unmanaged-share verification failure without pretending no unmanaged shares exist.
+- [ ] The Network File Sharing page displays a visible warning/error state when unmanaged shares cannot be verified.
+- [ ] The existing unmanaged-share modal still lists detected Unmanaged Samba Share names when verification succeeds.
+- [ ] The UI reuses existing Bunker warning/toast/modal patterns and does not add a large explanatory panel.
+- [ ] Existing managed-share table behavior remains unchanged when unmanaged-share verification succeeds.
+- [ ] Focused API and rendering tests cover detected unmanaged shares, no unmanaged shares, and verification failure.
+- [ ] Related Network File Sharing docs are updated if the visible verification state changes operator behavior.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+- Issue 1 - Detect Unmanaged Samba Shares From Effective Config.

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/04-complete-smb-share-publish-rollback.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/04-complete-smb-share-publish-rollback.md
@@ -1,0 +1,22 @@
+# Complete SMB Share Publish Rollback
+
+## What to build
+
+Complete rollback behavior for SimpleSaferServer-owned shares file publishes. If a share write fails
+after the owned shares file has been replaced, the old file should be restored and the required
+`smbd` service path should be restarted so Samba is asked to return to the known-good config. If
+that rollback restart fails, the API should surface a controlled operation error with clear detail.
+
+## Acceptance criteria
+
+- [ ] Share publish failure restores the previous SimpleSaferServer-owned shares file.
+- [ ] After restoring the previous shares file, rollback attempts to restart `smbd`.
+- [ ] Rollback restart failure returns a controlled operation error instead of being hidden behind a generic failure.
+- [ ] The existing modal/toast flow surfaces the rollback failure detail from the API problem response.
+- [ ] Discovery service restart failures remain best-effort and do not roll back valid share writes.
+- [ ] Focused tests cover successful rollback restart and failed rollback restart.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/05-honor-required-smbd-failure-in-installer.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/05-honor-required-smbd-failure-in-installer.md
@@ -1,0 +1,24 @@
+# Honor Required smbd Failure In Installer
+
+## What to build
+
+Make the installer honor required Samba file-serving failure. The top-level installer should stop
+when Samba service setup reports that `smbd` is not active after setup. It should still distinguish
+that hard failure from loud warnings where `smbd` is active now but enable/start commands returned
+nonzero and reboot persistence may need administrator attention.
+
+## Acceptance criteria
+
+- [ ] The top-level installer checks the Samba service setup function's return value.
+- [ ] The installer exits nonzero when `smbd` is not active after Samba service setup.
+- [ ] `smbd` active state is the hard requirement for install success.
+- [ ] Failed `smbd` enable with final active state `active` prints a loud warning and continues.
+- [ ] Failed `smbd` start with final active state `active` prints a loud warning and continues.
+- [ ] Required `smbd` failure output includes actionable remediation guidance.
+- [ ] `nmbd` and `wsdd2` enable/start/status failures remain non-fatal and appear as warnings or summary state.
+- [ ] Focused shell/static tests cover top-level return handling, inactive `smbd`, active-with-enable-warning, active-with-start-warning, and best-effort discovery failures.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/06-clean-owned-samba-files-on-uninstall-independently.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/06-clean-owned-samba-files-on-uninstall-independently.md
@@ -1,0 +1,27 @@
+# Clean Owned Samba Files On Uninstall Independently
+
+## What to build
+
+Split uninstall's main Samba config rewrite from deletion of SimpleSaferServer-owned Samba files.
+When the main Samba config exists, uninstall should remove SimpleSaferServer include blocks without
+touching unrelated config. Whether or not the main config exists, uninstall should delete the owned
+globals and shares files. Malformed include marker blocks should still prevent unsafe rewrites of
+the main config.
+
+## Acceptance criteria
+
+- [ ] If the main Samba config exists, uninstall removes the SimpleSaferServer global include block.
+- [ ] If the main Samba config exists, uninstall removes the SimpleSaferServer shares include block.
+- [ ] If the main Samba config is missing, uninstall skips only the main-config rewrite.
+- [ ] Uninstall deletes the SimpleSaferServer-owned globals file even when the main Samba config is missing.
+- [ ] Uninstall deletes the SimpleSaferServer-owned shares file even when the main Samba config is missing.
+- [ ] Malformed SimpleSaferServer include marker blocks prevent rewriting the main Samba config.
+- [ ] Malformed main-config markers do not prevent deleting unambiguously owned SimpleSaferServer Samba files.
+- [ ] Uninstall leaves unmanaged shares, unrelated include lines, shared packages, and non-SSS service state alone.
+- [ ] Final uninstall messaging remains accurate.
+- [ ] Focused uninstall tests cover missing main config, owned-file deletion, normal include removal, malformed marker rejection, and unrelated config preservation.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/07-repair-manual-install-documentation.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/07-repair-manual-install-documentation.md
@@ -1,0 +1,20 @@
+# Repair Manual Install Documentation
+
+## What to build
+
+Update manual install documentation so the Samba layout helper command works from the installed app
+directory and mirrors the automated installer's import-path assumptions. The docs should remain
+operator-facing and should not require the app to be installed as a Python package.
+
+## Acceptance criteria
+
+- [ ] Manual install docs run the Samba layout helper from the installed app directory.
+- [ ] Manual install docs insert the installed app path into Python's import path before importing the app package.
+- [ ] The documented command still creates or refreshes the SimpleSaferServer-owned Samba layout without creating the default `backup` share.
+- [ ] Related Network File Sharing docs remain consistent with Effective Samba Config and Unmanaged Samba Share terminology if referenced.
+- [ ] `index.html` documentation links remain valid.
+- [ ] `README.md` is not modified.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/README.md
+++ b/planning-archive/nmbd-wsdd2/samba-effective-config-hardening/issues/README.md
@@ -1,0 +1,50 @@
+# Samba Effective Config Hardening Issues
+
+These local issue files break the PRD into dependency-ordered AFK slices. They harden the
+Samba discovery/config redesign by making Unmanaged Samba Share detection use Samba's Effective
+Samba Config, tightening required `smbd` failure handling, completing rollback behavior, and fixing
+uninstall/manual-install edge cases before submission.
+
+## Breakdown
+
+1. **Detect Unmanaged Samba Shares From Effective Config**
+   - **Type**: AFK
+   - **Blocked by**: None
+   - **User stories covered**: 1, 3, 4, 5, 6, 19, 20, 21
+   - **File**: [01-detect-unmanaged-samba-shares-from-effective-config.md](01-detect-unmanaged-samba-shares-from-effective-config.md)
+
+2. **Use Effective Unmanaged-Share Detection In SMB Writes**
+   - **Type**: AFK
+   - **Blocked by**: Issue 1
+   - **User stories covered**: 2, 6, 7, 8, 19, 20
+   - **File**: [02-use-effective-unmanaged-share-detection-in-smb-writes.md](02-use-effective-unmanaged-share-detection-in-smb-writes.md)
+
+3. **Surface Unmanaged-Share Verification State In The UI**
+   - **Type**: AFK
+   - **Blocked by**: Issue 1
+   - **User stories covered**: 3, 4, 11
+   - **File**: [03-surface-unmanaged-share-verification-state-in-ui.md](03-surface-unmanaged-share-verification-state-in-ui.md)
+
+4. **Complete SMB Share Publish Rollback**
+   - **Type**: AFK
+   - **Blocked by**: None
+   - **User stories covered**: 9, 10, 11, 22
+   - **File**: [04-complete-smb-share-publish-rollback.md](04-complete-smb-share-publish-rollback.md)
+
+5. **Honor Required smbd Failure In Installer**
+   - **Type**: AFK
+   - **Blocked by**: None
+   - **User stories covered**: 12, 13, 14, 23
+   - **File**: [05-honor-required-smbd-failure-in-installer.md](05-honor-required-smbd-failure-in-installer.md)
+
+6. **Clean Owned Samba Files On Uninstall Independently**
+   - **Type**: AFK
+   - **Blocked by**: None
+   - **User stories covered**: 15, 16, 17, 24
+   - **File**: [06-clean-owned-samba-files-on-uninstall-independently.md](06-clean-owned-samba-files-on-uninstall-independently.md)
+
+7. **Repair Manual Install Documentation**
+   - **Type**: AFK
+   - **Blocked by**: None
+   - **User stories covered**: 18, 25
+   - **File**: [07-repair-manual-install-documentation.md](07-repair-manual-install-documentation.md)

--- a/planning-archive/nmbd-wsdd2/samba-post-review-fixes/PRD.md
+++ b/planning-archive/nmbd-wsdd2/samba-post-review-fixes/PRD.md
@@ -1,0 +1,109 @@
+# Samba Post-Review Fixes PRD
+
+## Problem Statement
+
+A code review of the uncommitted Samba discovery/config redesign, effective-config hardening, and
+pre-submit cleanup work found three remaining issues that should be fixed before the changes are
+committed:
+
+1. **Uninstall never restarts Samba** after removing SimpleSaferServer include blocks from
+   `smb.conf` and deleting the owned include files. The running `smbd` keeps stale in-memory config
+   until the next reboot or manual restart. Active file transfers will be interrupted by the
+   restart, so the uninstall confirmation prompt must warn about this upfront.
+
+2. **Uninstall deletes owned files even when marker stripping fails**, leaving `smb.conf` with
+   `include` directives pointing to nonexistent files. Samba will fail to start on next restart.
+   The current behavior is acceptable (clean up SSS artifacts regardless), but the admin needs a
+   loud, actionable warning with exact manual recovery steps.
+
+3. **Dead code remains**: `samba_backup_dir` in the runtime dataclass, `copy_config` on
+   `SmbCommandAdapter`, and the legacy `/etc/samba/backups` directory created by older installs are
+   all unused after the redesign removed the backup-before-write pattern from SMBManager.
+
+## Solution
+
+Fix the three issues in the uninstall script, runtime, adapter, and documentation without changing
+the Samba ownership model or layout helper behavior.
+
+- Add a best-effort `smbd` restart after successful Samba cleanup in the uninstall script.
+- Add a Samba disconnect warning to the top-level uninstall confirmation prompt.
+- Add a loud warning with manual recovery steps when marker stripping fails but owned files are
+  deleted.
+- Remove `samba_backup_dir` from the runtime dataclass, its resolution, and its `mkdir` call.
+- Remove `copy_config` from `SmbCommandAdapter` and its test.
+- Add `rmdir /etc/samba/backups 2>/dev/null || true` to the uninstall script to clean up the empty
+  legacy directory without removing any backup files an admin might still want.
+- Update `docs/uninstall.md`, `index.html`, and the uninstall script's final summary to reflect the
+  restart behavior and Samba disconnect warning.
+
+## User Stories
+
+1. As an administrator, I want Samba to be restarted after uninstall removes its include wiring, so that the running service matches the on-disk config immediately.
+2. As an administrator, I want the uninstall confirmation to warn me that active Samba file transfers will be interrupted, so that I can finish transfers or warn users before proceeding.
+3. As an administrator, I want a clear error message with exact recovery steps when the uninstall cannot strip SimpleSaferServer markers from `smb.conf`, so that I know how to fix Samba manually.
+4. As an administrator, I want the legacy empty `/etc/samba/backups` directory cleaned up during uninstall, so that no SimpleSaferServer artifacts linger after removal.
+5. As an administrator, I want old backup files in `/etc/samba/backups` preserved during uninstall, so that I can use them for manual recovery if something went wrong.
+6. As a future maintainer, I want `samba_backup_dir` removed from the runtime, so that the codebase does not suggest a backup-before-write pattern that no longer exists.
+7. As a future maintainer, I want `copy_config` removed from the command adapter, so that dead adapter methods do not mislead about the system's actual capabilities.
+
+## Implementation Decisions
+
+- The uninstall script's `cleanup_managed_smb_shares` function should call
+  `systemctl restart smbd 2>/dev/null || echo "WARNING: ..."` after successfully rewriting
+  `smb.conf` and deleting owned files. Restart failure is best-effort — warn and continue.
+- Discovery services (`nmbd`, `wsdd2`) are NOT restarted during uninstall. They are shared system
+  services and the uninstaller's policy is to leave them running.
+- The top-level uninstall confirmation prompt should include:
+  "Active Samba file transfers will be interrupted."
+- When the Python marker-stripping script fails (malformed markers), the uninstall should print a
+  warning like: "WARNING: /etc/samba/smb.conf still contains include lines referencing the deleted
+  files. Remove lines referencing simple_safer_server_globals.conf and
+  simple_safer_server_shares.conf from /etc/samba/smb.conf, then run: systemctl restart smbd"
+- `samba_backup_dir` should be removed from: the runtime dataclass field, `resolve_*` helpers,
+  `get_runtime()` construction, `FakeState` initialization, and the `mkdir` call.
+- `copy_config` should be removed from `SmbCommandAdapter` and `test_smb_command_adapter.py`.
+- Test fixtures that set `samba_backup_dir` on fake runtimes should drop that field.
+- Add `rmdir /etc/samba/backups 2>/dev/null || true` to the uninstall script. Only removes if
+  empty; non-empty directories with old backup files are left untouched silently.
+
+## Testing Decisions
+
+Good tests should verify the observable behavior of the uninstall script's Samba cleanup path and
+confirm dead code is actually removed.
+
+Modules and behaviors to test:
+
+- Uninstall script (`tests/test_uninstall.py`):
+  - Successful cleanup restarts `smbd` (best-effort).
+  - Restart failure after cleanup warns but does not fail the function.
+  - Malformed markers path prints the manual recovery warning with file names and `systemctl restart smbd`.
+  - Legacy backup directory is removed when empty, left alone when non-empty.
+  - Top-level confirmation text includes the Samba disconnect warning.
+- Runtime and adapter:
+  - `samba_backup_dir` attribute no longer exists on the runtime.
+  - `copy_config` method no longer exists on `SmbCommandAdapter`.
+- Existing tests must remain green after removing `samba_backup_dir` from fixtures.
+
+Prior art:
+
+- `tests/test_uninstall.py` already tests `cleanup_managed_smb_shares` with fake `systemctl` and
+  temp directories.
+- `tests/test_smb_manager.py` and `tests/test_samba_layout.py` use `SimpleNamespace` runtimes that
+  will need `samba_backup_dir` removed.
+- `tests/test_smb_command_adapter.py` has the `copy_config` test to remove.
+
+## Out of Scope
+
+- Changing the Samba ownership model or layout helper behavior.
+- Modifying the installer script's service setup logic.
+- Adding new features to the Network File Sharing page.
+- Editing `README.md`.
+- Removing or modifying old backup files in `/etc/samba/backups`.
+
+## Further Notes
+
+This PRD is a follow-up to the code review of the combined Samba redesign changeset. The decisions
+were reached through a grilling session that weighed Samba runtime safety against clean artifact
+removal. The key trade-off: we accept that malformed-marker uninstalls leave `smb.conf` in a broken
+state (it was likely already broken), but we give the admin exact steps to recover instead of
+silently breaking Samba.

--- a/planning-archive/nmbd-wsdd2/samba-post-review-fixes/issues/01-remove-dead-samba-backup-dir-and-copy-config.md
+++ b/planning-archive/nmbd-wsdd2/samba-post-review-fixes/issues/01-remove-dead-samba-backup-dir-and-copy-config.md
@@ -1,0 +1,30 @@
+# Remove dead `samba_backup_dir` and `copy_config` code
+
+## Parent
+
+Planning/samba-post-review-fixes/PRD.md
+
+## What to build
+
+Remove the unused backup infrastructure left over from the old backup-before-write pattern that was
+replaced by the file-path ownership model:
+
+- Remove `samba_backup_dir` from the runtime dataclass, its resolution helper, the `get_runtime()`
+  construction calls, and the `mkdir` that creates it on startup.
+- Remove `copy_config` from `SmbCommandAdapter` and its unit test.
+- Remove `samba_backup_dir` from all test fixtures that set it on fake runtimes.
+
+This is pure dead code removal. No behavioral change to the application or uninstall script.
+
+## Acceptance criteria
+
+- [ ] `samba_backup_dir` attribute no longer exists on the runtime dataclass.
+- [ ] No `mkdir` call creates a backup directory on startup.
+- [ ] `copy_config` method no longer exists on `SmbCommandAdapter`.
+- [ ] `test_smb_command_adapter.py` no longer tests `copy_config`.
+- [ ] All test fixtures compile without referencing `samba_backup_dir`.
+- [ ] All existing tests pass.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-post-review-fixes/issues/02-uninstall-restarts-smbd-after-cleanup.md
+++ b/planning-archive/nmbd-wsdd2/samba-post-review-fixes/issues/02-uninstall-restarts-smbd-after-cleanup.md
@@ -1,0 +1,34 @@
+# Uninstall restarts smbd after successful Samba cleanup
+
+## Parent
+
+Planning/samba-post-review-fixes/PRD.md
+
+## What to build
+
+After `cleanup_managed_smb_shares` successfully rewrites `smb.conf` (include blocks stripped) and
+deletes the owned include files, restart `smbd` so the running service matches the on-disk config.
+The restart is best-effort: warn and continue if it fails.
+
+Because the restart interrupts active file transfers, add a warning to the top-level uninstall
+confirmation prompt: "Active Samba file transfers will be interrupted."
+
+Update `docs/uninstall.md` and the `index.html` uninstall section to mention that Samba is
+restarted and active transfers will be dropped.
+
+Discovery services (`nmbd`, `wsdd2`) are NOT restarted — they are shared system services and the
+uninstaller leaves them running.
+
+## Acceptance criteria
+
+- [ ] Successful `cleanup_managed_smb_shares` calls `systemctl restart smbd` after rewriting `smb.conf` and deleting owned files.
+- [ ] If `smbd` restart fails, a warning is printed but the function does not return failure.
+- [ ] The top-level uninstall confirmation prompt includes a line about active Samba file transfers being interrupted.
+- [ ] `docs/uninstall.md` mentions the `smbd` restart and transfer interruption.
+- [ ] `index.html` uninstall note mentions the `smbd` restart and transfer interruption.
+- [ ] `nmbd` and `wsdd2` are NOT restarted by the uninstall script.
+- [ ] Existing uninstall tests pass; new tests cover the restart and warning behavior.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-post-review-fixes/issues/03-uninstall-warns-broken-includes-on-malformed-markers.md
+++ b/planning-archive/nmbd-wsdd2/samba-post-review-fixes/issues/03-uninstall-warns-broken-includes-on-malformed-markers.md
@@ -1,0 +1,31 @@
+# Uninstall warns about broken includes when marker stripping fails
+
+## Parent
+
+Planning/samba-post-review-fixes/PRD.md
+
+## What to build
+
+When the Python marker-stripping script fails (malformed SimpleSaferServer include markers in
+`smb.conf`), the uninstall already deletes the owned include files and returns failure. Add a loud,
+actionable warning that tells the administrator exactly what to do:
+
+The warning should explain that `smb.conf` still contains `include` lines referencing the deleted
+files, name both files (`simple_safer_server_globals.conf` and `simple_safer_server_shares.conf`),
+and give the exact recovery command (`systemctl restart smbd`).
+
+This does NOT change the decision to delete owned files on failure — that behavior stays. The fix
+is purely about giving the admin a clear recovery path instead of silently leaving Samba in a
+broken state.
+
+## Acceptance criteria
+
+- [ ] When marker stripping fails, the uninstall prints a warning naming both deleted files and telling the admin to remove the referencing `include` lines from `smb.conf`.
+- [ ] The warning includes `systemctl restart smbd` as the final recovery step.
+- [ ] The owned files are still deleted (existing behavior preserved).
+- [ ] The function still returns failure (existing behavior preserved).
+- [ ] A test verifies the warning text appears in stdout when markers are malformed.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-post-review-fixes/issues/04-uninstall-cleans-up-legacy-empty-backup-directory.md
+++ b/planning-archive/nmbd-wsdd2/samba-post-review-fixes/issues/04-uninstall-cleans-up-legacy-empty-backup-directory.md
@@ -1,0 +1,26 @@
+# Uninstall cleans up legacy empty backup directory
+
+## Parent
+
+Planning/samba-post-review-fixes/PRD.md
+
+## What to build
+
+Older SimpleSaferServer installs created `/etc/samba/backups` for timestamped `smb.conf` backup
+snapshots. Now that the backup-before-write pattern is removed, new installs no longer create or
+populate this directory. The uninstall script should attempt to remove it if empty, but leave it
+alone (silently) if it still contains old backup files the admin might want for recovery.
+
+Add `rmdir /etc/samba/backups 2>/dev/null || true` to the uninstall script's Samba cleanup path.
+
+## Acceptance criteria
+
+- [ ] The uninstall script attempts `rmdir` on the legacy backup directory.
+- [ ] A non-empty backup directory is left untouched (no error, no warning).
+- [ ] An empty backup directory is removed.
+- [ ] A missing backup directory does not produce an error.
+- [ ] Existing uninstall tests pass.
+
+## Blocked by
+
+- Planning/samba-post-review-fixes/issues/01-remove-dead-samba-backup-dir-and-copy-config.md

--- a/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/PRD.md
+++ b/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/PRD.md
@@ -1,0 +1,102 @@
+# Samba Pre-Submit Cleanup PRD
+
+## Problem Statement
+
+The Samba discovery/config redesign and effective-config hardening work is functionally complete and
+tests pass, but a pre-merge review found four issues that should be fixed before the changes are
+committed:
+
+1. The share-user helper (`get_share_users`, `update_share_users`) depends on Effective Samba Config
+   inspection even though it only operates on SimpleSaferServer-Managed Shares. A broken admin-owned
+   Samba include can block reading or updating users for a share SimpleSaferServer already owns.
+
+2. The drive health documentation still tells operators to check `/etc/samba/smb.conf` as the share
+   config, when managed shares now live in `/etc/samba/simple_safer_server_shares.conf`.
+
+3. The old inline managed-share machinery (marker constants, `_commit_smb_conf`, `_write_smb_conf`,
+   `_validate_smb_conf_candidate`, `_restore_smb_conf_backup`, `_create_backup`, and the marker
+   check inside `_parse_smb_conf`) is dead code that contradicts the new file-path ownership model
+   and could mislead future maintainers.
+
+4. The Network File Sharing page uses a binary green/red badge for discovery services (`nmbd`,
+   `wsdd2`). When `wsdd2` is not installed, the API returns `unavailable`, which shows a red badge
+   as if something is broken. Discovery services are best-effort and deserve a three-tier badge.
+
+## Solution
+
+Fix the four issues in place without changing the overall Samba redesign architecture.
+
+- Make `_get_managed_share_or_raise()` check the SimpleSaferServer-owned shares file first. Only
+  inspect unmanaged shares afterward, and only to produce the "not managed by SimpleSaferServer"
+  error message.
+- Update `docs/drive_health.md` to reference the SSS shares file and the Network File Sharing page.
+- Remove the dead inline managed-share code from SMBManager.
+- Use three badge tiers for discovery services: green for `active`, yellow for `inactive`, grey for
+  `unavailable`. Keep smbd binary (green/red) since it is the hard requirement.
+
+## User Stories
+
+1. As an administrator, I want to read share users for an existing SimpleSaferServer-Managed Share even when an unrelated Samba include is broken, so that Effective Config problems do not block routine share management.
+2. As an administrator, I want to update share users for an existing SimpleSaferServer-Managed Share without depending on Effective Config inspection, so that ownership-based edits stay resilient.
+3. As an administrator, I want the drive health docs to point me to the correct file for managed shares, so that manual recovery guidance matches the actual system layout.
+4. As an administrator, I want the `wsdd2` badge to show grey when the package is not installed, so that I can distinguish "not available on this system" from "installed but broken."
+5. As an administrator, I want the `nmbd` badge to show yellow when inactive, so that I can see it is worth noticing without being alarmed by a red badge for a best-effort service.
+6. As an administrator, I want the `smbd` badge to stay red when inactive, so that the hard file-serving requirement is visually distinct from optional discovery.
+7. As a future maintainer, I want the old marker-based managed-share code removed, so that the codebase does not look like it supports two ownership models.
+8. As a future maintainer, I want `_get_managed_share_or_raise()` to clearly separate ownership proof from conflict detection, so that the dependency boundary is obvious in code.
+9. As a future maintainer, I want no dead `_commit_smb_conf` or `_write_smb_conf` methods, so that a future edit cannot accidentally reintroduce direct smb.conf share writes.
+10. As a future maintainer, I want the `MANAGED_SHARE_BEGIN_PREFIX` constant removed, so that grep results do not suggest legacy marker support is still active.
+
+## Implementation Decisions
+
+- `_get_managed_share_or_raise()` should call `_load_managed_shares_file()` first. If the share is found there, return it immediately without touching Effective Config inspection.
+- After the managed lookup fails, optionally inspect unmanaged shares to produce the "not managed" error. If that inspection also fails, fall back to a generic "share not found" error.
+- The following dead methods and constants should be removed from SMBManager: `MANAGED_SHARE_BEGIN_PREFIX`, `MANAGED_SHARE_END_PREFIX`, `_create_backup()`, `_write_smb_conf()`, `_validate_smb_conf_candidate()`, `_restore_smb_conf_backup()`, `_commit_smb_conf()`.
+- The `self.backup_dir` attribute and its `mkdir` in `__init__` should be removed since nothing writes to it after the dead methods are gone. The `samba_backup_dir` runtime field stays untouched (separate cleanup).
+- The `MANAGED_SHARE_BEGIN_PREFIX` break check inside `_parse_smb_conf()` should be removed. That method is still used by effective-config inspection but should parse testparm output without legacy marker awareness.
+- `docs/drive_health.md` line 178 should reference the Network File Sharing page and the SSS shares file. Line 186 should list `/etc/samba/simple_safer_server_shares.conf` as the managed share config location.
+- Discovery service badge logic in the Network File Sharing template should use: `active` → `badge-success`, `inactive` → `badge-warning`, `unavailable` → `badge-neutral`.
+- The `smbd` badge stays binary: `active` → `badge-success`, anything else → `badge-danger`.
+- The same three-tier logic applies to both `nmbd` and `wsdd2` badges for consistency, even though `nmbd` is unlikely to return `unavailable` in practice.
+
+## Testing Decisions
+
+Good tests should verify external behavior and safety boundaries. The important new behavior is that
+managed-share user reads succeed independently of Effective Config inspection, and that dead code
+removal does not regress existing share management paths.
+
+Modules and behaviors to test:
+
+- SMBManager:
+  - `get_share_users()` succeeds for an existing SimpleSaferServer-Managed Share when Effective Config inspection would fail.
+  - `update_share_users()` succeeds for an existing SimpleSaferServer-Managed Share when Effective Config inspection would fail.
+  - `get_share_users()` raises a clear error for an unmanaged share name (when inspection succeeds).
+  - `get_share_users()` raises a clear error for a share that does not exist anywhere.
+  - All existing SMBManager tests remain green after dead code removal.
+- Network File Sharing template (if existing pattern supports it):
+  - `wsdd2` status `unavailable` renders a neutral badge class.
+  - `wsdd2` status `inactive` renders a warning badge class.
+  - `nmbd` status `inactive` renders a warning badge class.
+  - `smbd` status `inactive` renders a danger badge class.
+
+Prior art:
+
+- Existing `tests/test_smb_manager.py` covers share user helpers, unmanaged conflict rejection, and
+  service status behavior.
+- Existing `tests/test_app_factory_routes.py` covers Network File Sharing page rendering and API
+  response structure.
+
+## Out of Scope
+
+- Removing `samba_backup_dir` from the runtime dataclass or its initialization.
+- Changing the Samba ownership model or layout helper behavior.
+- Adding new features to the Network File Sharing page.
+- Modifying the installer or uninstaller scripts.
+- Editing `README.md`.
+
+## Further Notes
+
+This PRD is a follow-up to the pre-merge code review of the Samba discovery/config redesign and
+effective-config hardening work. All four findings were discussed and agreed before this PRD was
+written. The existing 137 tests pass on the current uncommitted state; this work should keep them
+green while adding targeted coverage for the `_get_managed_share_or_raise` fix.

--- a/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/issues/01-managed-share-user-helpers-owned-file-first.md
+++ b/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/issues/01-managed-share-user-helpers-owned-file-first.md
@@ -1,0 +1,24 @@
+# Managed-share user helpers use owned-file lookup first
+
+## What to build
+
+Change `_get_managed_share_or_raise()` so it checks the SimpleSaferServer-owned shares file before
+touching Effective Samba Config inspection. If the share is found in the owned file, return it
+immediately. Only inspect unmanaged shares afterward to produce the "not managed by
+SimpleSaferServer" error when the share exists outside the owned file. If unmanaged inspection also
+fails, fall back to a generic "share not found" error.
+
+This makes `get_share_users()` and `update_share_users()` resilient to broken admin-owned Samba
+includes, since they only operate on shares SimpleSaferServer already owns.
+
+## Acceptance criteria
+
+- [ ] `get_share_users()` succeeds for an existing SimpleSaferServer-Managed Share when Effective Config inspection would fail.
+- [ ] `update_share_users()` succeeds for an existing SimpleSaferServer-Managed Share when Effective Config inspection would fail.
+- [ ] `get_share_users()` raises a clear "not managed" error for an unmanaged share name when inspection succeeds.
+- [ ] `get_share_users()` raises a clear "not found" error for a share that does not exist anywhere.
+- [ ] All existing SMBManager tests remain green.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/issues/02-remove-dead-inline-managed-share-machinery.md
+++ b/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/issues/02-remove-dead-inline-managed-share-machinery.md
@@ -1,0 +1,32 @@
+# Remove dead inline managed-share machinery
+
+## What to build
+
+Remove the old marker-based managed-share code from SMBManager that is no longer called by any
+active path. The new file-path ownership model replaced this machinery, and leaving it in place
+makes the codebase look like two ownership models are supported.
+
+Remove:
+- `MANAGED_SHARE_BEGIN_PREFIX` and `MANAGED_SHARE_END_PREFIX` constants
+- `_create_backup()` method
+- `_write_smb_conf()` method
+- `_validate_smb_conf_candidate()` method
+- `_restore_smb_conf_backup()` method
+- `_commit_smb_conf()` method
+- `self.backup_dir` attribute and its `mkdir` in `__init__`
+- The `MANAGED_SHARE_BEGIN_PREFIX` break check inside `_parse_smb_conf()`
+
+Keep `_read_smb_conf()`, `_get_default_config()`, and `_parse_smb_conf()` since they are still used
+by effective-config inspection. Do not touch the `samba_backup_dir` runtime field.
+
+## Acceptance criteria
+
+- [ ] None of the removed methods or constants exist in SMBManager.
+- [ ] `_parse_smb_conf()` no longer references `MANAGED_SHARE_BEGIN_PREFIX`.
+- [ ] All existing SMBManager tests remain green.
+- [ ] All existing samba layout tests remain green.
+- [ ] `grep` for `MANAGED_SHARE_BEGIN_PREFIX` in non-test Python files returns no results.
+
+## Blocked by
+
+- 01-managed-share-user-helpers-owned-file-first

--- a/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/issues/03-discovery-service-badges-three-tier.md
+++ b/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/issues/03-discovery-service-badges-three-tier.md
@@ -1,0 +1,31 @@
+# Discovery service badges use three-tier colors
+
+## What to build
+
+Update the Network File Sharing template so discovery service badges (`nmbd`, `wsdd2`) use
+three badge tiers instead of binary green/red:
+
+- `active` → green (`badge-success`)
+- `inactive` → yellow (`badge-warning`)
+- `unavailable` → grey (`badge-neutral`)
+
+The `smbd` badge stays binary: `active` → green, anything else → red (`badge-danger`), because
+`smbd` is the hard file-serving requirement.
+
+This prevents a red "unavailable" badge for `wsdd2` on systems where the package simply is not
+installed, and a red "inactive" badge for `nmbd` on systems where Samba's ExecCondition skips it.
+
+## Acceptance criteria
+
+- [ ] `wsdd2` status `unavailable` renders with `badge-neutral` class.
+- [ ] `wsdd2` status `inactive` renders with `badge-warning` class.
+- [ ] `wsdd2` status `active` renders with `badge-success` class.
+- [ ] `nmbd` status `inactive` renders with `badge-warning` class.
+- [ ] `nmbd` status `active` renders with `badge-success` class.
+- [ ] `smbd` status `inactive` still renders with `badge-danger` class.
+- [ ] `smbd` status `active` still renders with `badge-success` class.
+- [ ] All existing app factory/route tests remain green.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/issues/04-drive-health-docs-sss-shares-file.md
+++ b/planning-archive/nmbd-wsdd2/samba-pre-submit-cleanup/issues/04-drive-health-docs-sss-shares-file.md
@@ -1,0 +1,22 @@
+# Drive health docs reference SSS shares file
+
+## What to build
+
+Update `docs/drive_health.md` so the manual recovery section points operators to the correct
+location for SimpleSaferServer-managed shares.
+
+- Line 178 ("If the mount point changes, also check `/etc/samba/smb.conf`") should reference the
+  Network File Sharing page and `/etc/samba/simple_safer_server_shares.conf`.
+- Line 186 ("Samba share config: `/etc/samba/smb.conf`") should list
+  `/etc/samba/simple_safer_server_shares.conf` as the managed share config, and note that
+  `/etc/samba/smb.conf` is Samba's main config with SimpleSaferServer include wiring.
+
+## Acceptance criteria
+
+- [ ] `docs/drive_health.md` no longer tells operators to check `/etc/samba/smb.conf` as the share config for managed shares.
+- [ ] The manual recovery section references `/etc/samba/simple_safer_server_shares.conf` and the Network File Sharing page.
+- [ ] `/etc/samba/smb.conf` is still mentioned as Samba's main config file where appropriate.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-review-round-2-fixes/PRD.md
+++ b/planning-archive/nmbd-wsdd2/samba-review-round-2-fixes/PRD.md
@@ -1,0 +1,106 @@
+# Samba Review Round 2 Fixes PRD
+
+## Problem Statement
+
+A second code review of the uncommitted Samba redesign changeset found three remaining issues:
+
+1. **Installer rsync excludes `simple_safer_server/services/templates/`** — the `--exclude='templates'`
+   pattern matches at any depth, so the globals config template file is never deployed to
+   `/opt/SimpleSaferServer`. The installer's step 9 (`SambaLayoutService.ensure_layout()`) will fail
+   with `FileNotFoundError`, blocking installation entirely.
+
+2. **Dashboard and file sharing page show "Partial/Degraded" when wsdd2 is unavailable** — the
+   overall status logic treats any non-`active` state as degradation. On systems where wsdd2 was
+   never installed (package unavailable on the distro), the status API returns `"unavailable"`,
+   causing a permanent yellow badge. The semantic distinction is: `"unavailable"` means "never
+   installed / not applicable" while `"inactive"` means "installed but stopped." Only the latter is
+   degradation.
+
+3. **Two test patches are dead code** — `test_get_share_users_succeeds_when_effective_config_inspection_fails`
+   and `test_update_share_users_succeeds_when_effective_config_inspection_fails` patch
+   `_inspect_unmanaged_effective_shares` with `SMBConfigError`, but the code path never calls that
+   method (the share is found in the managed file, so inspection is skipped). The tests pass
+   identically without the patch.
+
+## Solution
+
+1. Anchor the rsync excludes in `install.sh` so only top-level `templates/` and `static/` are
+   excluded from the main app copy.
+
+2. Change the overall status logic on both the dashboard and the network file sharing page to treat
+   `"unavailable"` as non-degrading. Per-service badges on the file sharing page remain unchanged
+   (grey neutral for unavailable).
+
+3. Change the two test patches to use `AssertionError` side effects (matching the pattern already
+   used by `test_delete_managed_share_does_not_inspect_unmanaged_effective_config`) so they catch
+   regressions if someone accidentally adds an inspection call to those paths.
+
+## User Stories
+
+1. As an administrator running the installer, I want the Samba globals template file deployed correctly, so that `SambaLayoutService.ensure_layout()` succeeds and installation completes.
+2. As an administrator on a system without wsdd2, I want the dashboard to show "Operational" when smbd is active and discovery services are either active or not applicable, so that I am not alarmed by a permanent yellow badge for a package my distro does not provide.
+3. As an administrator on a system where wsdd2 is installed but stopped, I want the dashboard to show "Partial" so that I know a service that should be running is down.
+4. As an administrator viewing the network file sharing page, I want the overall status banner to follow the same operational/partial/down rules as the dashboard, so that the two pages agree.
+5. As an administrator viewing the network file sharing page, I want to see the individual wsdd2 badge as grey "unavailable" when the package is not installed, so that I know the service is absent rather than broken.
+6. As a future maintainer, I want the test patches on `get_share_users` and `update_share_users` to use `AssertionError` so that a regression adding unnecessary effective-config inspection is caught immediately.
+
+## Implementation Decisions
+
+- In `install.sh` line 558, change `--exclude='templates'` to `--exclude='/templates'` and
+  `--exclude='static'` to `--exclude='/static'`. The leading `/` anchors the pattern to the rsync
+  source root, so nested directories with the same name are no longer excluded.
+- In `templates/dashboard.html`, extract a helper (or inline condition) that treats both `'active'`
+  and `'unavailable'` as non-degrading for the overall status check. The three states become:
+  - Operational: smbd active AND nmbd is active-or-unavailable AND wsdd2 is active-or-unavailable
+  - Partial: smbd active but at least one discovery service is inactive (not unavailable)
+  - Down: smbd not active
+- In `templates/network_file_sharing.html`, apply the same overall status logic to the
+  `updateOverallStatus` call inside `loadSMBStatus()`.
+- The `discoveryBadgeClass` function and per-service badge rendering remain unchanged.
+- In `tests/test_smb_manager.py`, change the `side_effect` in
+  `test_get_share_users_succeeds_when_effective_config_inspection_fails` and
+  `test_update_share_users_succeeds_when_effective_config_inspection_fails` from
+  `smb_manager.SMBConfigError("broken include")` to
+  `AssertionError("should not inspect effective config for a managed share")`.
+
+## Testing Decisions
+
+Good tests verify observable behavior. The rsync fix is best verified by the existing
+`test_samba_layout_helper_invoked_without_creating_backup_share` install preflight test (which
+exercises the installer text) and by the `test_samba_layout.py` tests that exercise the template
+read. The dashboard/file-sharing status logic is client-side JavaScript tested by the existing
+`test_discovery_badges_use_three_tier_and_smbd_stays_binary` and
+`test_dashboard_file_sharing_summary_tracks_wsdd2_and_three_state_rules` integration tests, which
+should be updated to assert the new unavailable-is-not-degrading semantics.
+
+Modules to verify:
+
+- `install.sh`: confirm the rsync exclude anchoring does not break the existing preflight tests.
+- `templates/dashboard.html`: update
+  `test_dashboard_file_sharing_summary_tracks_wsdd2_and_three_state_rules` to assert the
+  unavailable-aware condition is present in the rendered page.
+- `templates/network_file_sharing.html`: update or add assertions in
+  `test_discovery_badges_use_three_tier_and_smbd_stays_binary` to confirm the overall status logic
+  treats unavailable as non-degrading.
+- `tests/test_smb_manager.py`: the two patched tests should still pass after changing to
+  `AssertionError`.
+
+Prior art:
+
+- `test_delete_managed_share_does_not_inspect_unmanaged_effective_config` already uses the
+  `AssertionError` pattern for the same purpose.
+- `tests/test_install_preflight.py` tests installer script text content.
+- `tests/test_app_factory_routes.py` tests rendered page content for status logic.
+
+## Out of Scope
+
+- Migration of old marker-wrapped shares (no existing installations to upgrade).
+- Global include placement inside old marker blocks (non-issue for fresh installs).
+- Changes to the Samba ownership model or layout helper behavior.
+- Changes to `README.md`.
+
+## Further Notes
+
+The rsync fix is a hard blocker — without it, no fresh installation can complete. The status logic
+fix is a UX improvement that prevents false alarms on systems where wsdd2 is simply not packaged.
+The test fix is housekeeping that makes intent explicit and catches future regressions.

--- a/planning-archive/nmbd-wsdd2/samba-review-round-2-fixes/issues/01-anchor-rsync-excludes-in-install-sh.md
+++ b/planning-archive/nmbd-wsdd2/samba-review-round-2-fixes/issues/01-anchor-rsync-excludes-in-install-sh.md
@@ -1,0 +1,28 @@
+# Anchor rsync excludes in install.sh
+
+## Parent
+
+Planning/samba-review-round-2-fixes/PRD.md
+
+## What to build
+
+The installer's main rsync command uses `--exclude='templates'` and `--exclude='static'` which
+match at any directory depth. This excludes `simple_safer_server/services/templates/` (containing
+the Samba globals config template) from deployment, causing `SambaLayoutService.ensure_layout()` to
+fail with `FileNotFoundError` at install step 9.
+
+Anchor both excludes to the rsync source root so only the top-level `templates/` and `static/`
+directories are excluded (they are copied separately in step 5). Nested directories with those
+names inside the Python package must be deployed with the main app copy.
+
+## Acceptance criteria
+
+- [ ] `--exclude='templates'` changed to `--exclude='/templates'` in the main rsync command.
+- [ ] `--exclude='static'` changed to `--exclude='/static'` in the main rsync command.
+- [ ] `simple_safer_server/services/templates/simple_safer_server_globals.conf` would be included in the rsync destination.
+- [ ] All existing install preflight tests pass.
+- [ ] All existing samba layout tests pass.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-review-round-2-fixes/issues/02-treat-unavailable-as-non-degrading-in-overall-status.md
+++ b/planning-archive/nmbd-wsdd2/samba-review-round-2-fixes/issues/02-treat-unavailable-as-non-degrading-in-overall-status.md
@@ -1,0 +1,40 @@
+# Treat "unavailable" as non-degrading in overall status logic
+
+## Parent
+
+Planning/samba-review-round-2-fixes/PRD.md
+
+## What to build
+
+The dashboard and network file sharing page both determine an overall Samba status (Operational /
+Partial / Down). Currently, any non-`active` state for `nmbd` or `wsdd2` triggers "Partial." On
+systems where wsdd2 is not packaged, the status API returns `"unavailable"`, causing a permanent
+yellow badge even though the system is operating as well as it can.
+
+Change the overall status logic on both pages so that `"unavailable"` is treated as non-degrading:
+
+- **Operational:** smbd active AND nmbd is active-or-unavailable AND wsdd2 is active-or-unavailable
+- **Partial:** smbd active but at least one discovery service is `inactive` or `error` (not `unavailable`)
+- **Down:** smbd not active
+
+The per-service badges on the network file sharing page remain unchanged — `discoveryBadgeClass`
+still shows grey/neutral for `"unavailable"`, yellow for `"inactive"`, green for `"active"`.
+
+Update the existing integration tests that assert on the rendered page's status logic to confirm the
+new unavailable-aware conditions are present.
+
+## Acceptance criteria
+
+- [ ] Dashboard shows "Operational" when smbd=active, nmbd=active, wsdd2=unavailable.
+- [ ] Dashboard shows "Partial" when smbd=active, nmbd=inactive, wsdd2=active.
+- [ ] Dashboard shows "Down" when smbd=inactive.
+- [ ] Network file sharing page overall status follows the same three rules.
+- [ ] Per-service badges on the file sharing page are unchanged (grey for unavailable).
+- [ ] `test_dashboard_file_sharing_summary_tracks_wsdd2_and_three_state_rules` updated and passes.
+- [ ] `test_discovery_badges_use_three_tier_and_smbd_stays_binary` updated and passes.
+- [ ] Documentation in `docs/network_file_sharing.md` and `docs/dashboard.md` updated to reflect
+      that "unavailable" discovery services do not degrade the overall status.
+
+## Blocked by
+
+None - can start immediately.

--- a/planning-archive/nmbd-wsdd2/samba-review-round-2-fixes/issues/03-change-test-patches-to-assertion-error.md
+++ b/planning-archive/nmbd-wsdd2/samba-review-round-2-fixes/issues/03-change-test-patches-to-assertion-error.md
@@ -1,0 +1,32 @@
+# Change test patches to AssertionError for effective-config inspection guards
+
+## Parent
+
+Planning/samba-review-round-2-fixes/PRD.md
+
+## What to build
+
+Two tests patch `_inspect_unmanaged_effective_shares` with `SMBConfigError` to prove that managed
+share user reads/updates do not depend on effective config inspection. However, the patched method
+is never called in those code paths (the share is found in the managed file first), so the patch is
+dead — the tests pass identically without it.
+
+Change both patches to use `AssertionError` side effects, matching the pattern already used by
+`test_delete_managed_share_does_not_inspect_unmanaged_effective_config`. This makes the intent
+explicit ("this must NOT be called") and catches regressions if someone accidentally adds an
+inspection call to those paths.
+
+Tests to change:
+
+- `test_get_share_users_succeeds_when_effective_config_inspection_fails`
+- `test_update_share_users_succeeds_when_effective_config_inspection_fails`
+
+## Acceptance criteria
+
+- [ ] Both tests use `side_effect=AssertionError("should not inspect effective config for a managed share")` instead of `side_effect=smb_manager.SMBConfigError("broken include")`.
+- [ ] Both tests still pass.
+- [ ] Test names updated to reflect the guard intent (e.g., `test_get_share_users_does_not_inspect_effective_config_for_managed_share`).
+
+## Blocked by
+
+None - can start immediately.

--- a/simple_safer_server/adapters/smb_commands.py
+++ b/simple_safer_server/adapters/smb_commands.py
@@ -15,14 +15,7 @@ class SmbCommandAdapter:
     def _command(self, *parts: str):
         return list(parts)
 
-    def copy_config(self, source: str, backup_path: str) -> None:
-        self._command_runner.run(
-            self._command("cp", source, backup_path),
-            check=True,
-            timeout=SMB_COMMAND_TIMEOUT_SECONDS,
-        )
-
-    def validate_config(self, validator: str, candidate_path: Path):
+    def validate_config(self, validator: str, candidate_path: Path, cwd: Optional[Path] = None):
         if Path(validator).name == "testparm":
             command = self._command(validator, "-s", str(candidate_path))
         else:
@@ -32,6 +25,7 @@ class SmbCommandAdapter:
             capture_output=True,
             text=True,
             timeout=SMB_COMMAND_TIMEOUT_SECONDS,
+            cwd=str(cwd) if cwd is not None else None,
         )
 
     def restart_unit(self, unit_name: str) -> None:

--- a/simple_safer_server/adapters/smb_commands.py
+++ b/simple_safer_server/adapters/smb_commands.py
@@ -35,6 +35,19 @@ class SmbCommandAdapter:
             timeout=SMB_COMMAND_TIMEOUT_SECONDS,
         )
 
+    def reload_config(self) -> None:
+        """Reload running smbd configuration gracefully using smbcontrol.
+
+        This notifies active daemons via Samba's messaging interface to re-read
+        their configuration files immediately, preventing active file transfers
+        and TCP connections from dropping (unlike systemctl restart).
+        """
+        self._command_runner.run(
+            self._command("smbcontrol", "smbd", "reload-config"),
+            check=True,
+            timeout=SMB_COMMAND_TIMEOUT_SECONDS,
+        )
+
     def unit_status(self, unit_name: str) -> str:
         """Return 'active', 'inactive', or 'unavailable' for a systemd unit.
 

--- a/simple_safer_server/adapters/smb_commands.py
+++ b/simple_safer_server/adapters/smb_commands.py
@@ -36,10 +36,29 @@ class SmbCommandAdapter:
         )
 
     def unit_status(self, unit_name: str) -> str:
+        """Return 'active', 'inactive', or 'unavailable' for a systemd unit.
+
+        'unavailable' means the unit file does not exist on this system (e.g.
+        wsdd2 on distros that don't package it).  We distinguish this from
+        'inactive' (unit exists but is stopped) by probing with systemctl cat.
+        """
         result = self._command_runner.run(
             self._command("systemctl", "is-active", unit_name),
             capture_output=True,
             text=True,
             timeout=SMB_COMMAND_TIMEOUT_SECONDS,
         )
-        return result.stdout.strip()
+        status = result.stdout.strip()
+        if status == "active":
+            return "active"
+        # 'inactive' from is-active covers both stopped units and missing units.
+        # Check whether the unit file actually exists on disk.
+        cat_result = self._command_runner.run(
+            self._command("systemctl", "cat", unit_name),
+            capture_output=True,
+            text=True,
+            timeout=SMB_COMMAND_TIMEOUT_SECONDS,
+        )
+        if cat_result.returncode != 0:
+            return "unavailable"
+        return status

--- a/simple_safer_server/routes/smb.py
+++ b/simple_safer_server/routes/smb.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from flask import Blueprint, current_app, request
 
-from simple_safer_server.services.smb_manager import SMB_DOCS_URL
+from simple_safer_server.services.smb_manager import SMB_DOCS_URL, SMBConfigError, SMBOperationError
 from simple_safer_server.services.user_manager import api_admin_required
 from simple_safer_server.web.api import json_data, json_problem, json_request_data
 from simple_safer_server.web.problems import OperationProblem, ValidationProblem
@@ -54,15 +54,31 @@ def api_list_smb_shares():
     try:
         manager = _get_services().smb_manager
         shares = manager.list_managed_shares()
-        unmanaged_shares = manager.list_unmanaged_shares()
+        unmanaged_shares = []
+        unmanaged_shares_verified = True
+        unmanaged_share_verification_error = None
+        try:
+            unmanaged_shares = manager.list_unmanaged_shares()
+        except SMBConfigError as exc:
+            # Managed-share listing is still useful on page load. Treat only
+            # the Effective Samba Config read as unverifiable so the UI can
+            # warn without pretending the unmanaged set is empty.
+            unmanaged_shares_verified = False
+            unmanaged_share_verification_error = str(exc)
         return json_data(
             {
                 "shares": shares,
+                "unmanaged_shares_verified": unmanaged_shares_verified,
                 "unmanaged_shares_detected": bool(unmanaged_shares),
-                "unmanaged_share_count": len(unmanaged_shares),
+                "unmanaged_share_count": (
+                    len(unmanaged_shares) if unmanaged_shares_verified else None
+                ),
                 "unmanaged_share_names": [share["name"] for share in unmanaged_shares],
+                "unmanaged_share_verification_error": unmanaged_share_verification_error,
             }
         )
+    except SMBConfigError as exc:
+        return json_problem(ValidationProblem(str(exc), slug="smb-validation-error"))
     except Exception as exc:
         current_app.logger.error("Error reading SMB shares: %s", exc)
         return json_problem(OperationProblem("Failed to read SMB shares."))
@@ -96,6 +112,8 @@ def api_add_smb_share():
         return json_data({}, message=f"Share {share_name} added successfully.")
     except ValueError as exc:
         return json_problem(ValidationProblem(str(exc), slug="smb-validation-error"))
+    except SMBOperationError as exc:
+        return json_problem(OperationProblem(str(exc), slug="smb-operation-failed"))
     except Exception as exc:
         current_app.logger.error("Error adding SMB share: %s", exc)
         return json_problem(
@@ -131,6 +149,8 @@ def api_edit_smb_share(share_name):
         return json_data({}, message=f"Share {share_name} updated successfully.")
     except ValueError as exc:
         return json_problem(ValidationProblem(str(exc), slug="smb-validation-error"))
+    except SMBOperationError as exc:
+        return json_problem(OperationProblem(str(exc), slug="smb-operation-failed"))
     except Exception as exc:
         current_app.logger.error("Error editing SMB share: %s", exc)
         return json_problem(
@@ -146,6 +166,8 @@ def api_delete_smb_share(share_name):
         return json_data({}, message=f"Share {share_name} deleted successfully.")
     except ValueError as exc:
         return json_problem(ValidationProblem(str(exc), slug="smb-validation-error"))
+    except SMBOperationError as exc:
+        return json_problem(OperationProblem(str(exc), slug="smb-operation-failed"))
     except Exception as exc:
         current_app.logger.error("Error deleting SMB share: %s", exc)
         return json_problem(

--- a/simple_safer_server/services/drive_health.py
+++ b/simple_safer_server/services/drive_health.py
@@ -296,6 +296,11 @@ def _load_model_and_threshold(model_path: str, threshold_path: str):
     if not PREDICTION_DEPENDENCIES_AVAILABLE:
         return None, 0.5
 
+    # Pyright does not connect the availability flag to the optional imports
+    # above, so keep the runtime invariant explicit where the model is loaded.
+    assert XGBClassifier is not None
+    assert joblib is not None
+
     model = XGBClassifier()
     try:
         model.load_model(model_path)

--- a/simple_safer_server/services/drive_health.py
+++ b/simple_safer_server/services/drive_health.py
@@ -298,8 +298,8 @@ def _load_model_and_threshold(model_path: str, threshold_path: str):
 
     # Pyright does not connect the availability flag to the optional imports
     # above, so keep the runtime invariant explicit where the model is loaded.
-    assert XGBClassifier is not None
-    assert joblib is not None
+    if XGBClassifier is None or joblib is None:
+        raise RuntimeError("Prediction dependencies not available")
 
     model = XGBClassifier()
     try:

--- a/simple_safer_server/services/runtime.py
+++ b/simple_safer_server/services/runtime.py
@@ -23,7 +23,6 @@ class Runtime:
     tasks_log_dir: Path
     rclone_config_dir: Path
     samba_dir: Path
-    samba_backup_dir: Path
     systemd_dir: Path
     bin_dir: Path
     backup_drive_dir: Path
@@ -70,7 +69,6 @@ class FakeState:
         self.runtime.tasks_log_dir.mkdir(parents=True, exist_ok=True)
         self.runtime.rclone_config_dir.mkdir(parents=True, exist_ok=True)
         self.runtime.samba_dir.mkdir(parents=True, exist_ok=True)
-        self.runtime.samba_backup_dir.mkdir(parents=True, exist_ok=True)
         self.runtime.systemd_dir.mkdir(parents=True, exist_ok=True)
         self.runtime.bin_dir.mkdir(parents=True, exist_ok=True)
         self.runtime.backup_drive_dir.mkdir(parents=True, exist_ok=True)
@@ -86,7 +84,7 @@ class FakeState:
             "selected_drive": "/dev/fakebackup1",
             "uuid": "FAKE-UUID-0001",
             "usb_id": "FAKE:0001",
-            "smb_services": {"smbd": "active", "nmbd": "active"},
+            "smb_services": {"smbd": "active", "nmbd": "active", "wsdd2": "active"},
             "tasks": {
                 task_name: {
                     "status": "Not Run Yet",
@@ -154,14 +152,24 @@ class FakeState:
             return False
         return bool(state.get("mounted"))
 
-    def set_smb_services(self, smbd: str, nmbd: str) -> None:
+    def set_smb_services(self, smbd: str, nmbd: str, wsdd2: str = "active") -> None:
         with self._lock:
             state = self.load()
-            state["smb_services"] = {"smbd": smbd, "nmbd": nmbd}
+            state["smb_services"] = {"smbd": smbd, "nmbd": nmbd, "wsdd2": wsdd2}
             self.save(state)
 
     def get_smb_services(self) -> Dict[str, str]:
-        return self.load().get("smb_services", {"smbd": "active", "nmbd": "active"})
+        services = self.load().get(
+            "smb_services",
+            {"smbd": "active", "nmbd": "active", "wsdd2": "active"},
+        )
+        # Fake state can survive across branch changes; normalize old two-unit
+        # snapshots so UI tests and manual fake-mode sessions match real status.
+        return {
+            "smbd": services.get("smbd", "active"),
+            "nmbd": services.get("nmbd", "active"),
+            "wsdd2": services.get("wsdd2", "active"),
+        }
 
     def set_task_state(
         self,
@@ -355,7 +363,6 @@ def get_runtime() -> Runtime:
             tasks_log_dir=data_dir / "logs" / "tasks",
             rclone_config_dir=data_dir / "rclone",
             samba_dir=data_dir / "samba",
-            samba_backup_dir=data_dir / "samba" / "backups",
             systemd_dir=data_dir / "systemd",
             bin_dir=data_dir / "bin",
             backup_drive_dir=data_dir / "backup-drive",
@@ -381,7 +388,6 @@ def get_runtime() -> Runtime:
             tasks_log_dir=Path("/var/log/SimpleSaferServer"),
             rclone_config_dir=Path.home() / ".config" / "rclone",
             samba_dir=Path("/etc/samba"),
-            samba_backup_dir=Path("/etc/samba/backups"),
             systemd_dir=Path("/etc/systemd/system"),
             bin_dir=Path("/usr/local/bin"),
             backup_drive_dir=Path("/media/backup"),

--- a/simple_safer_server/services/samba_layout.py
+++ b/simple_safer_server/services/samba_layout.py
@@ -1,0 +1,280 @@
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+from simple_safer_server.adapters.smb_commands import SmbCommandAdapter
+from simple_safer_server.services.runtime import get_runtime
+
+SSS_GLOBALS_FILENAME = "simple_safer_server_globals.conf"
+SSS_SHARES_FILENAME = "simple_safer_server_shares.conf"
+
+SSS_GLOBALS_INCLUDE_BEGIN = "# BEGIN SimpleSaferServer global include"
+SSS_GLOBALS_INCLUDE_END = "# END SimpleSaferServer global include"
+SSS_SHARES_INCLUDE_BEGIN = "# BEGIN SimpleSaferServer shares include"
+SSS_SHARES_INCLUDE_END = "# END SimpleSaferServer shares include"
+
+
+class SambaLayoutError(RuntimeError):
+    """Raised when SSS-owned Samba layout changes cannot be published safely."""
+
+
+class SambaLayoutService:
+    """Owns the small Samba include surface that SimpleSaferServer may repair."""
+
+    def __init__(self, runtime=None, command_adapter=None):
+        self.runtime = runtime or get_runtime()
+        self.command_adapter = command_adapter or SmbCommandAdapter()
+        self.samba_dir = self.runtime.samba_dir
+        self.smb_conf_path = self.samba_dir / "smb.conf"
+        self.globals_path = self.samba_dir / SSS_GLOBALS_FILENAME
+        self.shares_path = self.samba_dir / SSS_SHARES_FILENAME
+
+    def ensure_layout(self):
+        """Create or repair SSS-owned Samba include files and wiring."""
+        self.samba_dir.mkdir(parents=True, exist_ok=True)
+        original_state = self._snapshot_paths(
+            [self.smb_conf_path, self.globals_path, self.shares_path]
+        )
+
+        try:
+            main_content = self._read_main_config()
+            updated_main_content = self._ensure_include_blocks(main_content)
+
+            self._write_owned_config(self.globals_path, self._globals_template())
+            if not self.shares_path.exists():
+                self._write_owned_config(self.shares_path, self._shares_header())
+
+            self._validate_candidate_main_config(updated_main_content)
+            self._write_owned_config(self.smb_conf_path, updated_main_content)
+        except Exception as exc:
+            self._restore_snapshot(original_state)
+            if isinstance(exc, SambaLayoutError):
+                raise
+            raise SambaLayoutError(str(exc)) from exc
+
+    def _snapshot_paths(self, paths):
+        snapshot = {}
+        for path in paths:
+            if path.exists():
+                snapshot[path] = (path.read_bytes(), path.stat().st_mode & 0o777)
+            else:
+                snapshot[path] = None
+        return snapshot
+
+    def _restore_snapshot(self, snapshot):
+        for path, state in snapshot.items():
+            if state is None:
+                if path.exists():
+                    path.unlink()
+                continue
+
+            content, mode = state
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(content)
+            os.chmod(str(path), mode)
+            self._chown_root_if_real(path)
+
+    def _read_main_config(self):
+        if self.smb_conf_path.exists():
+            return self.smb_conf_path.read_text(encoding="utf-8")
+        return "[global]\n"
+
+    def _write_owned_config(self, path: Path, content: str):
+        # Samba reads these files directly, so publish with a complete same-dir
+        # rename instead of leaving a partially written config on interruption.
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                delete=False,
+                dir=str(path.parent),
+                prefix=f"{path.name}.",
+                suffix=".tmp",
+                encoding="utf-8",
+            ) as handle:
+                handle.write(content)
+                temp_path = Path(handle.name)
+            os.chmod(str(temp_path), 0o644)
+            self._chown_root_if_real(temp_path)
+            os.replace(str(temp_path), str(path))
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink()
+
+    def _chown_root_if_real(self, path: Path):
+        if self.runtime.is_fake:
+            return
+        os.chown(str(path), 0, 0)
+
+    def _globals_template(self):
+        template_path = Path(__file__).with_name("templates") / SSS_GLOBALS_FILENAME
+        return template_path.read_text(encoding="utf-8")
+
+    def _shares_header(self):
+        return (
+            "# SimpleSaferServer-managed Samba shares\n"
+            "#\n"
+            "# normal share changes should use the Web UI.\n"
+            "# unsupported manual directives may be overwritten by Web UI edits because\n"
+            "# SimpleSaferServer writes the supported share shape it can validate and maintain.\n"
+        )
+
+    def _global_include_block(self):
+        return [
+            f"{SSS_GLOBALS_INCLUDE_BEGIN}\n",
+            f"   include = {self.globals_path}\n",
+            f"{SSS_GLOBALS_INCLUDE_END}\n",
+        ]
+
+    def _shares_include_block(self):
+        return [
+            f"{SSS_SHARES_INCLUDE_BEGIN}\n",
+            f"include = {self.shares_path}\n",
+            f"{SSS_SHARES_INCLUDE_END}\n",
+        ]
+
+    def _ensure_include_blocks(self, content: str):
+        lines = content.splitlines(keepends=True)
+        lines = self.strip_owned_include_blocks_from_lines(lines)
+        lines = self._insert_global_include(lines)
+        lines = self._append_shares_include(lines)
+        return "".join(lines)
+
+    def strip_owned_include_blocks(self, content: str):
+        """Remove only SimpleSaferServer-owned include marker blocks."""
+        return "".join(self.strip_owned_include_blocks_from_lines(content.splitlines(True)))
+
+    def strip_owned_include_blocks_from_lines(self, lines: List[str]):
+        lines = self._remove_marker_block(
+            lines,
+            SSS_GLOBALS_INCLUDE_BEGIN,
+            SSS_GLOBALS_INCLUDE_END,
+        )
+        return self._remove_marker_block(
+            lines,
+            SSS_SHARES_INCLUDE_BEGIN,
+            SSS_SHARES_INCLUDE_END,
+        )
+
+    def _remove_marker_block(self, lines: List[str], begin_marker: str, end_marker: str):
+        result = []
+        index = 0
+        removed = False
+
+        while index < len(lines):
+            stripped = lines[index].strip()
+            if stripped == end_marker:
+                raise SambaLayoutError("SSS Samba include marker block is malformed.")
+            if stripped != begin_marker:
+                result.append(lines[index])
+                index += 1
+                continue
+
+            if removed:
+                raise SambaLayoutError("SSS Samba include marker block is malformed.")
+            removed = True
+            index += 1
+            while index < len(lines) and lines[index].strip() != end_marker:
+                if lines[index].strip() == begin_marker:
+                    raise SambaLayoutError("SSS Samba include marker block is malformed.")
+                index += 1
+            if index >= len(lines):
+                raise SambaLayoutError("SSS Samba include marker block is malformed.")
+            index += 1
+            if (
+                result
+                and not result[-1].strip()
+                and index < len(lines)
+                and not lines[index].strip()
+            ):
+                index += 1
+
+        return result
+
+    def _insert_global_include(self, lines: List[str]):
+        global_start = self._find_section_start(lines, "global")
+        if global_start is None:
+            prefix = ["[global]\n"]
+            if lines and lines[0].strip():
+                prefix.append("\n")
+            lines = prefix + lines
+            global_start = 0
+
+        insert_at = len(lines)
+        for index in range(global_start + 1, len(lines)):
+            section_name = self._section_name(lines[index])
+            if section_name is not None and section_name.lower() != "global":
+                insert_at = index
+                break
+
+        new_lines = list(lines)
+        self._ensure_blank_before(new_lines, insert_at)
+        insert_at = self._adjust_insert_at_after_blank(new_lines, insert_at)
+        block = self._global_include_block()
+        new_lines[insert_at:insert_at] = block
+        self._ensure_blank_after(new_lines, insert_at + len(block))
+        return new_lines
+
+    def _append_shares_include(self, lines: List[str]):
+        new_lines = list(lines)
+        if new_lines and not new_lines[-1].endswith("\n"):
+            new_lines[-1] = new_lines[-1] + "\n"
+        if new_lines and new_lines[-1].strip():
+            new_lines.append("\n")
+        new_lines.extend(self._shares_include_block())
+        return new_lines
+
+    def _ensure_blank_before(self, lines: List[str], insert_at: int):
+        if insert_at > 0 and lines[insert_at - 1].strip():
+            lines.insert(insert_at, "\n")
+
+    def _adjust_insert_at_after_blank(self, lines: List[str], insert_at: int):
+        if insert_at > 0 and not lines[insert_at - 1].strip():
+            return insert_at
+        return insert_at + 1
+
+    def _ensure_blank_after(self, lines: List[str], insert_at: int):
+        if insert_at < len(lines) and lines[insert_at].strip():
+            lines.insert(insert_at, "\n")
+
+    def _find_section_start(self, lines: List[str], section_name: str) -> Optional[int]:
+        for index, line in enumerate(lines):
+            current = self._section_name(line)
+            if current is not None and current.lower() == section_name:
+                return index
+        return None
+
+    def _section_name(self, line: str) -> Optional[str]:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]") and len(stripped) > 2:
+            return stripped[1:-1].strip()
+        return None
+
+    def _validate_candidate_main_config(self, content: str):
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                delete=False,
+                dir=str(self.samba_dir),
+                prefix=f"{self.smb_conf_path.name}.",
+                suffix=".candidate",
+                encoding="utf-8",
+            ) as handle:
+                handle.write(content)
+                temp_path = Path(handle.name)
+            os.chmod(str(temp_path), 0o644)
+
+            validator = shutil.which("testparm") or "testparm"
+            result = self.command_adapter.validate_config(validator, temp_path)
+            if result.returncode != 0:
+                details = (
+                    result.stderr.strip() or result.stdout.strip() or "unknown validation error"
+                )
+                raise SambaLayoutError(f"Samba layout validation failed: {details}")
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink()

--- a/simple_safer_server/services/smb_manager.py
+++ b/simple_safer_server/services/smb_manager.py
@@ -3,7 +3,6 @@ import os
 import re
 import shutil
 import tempfile
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -11,6 +10,11 @@ from typing import List, Optional, Tuple
 from simple_safer_server.adapters.command_runner import CalledProcessError
 from simple_safer_server.adapters.smb_commands import SmbCommandAdapter
 from simple_safer_server.services.runtime import get_fake_state, get_runtime
+from simple_safer_server.services.samba_layout import (
+    SSS_SHARES_FILENAME,
+    SambaLayoutError,
+    SambaLayoutService,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -18,14 +22,16 @@ SMB_DOCS_URL = (
     "https://github.com/chrismin13/SimpleSaferServer/blob/main/docs/network_file_sharing.md"
     "#manual-conversion-unmanaged-share-to-simplesaferserver-managed-share"
 )
-MANAGED_SHARE_BEGIN_PREFIX = "# BEGIN SimpleSaferServer share: "
-MANAGED_SHARE_END_PREFIX = "# END SimpleSaferServer share: "
 SYSTEM_SHARE_NAMES = {"global", "homes", "printers", "print$"}
 VALID_SHARE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class SMBConfigError(ValueError):
-    """Raised when smb.conf contains ownership markers that SimpleSaferServer cannot trust."""
+    """Raised when Samba share configuration cannot be parsed or published safely."""
+
+
+class SMBOperationError(RuntimeError):
+    """Raised when a Samba operation fails after validation has already passed."""
 
 
 @dataclass
@@ -69,23 +75,8 @@ class SMBManager:
         self.runtime = runtime or get_runtime()
         self.command_adapter = command_adapter or SmbCommandAdapter()
         self.smb_conf_path = str(self.runtime.samba_dir / "smb.conf")
-        self.backup_dir = str(self.runtime.samba_backup_dir)
+        self.sss_shares_path = self.runtime.samba_dir / SSS_SHARES_FILENAME
         self.fake_state = get_fake_state(self.runtime) if self.runtime.is_fake else None
-
-        # The backup directory is intentionally outside smb.conf itself so a
-        # parse failure never prevents us from preserving the last good file.
-        Path(self.backup_dir).mkdir(parents=True, exist_ok=True)
-
-    def _create_backup(self):
-        """Create a backup of the current smb.conf."""
-        timestamp = time.strftime("%Y%m%d_%H%M%S")
-        backup_path = f"{self.backup_dir}/smb.conf.backup.{timestamp}"
-        if self.runtime.is_fake:
-            Path(backup_path).write_text(self._read_smb_conf())
-        else:
-            self.command_adapter.copy_config(self.smb_conf_path, backup_path)
-        logger.info("Created backup of smb.conf at %s", backup_path)
-        return backup_path
 
     def _read_smb_conf(self):
         """Read the current smb.conf file."""
@@ -303,102 +294,158 @@ class SMBManager:
    guest ok = no
 """
 
-    def _write_smb_conf(self, content):
-        """Write content to smb.conf."""
-        self._create_backup()
-        with open(self.smb_conf_path, "w", encoding="utf-8") as handle:
-            handle.write(content)
-        os.chmod(self.smb_conf_path, 0o644)
+    def _ensure_layout_for_share_write(self):
+        SambaLayoutService(
+            runtime=self.runtime,
+            command_adapter=self.command_adapter,
+        ).ensure_layout()
 
-    def _validate_smb_conf_candidate(self, candidate_path: Path):
-        validator = shutil.which("testparm")
-        if not validator:
-            validator = shutil.which("smbd")
-            if not validator:
-                raise RuntimeError(
-                    "Could not validate smb.conf because neither 'testparm' nor 'smbd' is available."
-                )
-
-        result = self.command_adapter.validate_config(validator, candidate_path)
+    def _validate_effective_smb_config(self):
+        validator = shutil.which("testparm") or shutil.which("smbd") or "testparm"
+        result = self.command_adapter.validate_config(validator, Path(self.smb_conf_path))
         if result.returncode != 0:
             details = result.stderr.strip() or result.stdout.strip() or "unknown validation error"
             raise SMBConfigError(f"Samba configuration validation failed: {details}")
 
-    def _restore_smb_conf_backup(self, backup_path: Path):
-        shutil.copy2(backup_path, self.smb_conf_path)
-        os.chmod(self.smb_conf_path, 0o644)
-
-    def _commit_smb_conf(self, content: str):
-        if self.runtime.is_fake:
-            self._write_smb_conf(content)
-            if not self._restart_services():
-                raise Exception("Failed to restart SMB services")
-            return
-
-        live_path = Path(self.smb_conf_path)
-        backup_path = Path(self._create_backup())
-        temp_path = None
-        replaced_live_config = False
-
+    def _strip_sss_include_blocks(self, content: str):
+        layout = SambaLayoutService(runtime=self.runtime, command_adapter=self.command_adapter)
         try:
+            return layout.strip_owned_include_blocks(content)
+        except SambaLayoutError as exc:
+            raise SMBConfigError(str(exc)) from exc
+
+    def _inspect_unmanaged_effective_shares(self):
+        candidate_path = None
+        try:
+            # Effective-config inspection intentionally uses volatile runtime
+            # storage so routine write-safety checks do not touch durable media.
+            self.runtime.volatile_dir.mkdir(parents=True, exist_ok=True)
             with tempfile.NamedTemporaryFile(
                 "w",
                 delete=False,
-                dir=str(live_path.parent),
-                prefix=f"{live_path.name}.",
+                dir=str(self.runtime.volatile_dir),
+                prefix="smb-unmanaged-candidate.",
+                suffix=".conf",
+                encoding="utf-8",
+            ) as handle:
+                handle.write(self._strip_sss_include_blocks(self._read_smb_conf()))
+                candidate_path = Path(handle.name)
+            os.chmod(str(candidate_path), 0o644)
+
+            validator = shutil.which("testparm") or shutil.which("smbd") or "testparm"
+            # Keep the inspection candidate on volatile storage, but run testparm
+            # from Samba's config directory so relative admin includes keep the
+            # same meaning they have when Samba reads smb.conf normally.
+            result = self.command_adapter.validate_config(
+                validator,
+                candidate_path,
+                cwd=self.runtime.samba_dir,
+            )
+            if result.returncode != 0:
+                details = (
+                    result.stderr.strip() or result.stdout.strip() or "unknown inspection error"
+                )
+                raise SMBConfigError(f"Could not inspect the effective Samba config: {details}")
+
+            _, shares = self._parse_smb_conf(result.stdout)
+            return shares
+        except SMBConfigError:
+            raise
+        except Exception as exc:
+            raise SMBConfigError(f"Could not inspect the effective Samba config: {exc}") from exc
+        finally:
+            if candidate_path is not None and candidate_path.exists():
+                candidate_path.unlink()
+
+    def _commit_sss_shares_file(self, content: str):
+        # The shares include is the ownership boundary. Snapshot this file
+        # separately so a bad publish never rewrites administrator-owned smb.conf.
+        original_exists = self.sss_shares_path.exists()
+        original_content = (
+            self.sss_shares_path.read_text(encoding="utf-8") if original_exists else ""
+        )
+        original_mode = self.sss_shares_path.stat().st_mode & 0o777 if original_exists else 0o644
+
+        try:
+            self._write_sss_shares_file(content, 0o644)
+            self._validate_effective_smb_config()
+            if not self._restart_services():
+                raise RuntimeError("Failed to restart SMB services")
+        except Exception as publish_error:
+            if original_exists:
+                self._write_sss_shares_file(original_content, original_mode)
+            elif self.sss_shares_path.exists():
+                self.sss_shares_path.unlink()
+            if not self._restart_required_smbd_after_rollback():
+                raise SMBOperationError(
+                    "Samba share update failed and rollback could not restart smbd. "
+                    "Check systemd status and the Samba journal before retrying."
+                ) from publish_error
+            raise
+
+    def _write_sss_shares_file(self, content: str, mode: int):
+        temp_path = None
+        try:
+            self.sss_shares_path.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "w",
+                delete=False,
+                dir=str(self.sss_shares_path.parent),
+                prefix=f"{self.sss_shares_path.name}.",
                 suffix=".tmp",
+                encoding="utf-8",
             ) as handle:
                 handle.write(content)
                 temp_path = Path(handle.name)
-
-            os.chmod(temp_path, 0o644)
-            # Validate the candidate before replacing the live file so Samba is
-            # never pointed at a config we already know is broken.
-            self._validate_smb_conf_candidate(temp_path)
-            os.replace(temp_path, live_path)
-            replaced_live_config = True
+            os.chmod(str(temp_path), mode)
+            if not self.runtime.is_fake:
+                os.chown(str(temp_path), 0, 0)
+            os.replace(str(temp_path), str(self.sss_shares_path))
             temp_path = None
-
-            if not self._restart_services():
-                raise RuntimeError("Failed to restart SMB services")
-        except Exception as original_error:
+        finally:
             if temp_path is not None and temp_path.exists():
                 temp_path.unlink()
-
-            if replaced_live_config:
-                try:
-                    self._restore_smb_conf_backup(backup_path)
-                    if not self._restart_services():
-                        raise RuntimeError(
-                            "Failed to restart SMB services after restoring smb.conf backup"
-                        )
-                except Exception as rollback_error:
-                    logger.error(
-                        "Failed to restore smb.conf after SMB update error: %s",
-                        rollback_error,
-                    )
-                    raise RuntimeError(
-                        f"Failed to roll back smb.conf after SMB update error: {rollback_error}. Original error: {original_error}"
-                    ) from rollback_error
-
-            raise original_error
 
     def _restart_services(self):
         """Restart SMB services."""
         if self.runtime.is_fake:
             if self.fake_state is None:
                 raise RuntimeError("Fake runtime is missing fake state.")
-            self.fake_state.set_smb_services("active", "active")
+            self.fake_state.set_smb_services("active", "active", "active")
             logger.info("Fake mode: marked SMB services as active")
             return True
         try:
             self.command_adapter.restart_unit("smbd")
-            self.command_adapter.restart_unit("nmbd")
-            logger.info("SMB services restarted successfully")
-            return True
         except CalledProcessError as exc:
-            logger.error("Failed to restart SMB services: %s", exc)
+            logger.error("Failed to restart required SMB service smbd: %s", exc)
             return False
+
+        for unit_name in ("nmbd", "wsdd2"):
+            try:
+                self.command_adapter.restart_unit(unit_name)
+            except CalledProcessError as exc:
+                # Discovery restarts are best-effort. The status API reports
+                # the resulting partial state without rolling back share writes.
+                logger.warning("Failed to restart discovery service %s: %s", unit_name, exc)
+
+        logger.info("SMB services restart requested successfully")
+        return True
+
+    def _restart_required_smbd_after_rollback(self):
+        if self.runtime.is_fake:
+            if self.fake_state is None:
+                raise RuntimeError("Fake runtime is missing fake state.")
+            self.fake_state.set_smb_services("active", "active", "active")
+            return True
+        try:
+            # Rollback has just restored the owned shares file. Only smbd is
+            # required for direct file serving; discovery remains best-effort
+            # and should not mask the publish failure we are reporting.
+            self.command_adapter.restart_unit("smbd")
+        except CalledProcessError as exc:
+            logger.error("Failed to restart required SMB service smbd after rollback: %s", exc)
+            return False
+        return True
 
     def restart_services(self):
         """Restart SMB services through the public service boundary."""
@@ -423,7 +470,7 @@ class SMBManager:
             if section_name is not None:
                 if share_name is not None:
                     raise SMBConfigError(
-                        "SimpleSaferServer only supports one share section per managed block."
+                        "SimpleSaferServer only supports one share section per parsed share block."
                     )
                 share_name = section_name
                 continue
@@ -450,7 +497,7 @@ class SMBManager:
                 share_data["valid_users"] = [user for user in value.split() if user != "%S"]
 
         if share_name is None:
-            raise SMBConfigError("Failed to find a Samba share section inside a managed block.")
+            raise SMBConfigError("Failed to find a Samba share section inside a parsed block.")
 
         if marker_name is not None and share_name != marker_name:
             raise SMBConfigError(
@@ -467,48 +514,6 @@ class SMBManager:
         while index < len(lines):
             stripped = lines[index].strip()
 
-            if stripped.startswith(MANAGED_SHARE_BEGIN_PREFIX):
-                marker_name = stripped[len(MANAGED_SHARE_BEGIN_PREFIX) :].strip()
-                if not marker_name:
-                    raise SMBConfigError("Managed share marker is missing a share name.")
-
-                start_line = index
-                index += 1
-
-                while index < len(lines):
-                    end_line = lines[index].strip()
-                    if end_line.startswith(MANAGED_SHARE_BEGIN_PREFIX):
-                        raise SMBConfigError(
-                            "Nested SimpleSaferServer share markers were found in smb.conf."
-                        )
-                    if end_line == f"{MANAGED_SHARE_END_PREFIX}{marker_name}":
-                        break
-                    index += 1
-
-                if index >= len(lines):
-                    raise SMBConfigError(
-                        f"Managed share '{marker_name}' is missing its END marker in smb.conf."
-                    )
-
-                block_end = index + 1
-                share = self._parse_share_block(
-                    lines[start_line + 1 : index],
-                    managed=True,
-                    marker_name=marker_name,
-                )
-                share.start_line = start_line
-                share.end_line = block_end
-                share.raw_text = "".join(lines[start_line:block_end])
-                shares.append(share)
-                index = block_end
-                continue
-
-            if stripped.startswith(MANAGED_SHARE_END_PREFIX):
-                marker_name = stripped[len(MANAGED_SHARE_END_PREFIX) :].strip() or stripped
-                raise SMBConfigError(
-                    f"Unexpected SimpleSaferServer END marker was found in smb.conf for '{marker_name}'."
-                )
-
             section_name = _extract_section_name(stripped)
             if section_name and section_name.lower() not in SYSTEM_SHARE_NAMES:
                 start_line = index
@@ -516,8 +521,6 @@ class SMBManager:
 
                 while index < len(lines):
                     current = lines[index].strip()
-                    if current.startswith(MANAGED_SHARE_BEGIN_PREFIX):
-                        break
                     if _extract_section_name(current) is not None:
                         break
                     index += 1
@@ -534,7 +537,59 @@ class SMBManager:
         return lines, shares
 
     def _load_shares(self):
-        return self._parse_smb_conf(self._read_smb_conf())
+        unmanaged = self._inspect_unmanaged_effective_shares()
+        managed_lines, managed = self._load_managed_shares_file()
+        return managed_lines, managed + unmanaged
+
+    def _find_unmanaged_share_record(self, name):
+        unmanaged = self._inspect_unmanaged_effective_shares()
+        return self._find_share_record(unmanaged, name)
+
+    def _read_sss_shares_file(self):
+        try:
+            return self.sss_shares_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return ""
+
+    def _load_managed_shares_file(self):
+        lines, shares = self._parse_plain_share_file(self._read_sss_shares_file(), managed=True)
+        seen = set()
+        for share in shares:
+            if share.name in seen:
+                raise SMBConfigError(
+                    f"The SimpleSaferServer shares file is unsupported or malformed: duplicate share '{share.name}'."
+                )
+            seen.add(share.name)
+        return lines, shares
+
+    def _parse_plain_share_file(self, content: str, *, managed: bool):
+        lines = content.splitlines(keepends=True)
+        shares = []
+        index = 0
+
+        while index < len(lines):
+            section_name = _extract_section_name(lines[index].strip())
+            if section_name is None:
+                index += 1
+                continue
+
+            if section_name.lower() in SYSTEM_SHARE_NAMES:
+                raise SMBConfigError(
+                    f"The SimpleSaferServer shares file is unsupported or malformed: [{section_name}] is not a managed share section."
+                )
+
+            start_line = index
+            index += 1
+            while index < len(lines) and _extract_section_name(lines[index].strip()) is None:
+                index += 1
+
+            share = self._parse_share_block(lines[start_line:index], managed=managed)
+            share.start_line = start_line
+            share.end_line = index
+            share.raw_text = "".join(lines[start_line:index])
+            shares.append(share)
+
+        return lines, shares
 
     def _find_share_record(self, shares, name, *, managed=None):
         matches = [
@@ -603,7 +658,6 @@ class SMBManager:
         valid_users = self._validate_valid_users(valid_users or [])
 
         lines = [
-            f"{MANAGED_SHARE_BEGIN_PREFIX}{name}\n",
             f"[{name}]\n",
             f"   path = {path}\n",
             f"   writeable = {'Yes' if writable else 'No'}\n",
@@ -614,7 +668,6 @@ class SMBManager:
         ]
         if valid_users:
             lines.append(f"   valid users = {' '.join(valid_users)}\n")
-        lines.append(f"{MANAGED_SHARE_END_PREFIX}{name}\n")
         return lines
 
     def _append_managed_block(self, lines, block_lines):
@@ -627,23 +680,30 @@ class SMBManager:
         return new_lines
 
     def list_managed_shares(self):
-        _, shares = self._load_shares()
-        return [share.as_dict() for share in shares if share.managed]
+        _, shares = self._load_managed_shares_file()
+        return [share.as_dict() for share in shares]
 
     def list_unmanaged_shares(self):
         _, shares = self._load_shares()
         return [share.as_dict() for share in shares if not share.managed]
 
     def get_managed_share(self, name):
-        _, shares = self._load_shares()
+        _, shares = self._load_managed_shares_file()
         share = self._find_share_record(shares, name, managed=True)
         return share.as_dict() if share else None
 
     def create_managed_share(self, name, path, writable=True, comment="", valid_users=None):
         self._validate_share_input(name, path)
+        self._ensure_layout_for_share_write()
 
-        lines, shares = self._load_shares()
-        if self._find_share_record(shares, name) is not None:
+        lines, managed_shares = self._load_managed_shares_file()
+        # The owned shares file stays authoritative for SimpleSaferServer
+        # ownership, while the effective config check catches administrator
+        # shares loaded from smb.conf or its non-SSS includes.
+        if (
+            self._find_share_record(managed_shares, name, managed=True) is not None
+            or self._find_unmanaged_share_record(name) is not None
+        ):
             raise ValueError(
                 f"Share '{name}' already exists. SimpleSaferServer will not overwrite an existing share "
                 f"with the same name. See {SMB_DOCS_URL} for manual conversion guidance."
@@ -651,7 +711,7 @@ class SMBManager:
 
         block_lines = self._render_managed_share_block(name, path, writable, comment, valid_users)
         new_lines = self._append_managed_block(lines, block_lines)
-        self._commit_smb_conf("".join(new_lines))
+        self._commit_sss_shares_file("".join(new_lines))
 
         return True
 
@@ -659,19 +719,28 @@ class SMBManager:
         self, old_name, new_name, path, writable=True, comment="", valid_users=None
     ):
         self._validate_share_input(new_name, path)
+        self._ensure_layout_for_share_write()
 
-        lines, shares = self._load_shares()
-        share = self._find_share_record(shares, old_name, managed=True)
+        lines, managed_shares = self._load_managed_shares_file()
+        share = self._find_share_record(managed_shares, old_name, managed=True)
         if share is None:
-            if self._find_share_record(shares, old_name, managed=False) is not None:
+            if self._find_unmanaged_share_record(old_name) is not None:
                 raise ValueError(
                     f"Share '{old_name}' is not managed by SimpleSaferServer, so it cannot be edited here. "
                     f"See {SMB_DOCS_URL} for manual conversion guidance."
                 )
             raise ValueError(f"Share {old_name} not found")
 
-        conflict = self._find_share_record(shares, new_name)
-        if conflict is not None and not (conflict.managed and conflict.name == old_name):
+        managed_conflict = self._find_share_record(managed_shares, new_name, managed=True)
+        unmanaged_conflict = None
+        if new_name != old_name:
+            unmanaged_conflict = self._find_unmanaged_share_record(new_name)
+        if managed_conflict is not None and managed_conflict.name != old_name:
+            raise ValueError(
+                f"Share '{new_name}' already exists. SimpleSaferServer will not overwrite an existing share "
+                f"with the same name. See {SMB_DOCS_URL} for manual conversion guidance."
+            )
+        if unmanaged_conflict is not None:
             raise ValueError(
                 f"Share '{new_name}' already exists. SimpleSaferServer will not overwrite an existing share "
                 f"with the same name. See {SMB_DOCS_URL} for manual conversion guidance."
@@ -682,15 +751,16 @@ class SMBManager:
             new_name, path, writable, comment, valid_users
         )
         new_lines[share.start_line : share.end_line] = replacement
-        self._commit_smb_conf("".join(new_lines))
+        self._commit_sss_shares_file("".join(new_lines))
 
         return True
 
     def delete_managed_share(self, name):
-        lines, shares = self._load_shares()
-        share = self._find_share_record(shares, name, managed=True)
+        self._ensure_layout_for_share_write()
+        lines, managed_shares = self._load_managed_shares_file()
+        share = self._find_share_record(managed_shares, name, managed=True)
         if share is None:
-            if self._find_share_record(shares, name, managed=False) is not None:
+            if self._find_unmanaged_share_record(name) is not None:
                 raise ValueError(
                     f"Share '{name}' is not managed by SimpleSaferServer, so it cannot be deleted here. "
                     f"See {SMB_DOCS_URL} for manual conversion guidance."
@@ -699,7 +769,7 @@ class SMBManager:
 
         new_lines = list(lines)
         del new_lines[share.start_line : share.end_line]
-        self._commit_smb_conf("".join(new_lines))
+        self._commit_sss_shares_file("".join(new_lines))
 
         return True
 
@@ -713,11 +783,10 @@ class SMBManager:
         elif comment is None:
             comment = "Default backup share created by SimpleSaferServer setup"
 
-        unmanaged_backup = self._find_share_record(self._load_shares()[1], "backup", managed=False)
+        unmanaged_backup = self._find_unmanaged_share_record("backup")
         if unmanaged_backup is not None:
             raise ValueError(
-                "An unmanaged Samba share named 'backup' already exists. SimpleSaferServer will not overwrite it. "
-                f"Convert it manually or remove it first. See {SMB_DOCS_URL} for manual conversion guidance."
+                'Samba share "backup" already exists. Rename or remove it, then retry.'
             )
 
         managed_backup = self.get_managed_share("backup")
@@ -740,18 +809,28 @@ class SMBManager:
         )
 
     def _get_managed_share_or_raise(self, share_name):
-        # Keep the unmanaged-share rejection in one place so helper methods do
-        # not drift apart and accidentally expose raw Samba state.
-        _, shares = self._load_shares()
-        share = self._find_share_record(shares, share_name)
-        if share is None:
-            raise ValueError(f"Share {share_name} not found")
-        if not share.managed:
-            raise ValueError(
-                f"Share '{share_name}' is not managed by SimpleSaferServer, so it cannot be edited here. "
-                f"See {SMB_DOCS_URL} for manual conversion guidance."
-            )
-        return share.as_dict()
+        # Check the owned shares file first so that a broken admin-owned Samba
+        # include never blocks routine management of SimpleSaferServer shares.
+        _, managed_shares = self._load_managed_shares_file()
+        share = self._find_share_record(managed_shares, share_name, managed=True)
+        if share is not None:
+            return share.as_dict()
+
+        # Share not in the owned file. Inspect unmanaged shares to distinguish
+        # "exists but not managed" from "does not exist anywhere".
+        try:
+            unmanaged = self._inspect_unmanaged_effective_shares()
+            if self._find_share_record(unmanaged, share_name) is not None:
+                raise ValueError(
+                    f"Share '{share_name}' is not managed by SimpleSaferServer, so it cannot be edited here. "
+                    f"See {SMB_DOCS_URL} for manual conversion guidance."
+                )
+        except SMBConfigError:
+            # Effective config inspection failed — we already know the share is
+            # not in the owned file, so report it as not found.
+            pass
+
+        raise ValueError(f"Share {share_name} not found")
 
     def get_share_users(self, share_name):
         # Callers use this to populate edit flows, so unmanaged shares need an
@@ -776,11 +855,21 @@ class SMBManager:
             if self.fake_state is None:
                 raise RuntimeError("Fake runtime is missing fake state.")
             return self.fake_state.get_smb_services()
+
+        statuses = {}
+        for unit_name in ("smbd", "nmbd"):
+            try:
+                statuses[unit_name] = self.command_adapter.unit_status(unit_name)
+            except Exception as exc:
+                logger.error("Error getting %s status: %s", unit_name, exc)
+                statuses[unit_name] = "error"
+
         try:
-            return {
-                "smbd": self.command_adapter.unit_status("smbd"),
-                "nmbd": self.command_adapter.unit_status("nmbd"),
-            }
+            statuses["wsdd2"] = self.command_adapter.unit_status("wsdd2")
         except Exception as exc:
-            logger.error("Error getting service status: %s", exc)
-            return {"smbd": "error", "nmbd": "error"}
+            # wsdd2 is optional on older distributions, so a missing unit is
+            # surfaced as unavailable instead of collapsing the whole response.
+            logger.info("wsdd2 status unavailable: %s", exc)
+            statuses["wsdd2"] = "unavailable"
+
+        return statuses

--- a/simple_safer_server/services/smb_manager.py
+++ b/simple_safer_server/services/smb_manager.py
@@ -406,18 +406,45 @@ class SMBManager:
             if temp_path is not None and temp_path.exists():
                 temp_path.unlink()
 
+    def _reload_or_restart_smbd(self) -> bool:
+        """Apply new configuration to smbd gracefully, with a hard fallback restart.
+
+        If smbd is active, we attempt to reload the config dynamically via smbcontrol
+        so active TCP connections are not disrupted. If that fails, or if smbd is
+        inactive, we fall back to a full systemd restart to ensure the daemon is
+        running and configuration takes effect.
+        """
+        if self.runtime.is_fake:
+            return True
+
+        try:
+            if self.command_adapter.unit_status("smbd") == "active":
+                logger.info("Attempting graceful config reload for smbd...")
+                self.command_adapter.reload_config()
+                return True
+            else:
+                logger.info("smbd is inactive; directly starting/restarting service...")
+        except Exception as exc:
+            logger.warning("Graceful smbd config reload failed; falling back to restart: %s", exc)
+
+        try:
+            self.command_adapter.restart_unit("smbd")
+            return True
+        except CalledProcessError as exc:
+            logger.error("Failed to restart required SMB service smbd: %s", exc)
+            return False
+
     def _restart_services(self):
-        """Restart SMB services."""
+        """Restart or reload SMB services."""
         if self.runtime.is_fake:
             if self.fake_state is None:
                 raise RuntimeError("Fake runtime is missing fake state.")
             self.fake_state.set_smb_services("active", "active", "active")
             logger.info("Fake mode: marked SMB services as active")
             return True
-        try:
-            self.command_adapter.restart_unit("smbd")
-        except CalledProcessError as exc:
-            logger.error("Failed to restart required SMB service smbd: %s", exc)
+
+        # Handle smbd via graceful reload / fallback restart
+        if not self._reload_or_restart_smbd():
             return False
 
         for unit_name in ("nmbd", "wsdd2"):
@@ -428,7 +455,7 @@ class SMBManager:
                 # the resulting partial state without rolling back share writes.
                 logger.warning("Failed to restart discovery service %s: %s", unit_name, exc)
 
-        logger.info("SMB services restart requested successfully")
+        logger.info("SMB services reload/restart completed successfully")
         return True
 
     def _restart_required_smbd_after_rollback(self):
@@ -437,15 +464,9 @@ class SMBManager:
                 raise RuntimeError("Fake runtime is missing fake state.")
             self.fake_state.set_smb_services("active", "active", "active")
             return True
-        try:
-            # Rollback has just restored the owned shares file. Only smbd is
-            # required for direct file serving; discovery remains best-effort
-            # and should not mask the publish failure we are reporting.
-            self.command_adapter.restart_unit("smbd")
-        except CalledProcessError as exc:
-            logger.error("Failed to restart required SMB service smbd after rollback: %s", exc)
-            return False
-        return True
+        # Rollback has just restored the owned shares file. Only smbd is
+        # required for direct file serving; try graceful reload/fallback restart.
+        return self._reload_or_restart_smbd()
 
     def restart_services(self):
         """Restart SMB services through the public service boundary."""

--- a/simple_safer_server/services/templates/simple_safer_server_globals.conf
+++ b/simple_safer_server/services/templates/simple_safer_server_globals.conf
@@ -1,0 +1,8 @@
+# SimpleSaferServer-managed Samba global defaults
+#
+# SimpleSaferServer install, setup, and update paths may refresh this file.
+# Put site-specific overrides in smb.conf after the SimpleSaferServer global
+# include if you intentionally want to override these defaults.
+
+map to guest = never
+disable netbios = no

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -717,7 +717,7 @@ Remove the drive now if you do not want it mounted again.`;
           badge.className = 'badge badge-success';
           badge.textContent = 'Operational';
           val.textContent = 'Running';
-          detail.textContent = 'smbd, nmbd, wsdd2 active';
+          detail.textContent = 'File sharing services operational';
         } else if (data.smbd === 'active') {
           badge.className = 'badge badge-warning';
           badge.textContent = 'Partial';

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -710,22 +710,26 @@ Remove the drive now if you do not want it mounted again.`;
         const badge = document.getElementById('sharing-status-badge');
         const val = document.getElementById('sharing-status');
         const detail = document.getElementById('sharing-detail');
+        // 'unavailable' means the package is not installed — not degradation.
+        const discoveryOk = (s) => s === 'active' || s === 'unavailable';
 
-        if (data.smbd === 'active' && data.nmbd === 'active') {
+        if (data.smbd === 'active' && discoveryOk(data.nmbd) && discoveryOk(data.wsdd2)) {
           badge.className = 'badge badge-success';
-          badge.textContent = 'Active';
+          badge.textContent = 'Operational';
           val.textContent = 'Running';
-          detail.textContent = 'SMB and NetBIOS services active';
-        } else if (data.smbd === 'active' || data.nmbd === 'active') {
+          detail.textContent = 'smbd, nmbd, wsdd2 active';
+        } else if (data.smbd === 'active') {
           badge.className = 'badge badge-warning';
           badge.textContent = 'Partial';
           val.textContent = 'Degraded';
-          detail.textContent = `smbd: ${data.smbd}, nmbd: ${data.nmbd}`;
+          // Keep the compact detail explicit so the dashboard matches the
+          // File Sharing page without adding another explanatory panel.
+          detail.textContent = `smbd: ${data.smbd}, nmbd: ${data.nmbd}, wsdd2: ${data.wsdd2}`;
         } else {
           badge.className = 'badge badge-danger';
-          badge.textContent = 'Stopped';
+          badge.textContent = 'Down';
           val.textContent = 'Not Running';
-          detail.textContent = 'File sharing services are down';
+          detail.textContent = `smbd: ${data.smbd}, nmbd: ${data.nmbd}, wsdd2: ${data.wsdd2}`;
         }
       })
       .catch(() => {

--- a/templates/network_file_sharing.html
+++ b/templates/network_file_sharing.html
@@ -35,14 +35,21 @@
       <div class="d-flex items-center gap-2">
         <span class="badge badge-neutral" id="smbdStatus">Checking…</span>
         <span style="font-size: var(--text-sm);">SMB Daemon (smbd)</span>
-        <span class="tooltip-trigger text-muted" data-tooltip="Handles file and printer sharing between Windows and Linux systems">
+        <span class="tooltip-trigger text-muted" data-tooltip="serves file shares to SMB clients.">
           <i class="fas fa-info-circle"></i>
         </span>
       </div>
       <div class="d-flex items-center gap-2">
         <span class="badge badge-neutral" id="nmbdStatus">Checking…</span>
-        <span style="font-size: var(--text-sm);">NetBIOS Daemon (nmbd)</span>
-        <span class="tooltip-trigger text-muted" data-tooltip="Handles network discovery and name resolution for Windows compatibility">
+        <span style="font-size: var(--text-sm);">NetBIOS Discovery (nmbd)</span>
+        <span class="tooltip-trigger text-muted" data-tooltip="helps older Windows network browsing find this server.">
+          <i class="fas fa-info-circle"></i>
+        </span>
+      </div>
+      <div class="d-flex items-center gap-2">
+        <span class="badge badge-neutral" id="wsdd2Status">Checking…</span>
+        <span style="font-size: var(--text-sm);">Windows Discovery (wsdd2)</span>
+        <span class="tooltip-trigger text-muted" data-tooltip="helps modern Windows network browsing find this server.">
           <i class="fas fa-info-circle"></i>
         </span>
       </div>
@@ -305,8 +312,8 @@
     </div>
     <div class="modal-body">
       <p class="text-secondary mb-4">
-        SimpleSaferServer found Samba share definitions in <code>/etc/samba/smb.conf</code> that are still active,
-        but are not marked as SimpleSaferServer-managed. They remain read-only here.
+        SimpleSaferServer found active Samba shares in the Effective Samba Config that are not
+        SimpleSaferServer-managed. They remain read-only here.
       </p>
 
       <div class="table-container mb-4">
@@ -559,22 +566,38 @@ function loadShares() {
       shares = data.shares;
       unmanagedShareNames = data.unmanaged_share_names || [];
       renderUnmanagedShareState(
+        data.unmanaged_shares_verified !== false,
         Boolean(data.unmanaged_shares_detected),
         data.unmanaged_share_count || unmanagedShareNames.length,
-        unmanagedShareNames
+        unmanagedShareNames,
+        data.unmanaged_share_verification_error || ''
       );
       renderSharesTable();
     })
     .catch(() => showAlert('Failed to load shares', 'danger'));
 }
 
-function renderUnmanagedShareState(hasUnmanagedShares, count, names) {
+function renderUnmanagedShareState(isVerified, hasUnmanagedShares, count, names, verificationError) {
   const button = document.getElementById('unmanagedSharesBtn');
   const label = document.getElementById('unmanagedSharesBtnLabel');
   const list = document.getElementById('unmanagedSharesList');
   if (!button || !label || !list) return;
 
   list.innerHTML = '';
+
+  if (!isVerified) {
+    label.textContent = 'Unmanaged share verification failed';
+    button.classList.remove('d-none');
+    list.innerHTML = '';
+
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.className = 'text-warning';
+    cell.textContent = verificationError || 'Could not verify unmanaged Samba shares.';
+    row.appendChild(cell);
+    list.appendChild(row);
+    return;
+  }
 
   if (!hasUnmanagedShares || !count) {
     button.classList.add('d-none');
@@ -818,6 +841,15 @@ function deleteShare() {
     .catch((error) => { window.AsyncButtonState.error(deleteBtn); showAlert(error.message || 'Failed to delete share', 'danger'); });
 }
 
+// Three-tier badge for discovery services: active → green, inactive → yellow,
+// unavailable (package not installed) → grey. Keeps the UI from alarming admins
+// about best-effort services that simply aren't present on the system.
+function discoveryBadgeClass(status) {
+  if (status === 'active') return 'badge-success';
+  if (status === 'inactive') return 'badge-warning';
+  return 'badge-neutral';
+}
+
 function loadSMBStatus() {
   window.ApiClient.fetchJson('/api/smb/status')
     .then(({ data }) => {
@@ -826,10 +858,18 @@ function loadSMBStatus() {
       smbdSt.className = data.smbd === 'active' ? 'badge badge-success' : 'badge badge-danger';
       const nmbdSt = document.getElementById('nmbdStatus');
       nmbdSt.textContent = data.nmbd;
-      nmbdSt.className = data.nmbd === 'active' ? 'badge badge-success' : 'badge badge-danger';
-      if (data.smbd === 'active' && data.nmbd === 'active') updateOverallStatus('success', 'Operational', 'File sharing is working properly');
-      else if (data.smbd === 'active' || data.nmbd === 'active') updateOverallStatus('warning', 'Partial', 'Some services not running');
-      else updateOverallStatus('danger', 'Down', 'File sharing services are not running');
+      nmbdSt.className = 'badge ' + discoveryBadgeClass(data.nmbd);
+      const wsdd2St = document.getElementById('wsdd2Status');
+      wsdd2St.textContent = data.wsdd2;
+      wsdd2St.className = 'badge ' + discoveryBadgeClass(data.wsdd2);
+
+      // smbd is the file-serving path; discovery daemons only decide whether
+      // Windows network browsing is complete or degraded.
+      // 'unavailable' means the package is not installed — not degradation.
+      const discoveryOk = (s) => s === 'active' || s === 'unavailable';
+      if (data.smbd === 'active' && discoveryOk(data.nmbd) && discoveryOk(data.wsdd2)) updateOverallStatus('success', 'Operational', 'File sharing and discovery are working');
+      else if (data.smbd === 'active') updateOverallStatus('warning', 'Partial', 'File sharing is active, but discovery is incomplete');
+      else updateOverallStatus('danger', 'Down', 'File sharing is not running');
     })
     .catch(() => updateOverallStatus('error', 'Error', 'Unable to check status'));
 }

--- a/tests/test_app_factory_routes.py
+++ b/tests/test_app_factory_routes.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -62,6 +63,76 @@ def test_fake_dashboard_renders_storage_action_urls():
             assert "Enable Schedule" in page
             assert 'data-task-schedule-control="disable-modal"' in page
             assert "<th>Schedule</th>" not in page
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_network_file_sharing_renders_three_service_status_labels_and_help_text():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            _finish_fake_setup(app)
+
+            with app.test_client() as client:
+                response = client.get("/network_file_sharing")
+
+            assert response.status_code == 200
+            page = response.get_data(as_text=True)
+            assert "SMB Daemon (smbd)" in page
+            assert "NetBIOS Discovery (nmbd)" in page
+            assert "Windows Discovery (wsdd2)" in page
+            assert "serves file shares" in page
+            assert "helps older Windows network browsing find this server" in page
+            assert "helps modern Windows network browsing find this server" in page
+            assert 'id="wsdd2Status"' in page
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_smb_status_api_returns_flat_three_service_object():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            _finish_fake_setup(app)
+
+            with app.test_client() as client:
+                response = client.get("/api/smb/status")
+
+            assert response.status_code == 200
+            assert response.get_json()["data"] == {
+                "smbd": "active",
+                "nmbd": "active",
+                "wsdd2": "active",
+            }
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_dashboard_file_sharing_summary_tracks_wsdd2_and_three_state_rules():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            _finish_fake_setup(app)
+
+            with app.test_client() as client:
+                response = client.get("/dashboard")
+
+            assert response.status_code == 200
+            page = response.get_data(as_text=True)
+            # Operational requires smbd active and discovery services active-or-unavailable
+            assert "discoveryOk(data.nmbd)" in page
+            assert "discoveryOk(data.wsdd2)" in page
+            assert "data.smbd === 'active'" in page
+            assert "wsdd2: ${data.wsdd2}" in page
     finally:
         runtime._runtime = previous_runtime
         runtime._fake_state = previous_fake_state
@@ -149,6 +220,222 @@ def test_setup_title_keeps_product_name_before_server_name_is_chosen():
 
             assert response.status_code == 200
             assert "<title>Setup — SimpleSaferServer</title>" in response.get_data(as_text=True)
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_smb_share_list_returns_validation_error_for_malformed_sss_shares_file():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            services = _finish_fake_setup(app)
+            shares_path = Path(services.runtime.samba_dir) / "simple_safer_server_shares.conf"
+            shares_path.parent.mkdir(parents=True, exist_ok=True)
+            shares_path.write_text("[backup]\n   path = /media/backup\n[backup]\n")
+
+            with app.test_client() as client:
+                response = client.get("/api/smb/shares")
+
+            payload = response.get_json()
+            assert response.status_code == 400
+            assert payload["detail"].startswith(
+                "The SimpleSaferServer shares file is unsupported or malformed"
+            )
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_smb_share_list_marks_unmanaged_verification_success_with_detected_shares():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            services = _finish_fake_setup(app)
+
+            with patch.object(
+                services.smb_manager,
+                "list_unmanaged_shares",
+                return_value=[{"name": "media"}, {"name": "legacy"}],
+            ):
+                with app.test_client() as client:
+                    response = client.get("/api/smb/shares")
+
+            payload = response.get_json()
+            assert response.status_code == 200
+            assert payload["data"]["unmanaged_shares_verified"] is True
+            assert payload["data"]["unmanaged_shares_detected"] is True
+            assert payload["data"]["unmanaged_share_count"] == 2
+            assert payload["data"]["unmanaged_share_names"] == ["media", "legacy"]
+            assert payload["data"]["unmanaged_share_verification_error"] is None
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_smb_share_list_marks_unmanaged_verification_success_with_no_unmanaged_shares():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            services = _finish_fake_setup(app)
+
+            with patch.object(services.smb_manager, "list_unmanaged_shares", return_value=[]):
+                with app.test_client() as client:
+                    response = client.get("/api/smb/shares")
+
+            payload = response.get_json()
+            assert response.status_code == 200
+            assert payload["data"]["unmanaged_shares_verified"] is True
+            assert payload["data"]["unmanaged_shares_detected"] is False
+            assert payload["data"]["unmanaged_share_count"] == 0
+            assert payload["data"]["unmanaged_share_names"] == []
+            assert payload["data"]["unmanaged_share_verification_error"] is None
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_smb_share_list_surfaces_unmanaged_verification_failure_without_hiding_shares():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            services = _finish_fake_setup(app)
+            shares_path = Path(services.runtime.samba_dir) / "simple_safer_server_shares.conf"
+            shares_path.parent.mkdir(parents=True, exist_ok=True)
+            shares_path.write_text("[backup]\n   path = /media/backup\n")
+
+            from simple_safer_server.services.smb_manager import SMBConfigError
+
+            with patch.object(
+                services.smb_manager,
+                "list_unmanaged_shares",
+                side_effect=SMBConfigError("Could not inspect the effective Samba config: boom"),
+            ):
+                with app.test_client() as client:
+                    response = client.get("/api/smb/shares")
+
+            payload = response.get_json()
+            assert response.status_code == 200
+            assert [share["name"] for share in payload["data"]["shares"]] == ["backup"]
+            assert payload["data"]["unmanaged_shares_verified"] is False
+            assert payload["data"]["unmanaged_shares_detected"] is False
+            assert payload["data"]["unmanaged_share_count"] is None
+            assert payload["data"]["unmanaged_share_names"] == []
+            assert (
+                "Could not inspect the effective Samba config"
+                in payload["data"]["unmanaged_share_verification_error"]
+            )
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_smb_share_add_surfaces_controlled_operation_detail():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            services = _finish_fake_setup(app)
+
+            from simple_safer_server.services.smb_manager import SMBOperationError
+
+            detail = "Samba share update failed and rollback could not restart smbd."
+            with patch.object(
+                services.smb_manager,
+                "create_managed_share",
+                side_effect=SMBOperationError(detail),
+            ):
+                with app.test_client() as client:
+                    response = client.post(
+                        "/api/smb/shares",
+                        json={
+                            "name": "backup",
+                            "path": "/media/backup",
+                            "writable": True,
+                            "comment": "",
+                            "users": [],
+                        },
+                    )
+
+            payload = response.get_json()
+            assert response.status_code == 500
+            assert payload["type"].endswith("#smb-operation-failed")
+            assert payload["detail"] == detail
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_network_file_sharing_renders_unmanaged_verification_warning_state():
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            _finish_fake_setup(app)
+
+            with app.test_client() as client:
+                response = client.get("/network_file_sharing")
+
+            assert response.status_code == 200
+            page = response.get_data(as_text=True)
+            assert "unmanaged_shares_verified" in page
+            assert "Unmanaged share verification failed" in page
+            assert "Could not verify unmanaged Samba shares" in page
+    finally:
+        runtime._runtime = previous_runtime
+        runtime._fake_state = previous_fake_state
+
+
+def test_discovery_badges_use_three_tier_and_smbd_stays_binary():
+    """Discovery services (nmbd, wsdd2) use three-tier badge colors:
+    active → badge-success, inactive → badge-warning, unavailable → badge-neutral.
+    smbd stays binary: active → badge-success, anything else → badge-danger.
+    """
+    previous_runtime = runtime._runtime
+    previous_fake_state = runtime._fake_state
+    try:
+        with TemporaryDirectory() as temp_dir:
+            app = _create_fake_app(temp_dir)
+            _finish_fake_setup(app)
+
+            with app.test_client() as client:
+                response = client.get("/network_file_sharing")
+
+            assert response.status_code == 200
+            page = response.get_data(as_text=True)
+
+            # smbd stays binary: active → success, anything else → danger
+            assert "data.smbd === 'active' ? 'badge badge-success' : 'badge badge-danger'" in page
+
+            # nmbd and wsdd2 must NOT use the binary danger pattern
+            assert (
+                "data.nmbd === 'active' ? 'badge badge-success' : 'badge badge-danger'" not in page
+            )
+            assert (
+                "data.wsdd2 === 'active' ? 'badge badge-success' : 'badge badge-danger'" not in page
+            )
+
+            # discoveryBadgeClass helper maps the three tiers:
+            # active → badge-success, inactive → badge-warning, other → badge-neutral
+            assert "discoveryBadgeClass(data.nmbd)" in page
+            assert "discoveryBadgeClass(data.wsdd2)" in page
+            assert "status === 'active') return 'badge-success'" in page
+            assert "status === 'inactive') return 'badge-warning'" in page
+            assert "return 'badge-neutral'" in page
+
+            # Overall status treats 'unavailable' as non-degrading
+            assert "discoveryOk(data.nmbd)" in page
+            assert "discoveryOk(data.wsdd2)" in page
     finally:
         runtime._runtime = previous_runtime
         runtime._fake_state = previous_fake_state

--- a/tests/test_drive_health.py
+++ b/tests/test_drive_health.py
@@ -230,7 +230,9 @@ class DriveHealthTests(unittest.TestCase):
                 ("backup", "mount_point"): "/media/backup",
             }.get((section, key), default)
         )
-        system_utils = SimpleNamespace(is_mounted=lambda mount_point: mount_point == "/media/backup")
+        system_utils = SimpleNamespace(
+            is_mounted=lambda mount_point: mount_point == "/media/backup"
+        )
         runtime = SimpleNamespace(is_fake=False, default_mount_point="/media/backup")
         smart = {"smart_194_raw": 31.0}
         hdsentinel_result = {

--- a/tests/test_drive_health.py
+++ b/tests/test_drive_health.py
@@ -263,7 +263,10 @@ class DriveHealthTests(unittest.TestCase):
             drive_health.get_prediction_unavailable_message(),
         )
         self.assertEqual(result["hdsentinel"], hdsentinel_result)
-        self.assertIn("SMART prediction is unavailable", captured.output[0])
+        # Pyright may infer 'captured' as None in some environments due to type stub limitations.
+        # We assert it is not None to satisfy runtime checks and use type: ignore for static analysis.
+        self.assertIsNotNone(captured)
+        self.assertIn("SMART prediction is unavailable", captured.output[0])  # type: ignore
         mock_alert.assert_not_called()
         mock_hdsentinel_monitor.assert_called_once_with(
             config_manager, system_utils, runtime=runtime

--- a/tests/test_drive_health_docs.py
+++ b/tests/test_drive_health_docs.py
@@ -1,0 +1,42 @@
+"""Verify drive_health.md references the correct Samba config paths for managed shares."""
+
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
+DRIVE_HEALTH_MD = DOCS_DIR / "drive_health.md"
+
+
+def _manual_recovery_section():
+    """Return the Manual Recovery section text from drive_health.md."""
+    content = DRIVE_HEALTH_MD.read_text()
+    marker = "## Manual Recovery"
+    start = content.index(marker)
+    # Find the next H2 or end of file
+    next_h2 = content.find("\n## ", start + len(marker))
+    if next_h2 == -1:
+        return content[start:]
+    return content[start:next_h2]
+
+
+def test_manual_recovery_references_sss_shares_file():
+    section = _manual_recovery_section()
+    assert "/etc/samba/simple_safer_server_shares.conf" in section
+
+
+def test_manual_recovery_references_network_file_sharing_page():
+    section = _manual_recovery_section()
+    # Should point operators to the Network File Sharing docs page
+    assert "network_file_sharing" in section.lower() or "Network File Sharing" in section
+
+
+def test_manual_recovery_does_not_present_smb_conf_as_managed_share_config():
+    section = _manual_recovery_section()
+    # The "Important file locations" list should not say
+    # "Samba share config: `/etc/samba/smb.conf`" as if that's where managed shares live
+    assert "Samba share config: `/etc/samba/smb.conf`" not in section
+
+
+def test_manual_recovery_still_mentions_smb_conf():
+    section = _manual_recovery_section()
+    # smb.conf should still be referenced as Samba's main config
+    assert "/etc/samba/smb.conf" in section

--- a/tests/test_drive_health_prediction_dependencies.py
+++ b/tests/test_drive_health_prediction_dependencies.py
@@ -1,8 +1,6 @@
-import builtins
-import importlib
+import subprocess
 import sys
 import unittest
-from unittest.mock import patch
 
 DRIVE_HEALTH_MODULE = "simple_safer_server.services.drive_health"
 NUMPY_X86_V2_ERROR = (
@@ -12,68 +10,80 @@ NUMPY_X86_V2_ERROR = (
 
 
 class DriveHealthPredictionDependencyTests(unittest.TestCase):
-    def setUp(self):
-        self.original_module = importlib.import_module(DRIVE_HEALTH_MODULE)
+    def run_import_in_subprocess(self, exception_class_name, exception_arg):
+        # We invoke Python in a subprocess to test the import behavior with zero side effects on the main process.
+        code = f"""
+import builtins
+import sys
+import logging
 
-    def tearDown(self):
-        # These tests import the service through a deliberately broken optional
-        # dependency path. Put the original module object back so patch targets
-        # in other Drive Health tests still refer to the same object they
-        # imported at collection time.
-        sys.modules[DRIVE_HEALTH_MODULE] = self.original_module
-        importlib.reload(self.original_module)
+class LogCaptureHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records = []
+    def emit(self, record):
+        self.records.append(record)
 
-    def import_drive_health_with_prediction_import_error(self, exception):
-        original_import = builtins.__import__
+logger = logging.getLogger("{DRIVE_HEALTH_MODULE}")
+logger.setLevel(logging.WARNING)
+handler = LogCaptureHandler()
+logger.addHandler(handler)
 
-        def failing_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "pandas":
-                raise exception
-            return original_import(name, globals, locals, fromlist, level)
+original_import = builtins.__import__
+def failing_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "pandas":
+        if "{exception_class_name}" == "SystemExit":
+            raise SystemExit("{exception_arg}")
+        else:
+            raise RuntimeError("{exception_arg}")
+    return original_import(name, globals, locals, fromlist, level)
 
-        sys.modules.pop(DRIVE_HEALTH_MODULE, None)
-        with patch("builtins.__import__", side_effect=failing_import):
-            return importlib.import_module(DRIVE_HEALTH_MODULE)
+builtins.__import__ = failing_import
+
+try:
+    from simple_safer_server.services import drive_health
+except SystemExit as exc:
+    print("SYSTEM_EXIT: " + str(exc))
+    sys.exit(99)
+
+assert not drive_health.PREDICTION_DEPENDENCIES_AVAILABLE
+if "X86_V2" in "{exception_arg}":
+    assert "this machine's CPU cannot run the installed NumPy package" in drive_health.PREDICTION_UNAVAILABLE_MESSAGE
+else:
+    assert "prediction dependencies could not be loaded" in drive_health.PREDICTION_UNAVAILABLE_MESSAGE
+
+assert drive_health.get_optimal_threshold() == 0.5
+assert drive_health.predict_failure_probability({{"smart_194_raw": 31.0}}) is None
+
+# Verify warning is logged properly
+assert len(handler.records) == 1
+assert handler.records[0].exc_info is None
+assert "SMART prediction dependencies could not be loaded" in handler.records[0].getMessage()
+
+print("OK")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        return result
 
     def test_drive_health_import_survives_numpy_x86_v2_prediction_dependency_failure(self):
-        with self.assertLogs(DRIVE_HEALTH_MODULE, level="WARNING") as captured:
-            drive_health = self.import_drive_health_with_prediction_import_error(
-                RuntimeError(NUMPY_X86_V2_ERROR)
-            )
-
-        self.assertFalse(drive_health.PREDICTION_DEPENDENCIES_AVAILABLE)
-        self.assertEqual(
-            drive_health.PREDICTION_UNAVAILABLE_MESSAGE,
-            (
-                "SMART prediction is unavailable because this machine's CPU cannot run "
-                "the installed NumPy package. SMART and HDSentinel checks can still run."
-            ),
-        )
-        self.assertEqual(drive_health.get_optimal_threshold(), 0.5)
-        self.assertIsNone(drive_health.predict_failure_probability({"smart_194_raw": 31.0}))
-        self.assertEqual(len(captured.records), 1)
-        self.assertIsNone(captured.records[0].exc_info)
-        self.assertIn("SMART prediction dependencies could not be loaded", captured.output[0])
+        result = self.run_import_in_subprocess("RuntimeError", NUMPY_X86_V2_ERROR)
+        self.assertEqual(result.returncode, 0, msg=result.stderr or result.stdout)
+        self.assertIn("OK", result.stdout)
 
     def test_drive_health_import_survives_general_prediction_dependency_failure(self):
-        with self.assertLogs(DRIVE_HEALTH_MODULE, level="WARNING"):
-            drive_health = self.import_drive_health_with_prediction_import_error(
-                RuntimeError("shared object could not be mapped")
-            )
-
-        self.assertFalse(drive_health.PREDICTION_DEPENDENCIES_AVAILABLE)
-        self.assertEqual(
-            drive_health.PREDICTION_UNAVAILABLE_MESSAGE,
-            (
-                "SMART prediction is unavailable because the prediction dependencies could "
-                "not be loaded. SMART and HDSentinel checks can still run."
-            ),
-        )
-        self.assertIsNone(drive_health.predict_failure_probability({"smart_194_raw": 31.0}))
+        result = self.run_import_in_subprocess("RuntimeError", "shared object could not be mapped")
+        self.assertEqual(result.returncode, 0, msg=result.stderr or result.stdout)
+        self.assertIn("OK", result.stdout)
 
     def test_prediction_dependency_boundary_does_not_catch_base_exception(self):
-        with self.assertRaises(SystemExit):
-            self.import_drive_health_with_prediction_import_error(SystemExit("stop import"))
+        result = self.run_import_in_subprocess("SystemExit", "stop import")
+        # SystemExit should bubble up, causing our try-except block in the subprocess to print SYSTEM_EXIT and exit with 99
+        self.assertEqual(result.returncode, 99, msg=result.stderr or result.stdout)
+        self.assertIn("SYSTEM_EXIT: stop import", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_install_preflight.py
+++ b/tests/test_install_preflight.py
@@ -494,10 +494,13 @@ class InstallPreflightTests(unittest.TestCase):
             systemctl() {{
                 printf '%s\\n' "$*" >> "$CALLS_PATH"
                 case "$*" in
-                    "start smbd") return 1 ;;
+                    "restart smbd") return 1 ;;
                     "is-active --quiet smbd") return 0 ;;
                     *) return 0 ;;
                 esac
+            }}
+            smbcontrol() {{
+                return 1
             }}
             command() {{
                 if [ "$1" = "-v" ] && [ "$2" = "systemctl" ]; then
@@ -520,7 +523,7 @@ class InstallPreflightTests(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
-        self.assertIn("WARNING: smbd is active, but systemctl start smbd failed", result.stdout)
+        self.assertIn("WARNING: smbd is active, but reload/restart failed", result.stdout)
         self.assertIn("smbd: active", result.stdout)
 
     def test_samba_services_summary_reports_best_effort_discovery(self):

--- a/tests/test_install_preflight.py
+++ b/tests/test_install_preflight.py
@@ -568,6 +568,46 @@ class InstallPreflightTests(unittest.TestCase):
         self.assertIn("nmbd: inactive", result.stdout)
         self.assertIn("wsdd2: inactive", result.stdout)
 
+    def test_samba_services_summary_reports_unavailable_when_unit_missing(self):
+        snippet = textwrap.dedent(
+            f"""\
+            set -e
+            {self.installer_function("configure_samba_discovery_services")}
+            systemctl() {{
+                printf '%s\\n' "$*" >> "$CALLS_PATH"
+                case "$*" in
+                    "is-active --quiet smbd") return 0 ;;
+                    "is-active --quiet nmbd") return 0 ;;
+                    "is-active --quiet wsdd2") return 1 ;;
+                    "cat wsdd2") return 1 ;;
+                    *) return 0 ;;
+                esac
+            }}
+            command() {{
+                if [ "$1" = "-v" ] && [ "$2" = "systemctl" ]; then
+                    return 0
+                fi
+                builtin command "$@"
+            }}
+            export CALLS_PATH="{Path(tempfile.gettempdir()) / "sss-samba-unavailable-calls"}"
+            rm -f "$CALLS_PATH"
+            configure_samba_discovery_services
+            cat "$CALLS_PATH"
+            """
+        )
+
+        result = subprocess.run(
+            ["bash", "-lc", snippet],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("smbd: active", result.stdout)
+        self.assertIn("nmbd: active", result.stdout)
+        self.assertIn("wsdd2: unavailable", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_install_preflight.py
+++ b/tests/test_install_preflight.py
@@ -358,6 +358,216 @@ class InstallPreflightTests(unittest.TestCase):
         self.assertIn("rsync -a --delete templates", text)
         self.assertIn("rsync -a --delete harddrive_model/", text)
 
+    def test_core_dependency_install_does_not_include_optional_wsdd_daemons(self):
+        text = INSTALL_SCRIPT.read_text()
+        core_install_line = next(
+            line for line in text.splitlines() if "apt-get install -y python3 " in line
+        )
+
+        self.assertIn("samba", core_install_line)
+        self.assertNotIn("wsdd2", core_install_line)
+        self.assertNotIn("wsdd", core_install_line)
+
+    def test_optional_wsdd2_install_warns_and_continues(self):
+        snippet = textwrap.dedent(
+            f"""\
+            set -e
+            {self.installer_function("install_optional_wsdd2")}
+            apt-get() {{
+                printf '%s\\n' "$*" >> "$CALLS_PATH"
+                return 42
+            }}
+            export CALLS_PATH="{Path(tempfile.gettempdir()) / "sss-wsdd2-install-calls"}"
+            rm -f "$CALLS_PATH"
+            install_optional_wsdd2
+            cat "$CALLS_PATH"
+            """
+        )
+
+        result = subprocess.run(
+            ["bash", "-lc", snippet],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("install -y wsdd2", result.stdout)
+        self.assertIn("Continuing without modern Windows discovery", result.stdout)
+
+    def test_samba_layout_helper_invoked_without_creating_backup_share(self):
+        text = INSTALL_SCRIPT.read_text()
+
+        self.assertIn("SambaLayoutService(runtime=rt).ensure_layout()", text)
+        self.assertNotIn("create_share('backup'", text)
+        self.assertNotIn('create_share("backup"', text)
+
+    def test_samba_services_fail_for_smbd_and_continue_for_discovery(self):
+        snippet = textwrap.dedent(
+            f"""\
+            set -e
+            {self.installer_function("configure_samba_discovery_services")}
+            systemctl() {{
+                printf '%s\\n' "$*" >> "$CALLS_PATH"
+                if [ "$1" = "is-active" ] && [ "$2" = "--quiet" ] && [ "$3" = "smbd" ]; then
+                    return 1
+                fi
+                return 0
+            }}
+            command() {{
+                if [ "$1" = "-v" ] && [ "$2" = "systemctl" ]; then
+                    return 0
+                fi
+                builtin command "$@"
+            }}
+            export CALLS_PATH="{Path(tempfile.gettempdir()) / "sss-samba-service-calls"}"
+            rm -f "$CALLS_PATH"
+            configure_samba_discovery_services
+            """
+        )
+
+        result = subprocess.run(
+            ["bash", "-lc", snippet],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ERROR: smbd is not active", result.stdout)
+        self.assertIn("systemctl status smbd", result.stdout)
+
+    def test_top_level_installer_honors_samba_service_setup_failure(self):
+        text = INSTALL_SCRIPT.read_text()
+        samba_step = text[
+            text.index("# 9. Prepare the SSS-owned Samba include layout") : text.index(
+                "# 10. Install/refresh systemd service for Flask app"
+            )
+        ]
+
+        self.assertIn("if configure_samba_discovery_services; then", samba_step)
+        self.assertIn("ERROR: Failed to start required Samba file serving.", samba_step)
+        self.assertIn("exit 1", samba_step)
+
+    def test_samba_service_setup_warns_when_smbd_enable_fails_but_active(self):
+        snippet = textwrap.dedent(
+            f"""\
+            set -e
+            {self.installer_function("configure_samba_discovery_services")}
+            systemctl() {{
+                printf '%s\\n' "$*" >> "$CALLS_PATH"
+                case "$*" in
+                    "enable smbd") return 1 ;;
+                    "is-active --quiet smbd") return 0 ;;
+                    *) return 0 ;;
+                esac
+            }}
+            command() {{
+                if [ "$1" = "-v" ] && [ "$2" = "systemctl" ]; then
+                    return 0
+                fi
+                builtin command "$@"
+            }}
+            export CALLS_PATH="{Path(tempfile.gettempdir()) / "sss-smbd-enable-warning-calls"}"
+            rm -f "$CALLS_PATH"
+            configure_samba_discovery_services
+            cat "$CALLS_PATH"
+            """
+        )
+
+        result = subprocess.run(
+            ["bash", "-lc", snippet],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("WARNING: smbd is active, but systemctl enable smbd failed", result.stdout)
+        self.assertIn("smbd: active", result.stdout)
+
+    def test_samba_service_setup_warns_when_smbd_start_fails_but_active(self):
+        snippet = textwrap.dedent(
+            f"""\
+            set -e
+            {self.installer_function("configure_samba_discovery_services")}
+            systemctl() {{
+                printf '%s\\n' "$*" >> "$CALLS_PATH"
+                case "$*" in
+                    "start smbd") return 1 ;;
+                    "is-active --quiet smbd") return 0 ;;
+                    *) return 0 ;;
+                esac
+            }}
+            command() {{
+                if [ "$1" = "-v" ] && [ "$2" = "systemctl" ]; then
+                    return 0
+                fi
+                builtin command "$@"
+            }}
+            export CALLS_PATH="{Path(tempfile.gettempdir()) / "sss-smbd-start-warning-calls"}"
+            rm -f "$CALLS_PATH"
+            configure_samba_discovery_services
+            cat "$CALLS_PATH"
+            """
+        )
+
+        result = subprocess.run(
+            ["bash", "-lc", snippet],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("WARNING: smbd is active, but systemctl start smbd failed", result.stdout)
+        self.assertIn("smbd: active", result.stdout)
+
+    def test_samba_services_summary_reports_best_effort_discovery(self):
+        snippet = textwrap.dedent(
+            f"""\
+            set -e
+            {self.installer_function("configure_samba_discovery_services")}
+            systemctl() {{
+                printf '%s\\n' "$*" >> "$CALLS_PATH"
+                case "$*" in
+                    "is-active --quiet smbd") return 0 ;;
+                    "is-active --quiet nmbd") return 1 ;;
+                    "is-active --quiet wsdd2") return 1 ;;
+                    *) return 0 ;;
+                esac
+            }}
+            command() {{
+                if [ "$1" = "-v" ] && [ "$2" = "systemctl" ]; then
+                    return 0
+                fi
+                builtin command "$@"
+            }}
+            export CALLS_PATH="{Path(tempfile.gettempdir()) / "sss-samba-summary-calls"}"
+            rm -f "$CALLS_PATH"
+            configure_samba_discovery_services
+            cat "$CALLS_PATH"
+            """
+        )
+
+        result = subprocess.run(
+            ["bash", "-lc", snippet],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("enable smbd", result.stdout)
+        self.assertIn("start smbd", result.stdout)
+        self.assertIn("enable nmbd", result.stdout)
+        self.assertIn("start nmbd", result.stdout)
+        self.assertIn("enable wsdd2", result.stdout)
+        self.assertIn("start wsdd2", result.stdout)
+        self.assertIn("smbd: active", result.stdout)
+        self.assertIn("nmbd: inactive", result.stdout)
+        self.assertIn("wsdd2: inactive", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_samba_layout.py
+++ b/tests/test_samba_layout.py
@@ -1,0 +1,141 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from simple_safer_server.services.samba_layout import (
+    SSS_GLOBALS_INCLUDE_BEGIN,
+    SSS_SHARES_INCLUDE_BEGIN,
+    SSS_SHARES_INCLUDE_END,
+    SambaLayoutError,
+    SambaLayoutService,
+)
+
+
+class FakeSambaCommandAdapter:
+    def __init__(self, *, validation_returncode=0):
+        self.validation_returncode = validation_returncode
+        self.validated_paths = []
+
+    def validate_config(self, validator, candidate_path, cwd=None):
+        self.validated_paths.append(Path(candidate_path))
+        return SimpleNamespace(
+            returncode=self.validation_returncode,
+            stdout="",
+            stderr="invalid include target" if self.validation_returncode else "",
+        )
+
+
+class SambaLayoutServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        self.runtime = SimpleNamespace(
+            samba_dir=self.root / "samba",
+            is_fake=True,
+        )
+        self.runtime.samba_dir.mkdir(parents=True)
+        self.adapter = FakeSambaCommandAdapter()
+        self.service = SambaLayoutService(runtime=self.runtime, command_adapter=self.adapter)
+
+    def write_main_config(self, content):
+        (self.runtime.samba_dir / "smb.conf").write_text(content, encoding="utf-8")
+
+    def read_main_config(self):
+        return (self.runtime.samba_dir / "smb.conf").read_text(encoding="utf-8")
+
+    def test_creates_owned_files_and_places_includes_without_changing_unrelated_config(self):
+        self.write_main_config(
+            "\n".join(
+                [
+                    "# site note",
+                    "[global]",
+                    "   workgroup = WORKGROUP",
+                    "   server string = Simple",
+                    "",
+                    "[media]",
+                    "   path = /srv/media",
+                    "",
+                ]
+            )
+        )
+
+        self.service.ensure_layout()
+
+        content = self.read_main_config()
+        self.assertIn("# site note\n[global]\n", content)
+        self.assertIn("   server string = Simple\n", content)
+        self.assertLess(content.index(SSS_GLOBALS_INCLUDE_BEGIN), content.index("[media]"))
+        self.assertTrue(content.rstrip().endswith(SSS_SHARES_INCLUDE_END))
+        self.assertEqual(len(self.adapter.validated_paths), 1)
+
+        globals_content = (self.runtime.samba_dir / "simple_safer_server_globals.conf").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("map to guest = never", globals_content)
+        self.assertIn("disable netbios = no", globals_content)
+        self.assertNotIn("[global]", globals_content)
+        self.assertEqual(
+            (self.runtime.samba_dir / "simple_safer_server_globals.conf").stat().st_mode & 0o777,
+            0o644,
+        )
+
+        shares_content = (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("normal share changes should use the Web UI", shares_content)
+        self.assertIn("unsupported manual directives may be overwritten", shares_content)
+        self.assertEqual(
+            (self.runtime.samba_dir / "simple_safer_server_shares.conf").stat().st_mode & 0o777,
+            0o644,
+        )
+
+    def test_layout_helper_is_idempotent(self):
+        self.write_main_config(
+            "[global]\n   workgroup = WORKGROUP\n\n[media]\n   path = /srv/media\n"
+        )
+
+        self.service.ensure_layout()
+        first_content = self.read_main_config()
+        self.service.ensure_layout()
+
+        self.assertEqual(self.read_main_config(), first_content)
+        self.assertEqual(self.read_main_config().count(SSS_GLOBALS_INCLUDE_BEGIN), 1)
+        self.assertEqual(self.read_main_config().count(SSS_SHARES_INCLUDE_BEGIN), 1)
+
+    def test_malformed_marker_blocks_fail_closed(self):
+        self.write_main_config(
+            "\n".join(
+                [
+                    "[global]",
+                    SSS_GLOBALS_INCLUDE_BEGIN,
+                    "   include = /etc/samba/simple_safer_server_globals.conf",
+                    "",
+                    "[media]",
+                    "   path = /srv/media",
+                    "",
+                ]
+            )
+        )
+
+        with self.assertRaisesRegex(SambaLayoutError, "malformed"):
+            self.service.ensure_layout()
+
+    def test_validation_failure_rolls_back_all_layout_changes(self):
+        self.write_main_config("[global]\n   workgroup = WORKGROUP\n")
+        failing_service = SambaLayoutService(
+            runtime=self.runtime,
+            command_adapter=FakeSambaCommandAdapter(validation_returncode=1),
+        )
+
+        with self.assertRaisesRegex(SambaLayoutError, "validation failed"):
+            failing_service.ensure_layout()
+
+        self.assertEqual(self.read_main_config(), "[global]\n   workgroup = WORKGROUP\n")
+        self.assertFalse((self.runtime.samba_dir / "simple_safer_server_globals.conf").exists())
+        self.assertFalse((self.runtime.samba_dir / "simple_safer_server_shares.conf").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -9,7 +9,6 @@ from flask import Flask
 
 from simple_safer_server.services.cloud_backup_service import MegaFolderList
 from simple_safer_server.services.server_identity import ServerIdentityError
-from simple_safer_server.services.smb_manager import SMB_DOCS_URL
 
 
 class FakeCloudBackupService:
@@ -466,7 +465,7 @@ class SetupWizardTests(unittest.TestCase):
     def test_setup_smb_share_surfaces_unmanaged_backup_guidance(self):
         smb_manager = MagicMock()
         smb_manager.ensure_default_backup_share.side_effect = ValueError(
-            f"An unmanaged Samba share named 'backup' already exists. See {SMB_DOCS_URL}"
+            'Samba share "backup" already exists. Rename or remove it, then retry.'
         )
         user_manager = MagicMock()
         user_manager.users = {'admin': {}}
@@ -482,7 +481,9 @@ class SetupWizardTests(unittest.TestCase):
                 )
 
         self.assertFalse(ok)
-        self.assertIn(SMB_DOCS_URL, err)
+        self.assertEqual(
+            err, 'Samba share "backup" already exists. Rename or remove it, then retry.'
+        )
         user_manager.reload_users.assert_called_once_with()
 
     # ------------------------------------------------------------------

--- a/tests/test_smb_command_adapter.py
+++ b/tests/test_smb_command_adapter.py
@@ -111,6 +111,22 @@ class SmbCommandAdapterTests(unittest.TestCase):
             ],
         )
 
+    def test_reload_config_uses_smbcontrol_command(self):
+        runner = RecordingRunner()
+        adapter = SmbCommandAdapter(command_runner=runner)
+
+        adapter.reload_config()
+
+        self.assertEqual(
+            runner.calls,
+            [
+                (
+                    ["smbcontrol", "smbd", "reload-config"],
+                    {"check": True, "timeout": SMB_COMMAND_TIMEOUT_SECONDS},
+                )
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_smb_command_adapter.py
+++ b/tests/test_smb_command_adapter.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 from simple_safer_server.adapters.command_runner import CommandRunner
@@ -15,18 +16,23 @@ class RecordingRunner(CommandRunner):
 
 
 class SmbCommandAdapterTests(unittest.TestCase):
-    def test_copy_config_defaults_to_no_sudo(self):
+    def test_validate_config_passes_optional_working_directory(self):
         runner = RecordingRunner()
         adapter = SmbCommandAdapter(command_runner=runner)
 
-        adapter.copy_config("/etc/samba/smb.conf", "/tmp/smb.conf.backup")
+        adapter.validate_config("testparm", Path("/tmp/candidate.conf"), cwd=Path("/etc/samba"))
 
         self.assertEqual(
             runner.calls,
             [
                 (
-                    ["cp", "/etc/samba/smb.conf", "/tmp/smb.conf.backup"],
-                    {"check": True, "timeout": SMB_COMMAND_TIMEOUT_SECONDS},
+                    ["testparm", "-s", "/tmp/candidate.conf"],
+                    {
+                        "capture_output": True,
+                        "text": True,
+                        "timeout": SMB_COMMAND_TIMEOUT_SECONDS,
+                        "cwd": "/etc/samba",
+                    },
                 )
             ],
         )

--- a/tests/test_smb_command_adapter.py
+++ b/tests/test_smb_command_adapter.py
@@ -33,27 +33,41 @@ class ConfigurableRunner(CommandRunner):
 
 class UnitStatusTests(unittest.TestCase):
     def test_unit_status_returns_active_when_running(self):
-        runner = ConfigurableRunner(results={
-            ("systemctl", "is-active"): SimpleNamespace(returncode=0, stdout="active\n", stderr=""),
-        })
+        runner = ConfigurableRunner(
+            results={
+                ("systemctl", "is-active"): SimpleNamespace(
+                    returncode=0, stdout="active\n", stderr=""
+                ),
+            }
+        )
         adapter = SmbCommandAdapter(command_runner=runner)
 
         self.assertEqual(adapter.unit_status("smbd"), "active")
 
     def test_unit_status_returns_inactive_when_stopped_but_unit_exists(self):
-        runner = ConfigurableRunner(results={
-            ("systemctl", "is-active"): SimpleNamespace(returncode=3, stdout="inactive\n", stderr=""),
-            ("systemctl", "cat"): SimpleNamespace(returncode=0, stdout="[Unit]\n", stderr=""),
-        })
+        runner = ConfigurableRunner(
+            results={
+                ("systemctl", "is-active"): SimpleNamespace(
+                    returncode=3, stdout="inactive\n", stderr=""
+                ),
+                ("systemctl", "cat"): SimpleNamespace(returncode=0, stdout="[Unit]\n", stderr=""),
+            }
+        )
         adapter = SmbCommandAdapter(command_runner=runner)
 
         self.assertEqual(adapter.unit_status("wsdd2"), "inactive")
 
     def test_unit_status_returns_unavailable_when_unit_file_missing(self):
-        runner = ConfigurableRunner(results={
-            ("systemctl", "is-active"): SimpleNamespace(returncode=3, stdout="inactive\n", stderr=""),
-            ("systemctl", "cat"): SimpleNamespace(returncode=1, stdout="", stderr="No files found\n"),
-        })
+        runner = ConfigurableRunner(
+            results={
+                ("systemctl", "is-active"): SimpleNamespace(
+                    returncode=3, stdout="inactive\n", stderr=""
+                ),
+                ("systemctl", "cat"): SimpleNamespace(
+                    returncode=1, stdout="", stderr="No files found\n"
+                ),
+            }
+        )
         adapter = SmbCommandAdapter(command_runner=runner)
 
         self.assertEqual(adapter.unit_status("wsdd2"), "unavailable")

--- a/tests/test_smb_command_adapter.py
+++ b/tests/test_smb_command_adapter.py
@@ -15,6 +15,50 @@ class RecordingRunner(CommandRunner):
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
 
+class ConfigurableRunner(CommandRunner):
+    """Runner that returns preconfigured results keyed by command prefix."""
+
+    def __init__(self, results=None):
+        self.calls = []
+        self._results = results or {}
+
+    def run(self, command, **kwargs):
+        self.calls.append((command, kwargs))
+        # Match on the first two args (e.g. ["systemctl", "is-active"])
+        key = tuple(command[:2]) if len(command) >= 2 else tuple(command)
+        if key in self._results:
+            return self._results[key]
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+class UnitStatusTests(unittest.TestCase):
+    def test_unit_status_returns_active_when_running(self):
+        runner = ConfigurableRunner(results={
+            ("systemctl", "is-active"): SimpleNamespace(returncode=0, stdout="active\n", stderr=""),
+        })
+        adapter = SmbCommandAdapter(command_runner=runner)
+
+        self.assertEqual(adapter.unit_status("smbd"), "active")
+
+    def test_unit_status_returns_inactive_when_stopped_but_unit_exists(self):
+        runner = ConfigurableRunner(results={
+            ("systemctl", "is-active"): SimpleNamespace(returncode=3, stdout="inactive\n", stderr=""),
+            ("systemctl", "cat"): SimpleNamespace(returncode=0, stdout="[Unit]\n", stderr=""),
+        })
+        adapter = SmbCommandAdapter(command_runner=runner)
+
+        self.assertEqual(adapter.unit_status("wsdd2"), "inactive")
+
+    def test_unit_status_returns_unavailable_when_unit_file_missing(self):
+        runner = ConfigurableRunner(results={
+            ("systemctl", "is-active"): SimpleNamespace(returncode=3, stdout="inactive\n", stderr=""),
+            ("systemctl", "cat"): SimpleNamespace(returncode=1, stdout="", stderr="No files found\n"),
+        })
+        adapter = SmbCommandAdapter(command_runner=runner)
+
+        self.assertEqual(adapter.unit_status("wsdd2"), "unavailable")
+
+
 class SmbCommandAdapterTests(unittest.TestCase):
     def test_validate_config_passes_optional_working_directory(self):
         runner = RecordingRunner()

--- a/tests/test_smb_manager.py
+++ b/tests/test_smb_manager.py
@@ -16,6 +16,7 @@ class FakeSmbCommandAdapter:
         validation_returncodes=None,
         unit_statuses=None,
         restart_failures=None,
+        reload_failures=None,
     ):
         self.validation_returncode = validation_returncode
         self.validation_returncodes = list(validation_returncodes or [])
@@ -25,6 +26,8 @@ class FakeSmbCommandAdapter:
         self.unit_statuses = unit_statuses or {}
         self.restart_failures = set(restart_failures or [])
         self.restarted_units = []
+        self.reload_failures = set(reload_failures or [])
+        self.reloaded_units = []
 
     def validate_config(self, validator, candidate_path, cwd=None):
         self.validated_paths.append(Path(candidate_path))
@@ -51,6 +54,11 @@ class FakeSmbCommandAdapter:
         self.restarted_units.append(unit_name)
         if unit_name in self.restart_failures:
             raise smb_manager.CalledProcessError(1, ["systemctl", "restart", unit_name])
+
+    def reload_config(self):
+        self.reloaded_units.append("smbd")
+        if "smbd" in self.reload_failures:
+            raise smb_manager.CalledProcessError(1, ["smbcontrol", "smbd", "reload-config"])
 
 
 class SMBManagerTests(unittest.TestCase):
@@ -682,6 +690,37 @@ class SMBManagerTests(unittest.TestCase):
 
         self.assertTrue(manager.restart_services())
         self.assertEqual(adapter.restarted_units, ["smbd", "nmbd", "wsdd2"])
+
+    def test_reload_or_restart_smbd_reloads_when_active(self):
+        self.runtime.is_fake = False
+        adapter = FakeSmbCommandAdapter(unit_statuses={"smbd": "active"})
+        manager = smb_manager.SMBManager(runtime=self.runtime, command_adapter=adapter)
+
+        self.assertTrue(manager._reload_or_restart_smbd())
+        self.assertEqual(adapter.reloaded_units, ["smbd"])
+        self.assertEqual(adapter.restarted_units, [])
+
+    def test_reload_or_restart_smbd_restarts_when_inactive(self):
+        self.runtime.is_fake = False
+        adapter = FakeSmbCommandAdapter(unit_statuses={"smbd": "inactive"})
+        manager = smb_manager.SMBManager(runtime=self.runtime, command_adapter=adapter)
+
+        self.assertTrue(manager._reload_or_restart_smbd())
+        self.assertEqual(adapter.reloaded_units, [])
+        self.assertEqual(adapter.restarted_units, ["smbd"])
+
+    def test_reload_or_restart_smbd_restarts_when_reload_fails(self):
+        self.runtime.is_fake = False
+        adapter = FakeSmbCommandAdapter(
+            unit_statuses={"smbd": "active"},
+            reload_failures={"smbd"},
+        )
+        manager = smb_manager.SMBManager(runtime=self.runtime, command_adapter=adapter)
+
+        self.assertTrue(manager._reload_or_restart_smbd())
+        # Reload was attempted, but failed, so we fall back to restart
+        self.assertEqual(adapter.reloaded_units, ["smbd"])
+        self.assertEqual(adapter.restarted_units, ["smbd"])
 
     def test_parse_smb_conf_does_not_treat_marker_comments_as_share_boundaries(self):
         """_parse_smb_conf should parse through old marker-like comments without

--- a/tests/test_smb_manager.py
+++ b/tests/test_smb_manager.py
@@ -8,6 +8,51 @@ from unittest.mock import patch
 from simple_safer_server.services import smb_manager
 
 
+class FakeSmbCommandAdapter:
+    def __init__(
+        self,
+        *,
+        validation_returncode=0,
+        validation_returncodes=None,
+        unit_statuses=None,
+        restart_failures=None,
+    ):
+        self.validation_returncode = validation_returncode
+        self.validation_returncodes = list(validation_returncodes or [])
+        self.validated_paths = []
+        self.validation_cwds = []
+        self.validated_candidate_texts = []
+        self.unit_statuses = unit_statuses or {}
+        self.restart_failures = set(restart_failures or [])
+        self.restarted_units = []
+
+    def validate_config(self, validator, candidate_path, cwd=None):
+        self.validated_paths.append(Path(candidate_path))
+        self.validation_cwds.append(Path(cwd) if cwd is not None else None)
+        candidate_text = Path(candidate_path).read_text(encoding="utf-8")
+        self.validated_candidate_texts.append(candidate_text)
+        returncode = (
+            self.validation_returncodes.pop(0)
+            if self.validation_returncodes
+            else self.validation_returncode
+        )
+        return SimpleNamespace(
+            returncode=returncode,
+            stdout=candidate_text if returncode == 0 else "",
+            stderr="invalid shares file" if returncode else "",
+        )
+
+    def unit_status(self, unit_name):
+        if unit_name not in self.unit_statuses:
+            raise RuntimeError(f"{unit_name} status unavailable")
+        return self.unit_statuses[unit_name]
+
+    def restart_unit(self, unit_name):
+        self.restarted_units.append(unit_name)
+        if unit_name in self.restart_failures:
+            raise smb_manager.CalledProcessError(1, ["systemctl", "restart", unit_name])
+
+
 class SMBManagerTests(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
@@ -15,26 +60,33 @@ class SMBManagerTests(unittest.TestCase):
         self.root = Path(self.tempdir.name)
         self.runtime = SimpleNamespace(
             samba_dir=self.root / "samba",
-            samba_backup_dir=self.root / "samba-backups",
+            volatile_dir=self.root / "run",
             is_fake=True,
         )
         self.runtime.samba_dir.mkdir(parents=True, exist_ok=True)
-        self.runtime.samba_backup_dir.mkdir(parents=True, exist_ok=True)
+        self.runtime.volatile_dir.mkdir(parents=True, exist_ok=True)
         self.fake_state = SimpleNamespace(
-            set_smb_services=lambda smbd, nmbd: None,
-            get_smb_services=lambda: {"smbd": "active", "nmbd": "active"},
+            set_smb_services=lambda smbd, nmbd, wsdd2="active": None,
+            get_smb_services=lambda: {"smbd": "active", "nmbd": "active", "wsdd2": "active"},
         )
 
         patcher = patch.object(smb_manager, "get_fake_state", return_value=self.fake_state)
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        self.manager = smb_manager.SMBManager(runtime=self.runtime)
+        self.adapter = FakeSmbCommandAdapter()
+        self.manager = smb_manager.SMBManager(
+            runtime=self.runtime,
+            command_adapter=self.adapter,
+        )
 
     def _write_conf(self, content):
         (self.runtime.samba_dir / "smb.conf").write_text(content)
 
-    def test_list_managed_and_unmanaged_shares_in_mixed_config(self):
+    def _write_shares(self, content):
+        (self.runtime.samba_dir / "simple_safer_server_shares.conf").write_text(content)
+
+    def test_list_managed_shares_reads_sss_shares_file_not_main_config_markers(self):
         self._write_conf(
             "\n".join(
                 [
@@ -56,49 +108,62 @@ class SMBManagerTests(unittest.TestCase):
                 ]
             )
         )
+        self._write_shares(
+            "\n".join(
+                [
+                    "# SimpleSaferServer-managed Samba shares",
+                    "[photos]",
+                    "   path = /srv/photos",
+                    "   writeable = Yes",
+                    "   comment = SSS file share",
+                    "   valid users = admin",
+                    "",
+                ]
+            )
+        )
 
         managed = self.manager.list_managed_shares()
         unmanaged = self.manager.list_unmanaged_shares()
 
-        self.assertEqual([share["name"] for share in managed], ["backup"])
-        self.assertEqual([share["name"] for share in unmanaged], ["media"])
-        self.assertEqual(managed[0]["path"], "/media/backup")
+        self.assertEqual([share["name"] for share in managed], ["photos"])
+        self.assertEqual([share["name"] for share in unmanaged], ["backup", "media"])
+        self.assertEqual(managed[0]["path"], "/srv/photos")
 
-    def test_malformed_managed_marker_raises_clear_error(self):
-        self._write_conf(
+    def test_malformed_sss_shares_file_raises_clear_error(self):
+        self._write_shares(
             "\n".join(
                 [
-                    "[global]",
-                    "   workgroup = WORKGROUP",
-                    "",
-                    "# BEGIN SimpleSaferServer share: backup",
                     "[backup]",
                     "   path = /media/backup",
-                    "",
+                    "[backup]",
+                    "   path = /srv/duplicate",
                 ]
             )
         )
 
-        with self.assertRaises(smb_manager.SMBConfigError):
+        with self.assertRaisesRegex(smb_manager.SMBConfigError, "unsupported or malformed"):
             self.manager.list_managed_shares()
 
-    def test_stray_end_marker_raises_clear_error(self):
-        self._write_conf(
+    def test_unsupported_directives_in_sss_shares_file_do_not_crash_listing(self):
+        self._write_shares(
             "\n".join(
                 [
-                    "[global]",
-                    "   workgroup = WORKGROUP",
-                    "",
-                    "# END SimpleSaferServer share: backup",
+                    "[backup]",
+                    "   path = /media/backup",
+                    "   veto files = /*.tmp/",
+                    "   writeable = Yes",
+                    "   comment = Manual extra directive",
                     "",
                 ]
             )
         )
 
-        with self.assertRaisesRegex(smb_manager.SMBConfigError, "END marker"):
-            self.manager.list_managed_shares()
+        shares = self.manager.list_managed_shares()
 
-    def test_create_managed_share_writes_wrapped_block(self):
+        self.assertEqual(shares[0]["name"], "backup")
+        self.assertEqual(shares[0]["path"], "/media/backup")
+
+    def test_create_managed_share_writes_sss_shares_file_and_validates_layout(self):
         share_path = self.root / "share"
         share_path.mkdir()
 
@@ -110,34 +175,113 @@ class SMBManagerTests(unittest.TestCase):
             valid_users=["admin"],
         )
 
-        content = (self.runtime.samba_dir / "smb.conf").read_text()
-        self.assertIn("# BEGIN SimpleSaferServer share: backup", content)
+        content = (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text()
+        self.assertNotIn("# BEGIN SimpleSaferServer share: backup", content)
         self.assertIn("[backup]", content)
         self.assertIn(f"   path = {share_path}", content)
-        self.assertIn("# END SimpleSaferServer share: backup", content)
+        self.assertTrue((self.runtime.samba_dir / "simple_safer_server_globals.conf").exists())
+        self.assertEqual(len(self.adapter.validated_paths), 3)
+
+    def test_list_unmanaged_shares_uses_stripped_effective_config_candidate(self):
+        self._write_conf(
+            "\n".join(
+                [
+                    "[global]",
+                    "   workgroup = WORKGROUP",
+                    "# BEGIN SimpleSaferServer global include",
+                    "   include = /etc/samba/simple_safer_server_globals.conf",
+                    "# END SimpleSaferServer global include",
+                    "",
+                    "[homes]",
+                    "   browseable = no",
+                    "",
+                    "include = /etc/samba/site-shares.conf",
+                    "",
+                    "# BEGIN SimpleSaferServer shares include",
+                    "include = /etc/samba/simple_safer_server_shares.conf",
+                    "# END SimpleSaferServer shares include",
+                    "",
+                ]
+            )
+        )
+
+        captured = {}
+
+        def fake_effective_config(_validator, candidate_path, cwd=None):
+            captured["candidate_path"] = Path(candidate_path)
+            captured["cwd"] = Path(cwd) if cwd is not None else None
+            captured["candidate_text"] = Path(candidate_path).read_text(encoding="utf-8")
+            return SimpleNamespace(
+                returncode=0,
+                stdout="\n".join(
+                    [
+                        "[global]",
+                        "[homes]",
+                        "[printers]",
+                        "[print$]",
+                        "[media]",
+                        "   path = /srv/media",
+                        "[backup]",
+                        "   path = /srv/backup",
+                        "",
+                    ]
+                ),
+                stderr="",
+            )
+
+        with patch.object(self.adapter, "validate_config", side_effect=fake_effective_config):
+            unmanaged = self.manager.list_unmanaged_shares()
+
+        self.assertEqual([share["name"] for share in unmanaged], ["media", "backup"])
+        candidate_path = captured["candidate_path"]
+        self.assertEqual(candidate_path.parent, self.runtime.volatile_dir)
+        self.assertEqual(captured["cwd"], self.runtime.samba_dir)
+        self.assertFalse(candidate_path.exists())
+        self.assertIn("include = /etc/samba/site-shares.conf", captured["candidate_text"])
+        self.assertNotIn("SimpleSaferServer global include", captured["candidate_text"])
+        self.assertNotIn("SimpleSaferServer shares include", captured["candidate_text"])
+
+    def test_unmanaged_inspection_fails_closed_for_malformed_include_markers(self):
+        self._write_conf(
+            "\n".join(
+                [
+                    "[global]",
+                    "# BEGIN SimpleSaferServer shares include",
+                    "include = /etc/samba/simple_safer_server_shares.conf",
+                    "[media]",
+                    "   path = /srv/media",
+                    "",
+                ]
+            )
+        )
+
+        with self.assertRaisesRegex(smb_manager.SMBConfigError, "marker block is malformed"):
+            self.manager.list_unmanaged_shares()
+
+    def test_unmanaged_inspection_fails_closed_when_effective_config_fails(self):
+        self._write_conf("[global]\n[media]\n   path = /srv/media\n")
+        manager = smb_manager.SMBManager(
+            runtime=self.runtime,
+            command_adapter=FakeSmbCommandAdapter(validation_returncode=1),
+        )
+
+        with self.assertRaisesRegex(smb_manager.SMBConfigError, "effective Samba config"):
+            manager.list_unmanaged_shares()
 
     def test_update_managed_share_preserves_unmanaged_block(self):
         old_path = self.root / "old-share"
         old_path.mkdir()
         new_path = self.root / "new-share"
         new_path.mkdir()
-        self._write_conf(
+        self._write_conf("[media]\n   path = /srv/media\n   guest ok = yes\n")
+        self._write_shares(
             "\n".join(
                 [
-                    "[global]",
-                    "   workgroup = WORKGROUP",
-                    "",
-                    "[media]",
-                    "   path = /srv/media",
-                    "   guest ok = yes",
-                    "",
-                    "# BEGIN SimpleSaferServer share: backup",
                     "[backup]",
                     f"   path = {old_path}",
                     "   writeable = Yes",
                     "   comment = Old comment",
                     "   valid users = admin",
-                    "# END SimpleSaferServer share: backup",
                     "",
                 ]
             )
@@ -152,27 +296,20 @@ class SMBManagerTests(unittest.TestCase):
             valid_users=["admin", "operator"],
         )
 
-        content = (self.runtime.samba_dir / "smb.conf").read_text()
-        self.assertIn("[media]\n   path = /srv/media\n   guest ok = yes\n", content)
+        content = (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text()
+        self.assertNotIn("[media]", content)
         self.assertIn(f"   path = {new_path}", content)
         self.assertIn("   writeable = No", content)
         self.assertIn("   valid users = admin operator", content)
 
     def test_delete_managed_share_only_removes_owned_block(self):
-        self._write_conf(
+        self._write_conf("[media]\n   path = /srv/media\n")
+        self._write_shares(
             "\n".join(
                 [
-                    "[global]",
-                    "   workgroup = WORKGROUP",
-                    "",
-                    "# BEGIN SimpleSaferServer share: backup",
                     "[backup]",
                     "   path = /media/backup",
                     "   writeable = Yes",
-                    "# END SimpleSaferServer share: backup",
-                    "",
-                    "[media]",
-                    "   path = /srv/media",
                     "",
                 ]
             )
@@ -180,25 +317,68 @@ class SMBManagerTests(unittest.TestCase):
 
         self.manager.delete_managed_share("backup")
 
-        content = (self.runtime.samba_dir / "smb.conf").read_text()
+        content = (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text()
         self.assertNotIn("[backup]", content)
-        self.assertIn("[media]", content)
+        self.assertIn("[media]", (self.runtime.samba_dir / "smb.conf").read_text())
+
+    def test_delete_managed_share_does_not_inspect_unmanaged_effective_config(self):
+        self._write_conf("[global]\n[media]\n   path = /srv/media\n")
+        self._write_shares("[backup]\n   path = /media/backup\n")
+
+        with patch.object(
+            self.manager,
+            "_inspect_unmanaged_effective_shares",
+            side_effect=AssertionError("delete should only read the owned shares file"),
+        ):
+            self.manager.delete_managed_share("backup")
+
+        content = (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text()
+        self.assertNotIn("[backup]", content)
+
+    def test_update_managed_share_without_rename_ignores_effective_self_conflict(self):
+        old_path = self.root / "old-backup"
+        old_path.mkdir()
+        new_path = self.root / "new-backup"
+        new_path.mkdir()
+        self._write_shares(
+            "\n".join(
+                [
+                    "[backup]",
+                    f"   path = {old_path}",
+                    "   writeable = Yes",
+                    "",
+                ]
+            )
+        )
+
+        effective_self = smb_manager.ParsedShare(
+            name="backup",
+            managed=False,
+            path="/media/backup",
+        )
+        with patch.object(
+            self.manager,
+            "_inspect_unmanaged_effective_shares",
+            return_value=[effective_self],
+        ):
+            self.manager.update_managed_share("backup", "backup", str(new_path))
+
+        content = (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text()
+        self.assertIn(f"   path = {new_path}", content)
 
     def test_ensure_default_backup_share_updates_existing_managed_share(self):
         old_path = self.root / "old-backup"
         old_path.mkdir()
         new_path = self.root / "new-backup"
         new_path.mkdir()
-        self._write_conf(
+        self._write_shares(
             "\n".join(
                 [
-                    "# BEGIN SimpleSaferServer share: backup",
                     "[backup]",
                     f"   path = {old_path}",
                     "   writeable = Yes",
                     "   comment = Original",
                     "   valid users = admin",
-                    "# END SimpleSaferServer share: backup",
                     "",
                 ]
             )
@@ -210,7 +390,7 @@ class SMBManagerTests(unittest.TestCase):
         self.assertEqual(share["path"], str(new_path))
         self.assertEqual(share["valid_users"], ["admin"])
 
-    def test_ensure_default_backup_share_rejects_unmanaged_backup_share(self):
+    def test_ensure_default_backup_share_uses_short_unmanaged_backup_conflict(self):
         share_path = self.root / "backup"
         share_path.mkdir()
         self._write_conf(
@@ -224,8 +404,47 @@ class SMBManagerTests(unittest.TestCase):
             )
         )
 
-        with self.assertRaisesRegex(ValueError, "unmanaged Samba share named 'backup'"):
+        with self.assertRaisesRegex(
+            ValueError,
+            'Samba share "backup" already exists. Rename or remove it, then retry.',
+        ):
             self.manager.ensure_default_backup_share(str(share_path), "admin")
+
+    def test_create_managed_share_rejects_unmanaged_conflict_from_main_config(self):
+        share_path = self.root / "new-backup"
+        share_path.mkdir()
+        self._write_conf("[backup]\n   path = /srv/existing\n")
+
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            self.manager.create_managed_share("backup", str(share_path))
+
+    def test_update_managed_share_rejects_rename_to_unmanaged_conflict(self):
+        old_path = self.root / "old-backup"
+        old_path.mkdir()
+        new_path = self.root / "new-backup"
+        new_path.mkdir()
+        self._write_conf("[media]\n   path = /srv/media\n")
+        self._write_shares(f"[backup]\n   path = {old_path}\n")
+
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            self.manager.update_managed_share("backup", "media", str(new_path))
+
+    def test_validation_failure_rolls_back_sss_shares_file(self):
+        share_path = self.root / "validated-share"
+        share_path.mkdir()
+        self._write_shares("# existing shares\n")
+        manager = smb_manager.SMBManager(
+            runtime=self.runtime,
+            command_adapter=FakeSmbCommandAdapter(validation_returncodes=[0, 0, 1]),
+        )
+
+        with self.assertRaisesRegex(smb_manager.SMBConfigError, "validation failed"):
+            manager.create_managed_share("backup", str(share_path))
+
+        self.assertEqual(
+            (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text(),
+            "# existing shares\n",
+        )
 
     def test_create_managed_share_rejects_comment_with_newline_injection(self):
         share_path = self.root / "share-with-comment"
@@ -270,6 +489,66 @@ class SMBManagerTests(unittest.TestCase):
                 valid_users="admin",
             )
 
+    def test_get_share_users_does_not_inspect_effective_config_for_managed_share(self):
+        """Managed-share user reads must not call Effective Config inspection.
+
+        The share is found in the owned file, so inspection is unnecessary and
+        must not be triggered.
+        """
+        share_path = self.root / "managed-share"
+        share_path.mkdir()
+        self._write_shares(
+            "\n".join(
+                [
+                    "[backup]",
+                    f"   path = {share_path}",
+                    "   writeable = Yes",
+                    "   valid users = admin operator",
+                    "",
+                ]
+            )
+        )
+
+        with patch.object(
+            self.manager,
+            "_inspect_unmanaged_effective_shares",
+            side_effect=AssertionError("should not inspect effective config for a managed share"),
+        ):
+            users = self.manager.get_share_users("backup")
+
+        self.assertEqual(users, ["admin", "operator"])
+
+    def test_update_share_users_does_not_inspect_effective_config_for_managed_share(self):
+        """Managed-share user updates must not call Effective Config inspection.
+
+        The share is found in the owned file and the name is unchanged, so
+        inspection is unnecessary and must not be triggered.
+        """
+        share_path = self.root / "managed-share"
+        share_path.mkdir()
+        self._write_shares(
+            "\n".join(
+                [
+                    "[backup]",
+                    f"   path = {share_path}",
+                    "   writeable = Yes",
+                    "   comment = Test share",
+                    "   valid users = admin",
+                    "",
+                ]
+            )
+        )
+
+        with patch.object(
+            self.manager,
+            "_inspect_unmanaged_effective_shares",
+            side_effect=AssertionError("should not inspect effective config for a managed share"),
+        ):
+            self.manager.update_share_users("backup", ["admin", "operator"])
+
+        content = (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text()
+        self.assertIn("valid users = admin operator", content)
+
     def test_get_share_users_rejects_unmanaged_share(self):
         share_path = self.root / "unmanaged-share"
         share_path.mkdir()
@@ -290,16 +569,14 @@ class SMBManagerTests(unittest.TestCase):
     def test_get_share_users_uses_existing_snapshot_without_second_lookup(self):
         share_path = self.root / "managed-share"
         share_path.mkdir()
-        self._write_conf(
+        self._write_shares(
             "\n".join(
                 [
-                    "# BEGIN SimpleSaferServer share: backup",
                     "[backup]",
                     f"   path = {share_path}",
                     "   writeable = Yes",
                     "   comment = Managed backup share",
                     "   valid users = admin",
-                    "# END SimpleSaferServer share: backup",
                     "",
                 ]
             )
@@ -314,63 +591,159 @@ class SMBManagerTests(unittest.TestCase):
         ):
             self.assertEqual(self.manager.get_share_users("backup"), ["admin"])
 
-    def test_restart_failure_restores_previous_live_config(self):
-        runtime = SimpleNamespace(
-            samba_dir=self.root / "real-samba",
-            samba_backup_dir=self.root / "real-samba-backups",
-            is_fake=False,
-        )
-        runtime.samba_dir.mkdir(parents=True, exist_ok=True)
-        runtime.samba_backup_dir.mkdir(parents=True, exist_ok=True)
-        manager = smb_manager.SMBManager(runtime=runtime)
-        live_path = runtime.samba_dir / "smb.conf"
-        original_content = "[global]\n   workgroup = WORKGROUP\n"
-        live_path.write_text(original_content)
-
+    def test_restart_failure_restores_previous_sss_shares_file(self):
         share_path = self.root / "real-share"
         share_path.mkdir()
-        backup_path = runtime.samba_backup_dir / "smb.conf.backup.test"
+        self._write_shares("# original shares\n")
 
-        def fake_backup():
-            backup_path.write_text(live_path.read_text())
-            return str(backup_path)
+        with patch.object(self.manager, "_restart_services", return_value=False):
+            with self.assertRaisesRegex(RuntimeError, "Failed to restart SMB services"):
+                self.manager.create_managed_share("backup", str(share_path))
 
-        with patch.object(manager, "_create_backup", side_effect=fake_backup):
-            with patch.object(manager, "_validate_smb_conf_candidate", return_value=None):
-                with patch.object(manager, "_restart_services", side_effect=[False, True]):
-                    with self.assertRaisesRegex(RuntimeError, "Failed to restart SMB services"):
-                        manager.create_managed_share("backup", str(share_path))
-
-        self.assertEqual(live_path.read_text(), original_content)
-
-    def test_rollback_restart_failure_raises_rollback_error(self):
-        runtime = SimpleNamespace(
-            samba_dir=self.root / "rollback-samba",
-            samba_backup_dir=self.root / "rollback-samba-backups",
-            is_fake=False,
+        self.assertEqual(
+            (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text(),
+            "# original shares\n",
         )
-        runtime.samba_dir.mkdir(parents=True, exist_ok=True)
-        runtime.samba_backup_dir.mkdir(parents=True, exist_ok=True)
-        manager = smb_manager.SMBManager(runtime=runtime)
-        live_path = runtime.samba_dir / "smb.conf"
-        original_content = "[global]\n   workgroup = WORKGROUP\n"
-        live_path.write_text(original_content)
 
-        share_path = self.root / "rollback-share"
-        share_path.mkdir()
-        backup_path = runtime.samba_backup_dir / "smb.conf.backup.rollback"
+    def test_publish_failure_restarts_smbd_after_restoring_previous_shares_file(self):
+        self.runtime.is_fake = False
+        adapter = FakeSmbCommandAdapter(validation_returncodes=[1])
+        manager = smb_manager.SMBManager(runtime=self.runtime, command_adapter=adapter)
+        self._write_conf("[global]\n")
+        self._write_shares("# original shares\n")
 
-        def fake_backup():
-            backup_path.write_text(live_path.read_text())
-            return str(backup_path)
+        with patch.object(smb_manager.os, "chown"):
+            with self.assertRaisesRegex(smb_manager.SMBConfigError, "validation failed"):
+                manager._commit_sss_shares_file("# broken publish\n")
 
-        with patch.object(manager, "_create_backup", side_effect=fake_backup):
-            with patch.object(manager, "_validate_smb_conf_candidate", return_value=None):
-                with patch.object(manager, "_restart_services", side_effect=[False, False]):
-                    with self.assertRaisesRegex(RuntimeError, "Failed to roll back smb.conf"):
-                        manager.create_managed_share("backup", str(share_path))
+        self.assertEqual(
+            (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text(),
+            "# original shares\n",
+        )
+        self.assertEqual(adapter.restarted_units, ["smbd"])
 
-        self.assertEqual(live_path.read_text(), original_content)
+    def test_publish_failure_reports_rollback_restart_failure(self):
+        self.runtime.is_fake = False
+        adapter = FakeSmbCommandAdapter(
+            validation_returncodes=[1],
+            restart_failures={"smbd"},
+        )
+        manager = smb_manager.SMBManager(runtime=self.runtime, command_adapter=adapter)
+        self._write_conf("[global]\n")
+        self._write_shares("# original shares\n")
+
+        with patch.object(smb_manager.os, "chown"):
+            with self.assertRaisesRegex(
+                smb_manager.SMBOperationError,
+                "share update failed and rollback could not restart smbd",
+            ):
+                manager._commit_sss_shares_file("# broken publish\n")
+
+        self.assertEqual(
+            (self.runtime.samba_dir / "simple_safer_server_shares.conf").read_text(),
+            "# original shares\n",
+        )
+        self.assertEqual(adapter.restarted_units, ["smbd"])
+
+    def test_status_includes_wsdd2_and_reports_missing_unit_as_unavailable(self):
+        self.runtime.is_fake = False
+        manager = smb_manager.SMBManager(
+            runtime=self.runtime,
+            command_adapter=FakeSmbCommandAdapter(
+                unit_statuses={"smbd": "active", "nmbd": "active"}
+            ),
+        )
+
+        self.assertEqual(
+            manager.get_service_status(),
+            {"smbd": "active", "nmbd": "active", "wsdd2": "unavailable"},
+        )
+
+    def test_restart_services_attempts_all_three_units(self):
+        self.runtime.is_fake = False
+        adapter = FakeSmbCommandAdapter()
+        manager = smb_manager.SMBManager(runtime=self.runtime, command_adapter=adapter)
+
+        self.assertTrue(manager.restart_services())
+        self.assertEqual(adapter.restarted_units, ["smbd", "nmbd", "wsdd2"])
+
+    def test_restart_services_fails_when_smbd_restart_fails(self):
+        self.runtime.is_fake = False
+        adapter = FakeSmbCommandAdapter(restart_failures={"smbd"})
+        manager = smb_manager.SMBManager(runtime=self.runtime, command_adapter=adapter)
+
+        self.assertFalse(manager.restart_services())
+        self.assertEqual(adapter.restarted_units, ["smbd"])
+
+    def test_restart_services_allows_discovery_restart_failures(self):
+        self.runtime.is_fake = False
+        adapter = FakeSmbCommandAdapter(restart_failures={"nmbd", "wsdd2"})
+        manager = smb_manager.SMBManager(runtime=self.runtime, command_adapter=adapter)
+
+        self.assertTrue(manager.restart_services())
+        self.assertEqual(adapter.restarted_units, ["smbd", "nmbd", "wsdd2"])
+
+    def test_parse_smb_conf_does_not_treat_marker_comments_as_share_boundaries(self):
+        """_parse_smb_conf should parse through old marker-like comments without
+        treating them as share block terminators. The method is used to parse
+        testparm output which never contains markers, but this confirms the
+        legacy break logic is gone."""
+        content = "\n".join(
+            [
+                "[media]",
+                "   path = /srv/media",
+                "# BEGIN SimpleSaferServer share: media",
+                "   writeable = Yes",
+                "",
+                "[photos]",
+                "   path = /srv/photos",
+                "",
+            ]
+        )
+
+        _, shares = self.manager._parse_smb_conf(content)
+
+        self.assertEqual(len(shares), 2)
+        self.assertEqual(shares[0].name, "media")
+        self.assertTrue(shares[0].writable)
+        self.assertEqual(shares[1].name, "photos")
+
+    def test_dead_inline_managed_share_methods_are_removed(self):
+        """The old marker-based managed-share machinery should not exist on
+        SMBManager. These were replaced by the file-path ownership model."""
+        self.assertFalse(hasattr(self.manager, '_create_backup'))
+        self.assertFalse(hasattr(self.manager, '_write_smb_conf'))
+        self.assertFalse(hasattr(self.manager, '_validate_smb_conf_candidate'))
+        self.assertFalse(hasattr(self.manager, '_restore_smb_conf_backup'))
+        self.assertFalse(hasattr(self.manager, '_commit_smb_conf'))
+        self.assertFalse(hasattr(self.manager, 'backup_dir'))
+
+    def test_dead_marker_constants_are_removed(self):
+        """The old marker constants should not exist in the module."""
+        self.assertFalse(hasattr(smb_manager, 'MANAGED_SHARE_BEGIN_PREFIX'))
+        self.assertFalse(hasattr(smb_manager, 'MANAGED_SHARE_END_PREFIX'))
+
+    def test_get_share_users_raises_not_found_when_share_missing_everywhere(self):
+        """A share that exists neither in the owned file nor in unmanaged config
+        should produce a generic 'not found' error."""
+        self._write_shares("")
+        self._write_conf("[global]\n   workgroup = WORKGROUP\n")
+
+        with self.assertRaisesRegex(ValueError, "not found"):
+            self.manager.get_share_users("nonexistent")
+
+    def test_get_share_users_raises_not_found_when_inspection_also_fails(self):
+        """When the share is not in the owned file and effective config inspection
+        also fails, fall back to a generic 'not found' error."""
+        self._write_shares("")
+
+        with patch.object(
+            self.manager,
+            "_inspect_unmanaged_effective_shares",
+            side_effect=smb_manager.SMBConfigError("broken include"),
+        ):
+            with self.assertRaisesRegex(ValueError, "not found"):
+                self.manager.get_share_users("nonexistent")
 
 
 if __name__ == "__main__":

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -314,7 +314,7 @@ class UninstallScriptTests(unittest.TestCase):
         self.assertNotIn("UUID=drop /media/backup", content)
         self.assertNotIn("UUID=legacy /media/legacy", content)
 
-    def test_cleanup_managed_smb_shares_leaves_unmanaged_blocks(self):
+    def test_cleanup_managed_smb_shares_leaves_unmanaged_and_legacy_inline_blocks(self):
         with tempfile.TemporaryDirectory() as tempdir:
             smb_conf_path = Path(tempdir) / "smb.conf"
             smb_conf_path.write_text(
@@ -347,20 +347,148 @@ class UninstallScriptTests(unittest.TestCase):
 
             content = smb_conf_path.read_text()
 
-        self.assertNotIn("[backup]", content)
+        self.assertIn("# BEGIN SimpleSaferServer share: backup", content)
+        self.assertIn("[backup]", content)
+        self.assertIn("# END SimpleSaferServer share: backup", content)
         self.assertIn("[media]", content)
         self.assertIn("guest ok = yes", content)
 
-    def test_cleanup_managed_smb_shares_allows_empty_result_when_only_managed_blocks_exist(self):
+    def test_cleanup_managed_smb_shares_removes_sss_include_blocks_and_owned_files(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            samba_dir = Path(tempdir)
+            smb_conf_path = samba_dir / "smb.conf"
+            globals_path = samba_dir / "simple_safer_server_globals.conf"
+            shares_path = samba_dir / "simple_safer_server_shares.conf"
+            globals_path.write_text("map to guest = never\n")
+            shares_path.write_text("# managed shares\n")
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    f"""\
+                    [global]
+                       workgroup = WORKGROUP
+                    # BEGIN SimpleSaferServer global include
+                       include = {globals_path}
+                    # END SimpleSaferServer global include
+
+                    [media]
+                       path = /srv/media
+
+                    # BEGIN SimpleSaferServer shares include
+                    include = {shares_path}
+                    # END SimpleSaferServer shares include
+                    """
+                )
+            )
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    SMB_CONF="{smb_conf_path}"
+                    SSS_SAMBA_GLOBALS_FILE="{globals_path}"
+                    SSS_SAMBA_SHARES_FILE="{shares_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            content = smb_conf_path.read_text()
+            globals_exists = globals_path.exists()
+            shares_exists = shares_path.exists()
+
+        self.assertIn("[global]", content)
+        self.assertIn("[media]", content)
+        self.assertNotIn("SimpleSaferServer global include", content)
+        self.assertNotIn("SimpleSaferServer shares include", content)
+        self.assertFalse(globals_exists)
+        self.assertFalse(shares_exists)
+
+    def test_cleanup_managed_smb_shares_deletes_owned_files_when_main_config_missing(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            samba_dir = Path(tempdir)
+            smb_conf_path = samba_dir / "smb.conf"
+            globals_path = samba_dir / "simple_safer_server_globals.conf"
+            shares_path = samba_dir / "simple_safer_server_shares.conf"
+            globals_path.write_text("map to guest = never\n")
+            shares_path.write_text("# managed shares\n")
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    SMB_CONF="{smb_conf_path}"
+                    SSS_SAMBA_GLOBALS_FILE="{globals_path}"
+                    SSS_SAMBA_SHARES_FILE="{shares_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            self.assertFalse(globals_path.exists())
+            self.assertFalse(shares_path.exists())
+
+    def test_cleanup_managed_smb_shares_does_not_restart_discovery_services(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            samba_dir = root / "samba"
+            fake_bin = root / "bin"
+            calls_path = root / "systemctl-calls"
+            samba_dir.mkdir()
+            fake_bin.mkdir()
+            smb_conf_path = samba_dir / "smb.conf"
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    """\
+                    [global]
+                       workgroup = WORKGROUP
+                    # BEGIN SimpleSaferServer shares include
+                    include = /etc/samba/simple_safer_server_shares.conf
+                    # END SimpleSaferServer shares include
+                    """
+                )
+            )
+            systemctl = fake_bin / "systemctl"
+            systemctl.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    printf '%s\\n' "$*" >> "{calls_path}"
+                    exit 0
+                    """
+                )
+            )
+            systemctl.chmod(0o755)
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    export PATH="{fake_bin}:$PATH"
+                    SMB_CONF="{smb_conf_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            calls = calls_path.read_text()
+
+        self.assertIn("restart smbd", calls)
+        self.assertNotIn("restart nmbd", calls)
+        self.assertNotIn("restart wsdd2", calls)
+
+    def test_cleanup_managed_smb_shares_allows_empty_result_when_only_include_blocks_exist(self):
         with tempfile.TemporaryDirectory() as tempdir:
             smb_conf_path = Path(tempdir) / "smb.conf"
             smb_conf_path.write_text(
                 textwrap.dedent(
                     """\
-                    # BEGIN SimpleSaferServer share: backup
-                    [backup]
-                       path = /media/backup
-                    # END SimpleSaferServer share: backup
+                    # BEGIN SimpleSaferServer global include
+                       include = /etc/samba/simple_safer_server_globals.conf
+                    # END SimpleSaferServer global include
+
+                    # BEGIN SimpleSaferServer shares include
+                    include = /etc/samba/simple_safer_server_shares.conf
+                    # END SimpleSaferServer shares include
                     """
                 )
             )
@@ -377,20 +505,27 @@ class UninstallScriptTests(unittest.TestCase):
 
             content = smb_conf_path.read_text()
 
-        self.assertEqual(content, "")
+        self.assertNotIn("SimpleSaferServer global include", content)
+        self.assertNotIn("SimpleSaferServer shares include", content)
 
-    def test_cleanup_managed_smb_shares_rejects_malformed_markers(self):
+    def test_cleanup_managed_smb_shares_rejects_malformed_include_markers(self):
         with tempfile.TemporaryDirectory() as tempdir:
-            smb_conf_path = Path(tempdir) / "smb.conf"
+            samba_dir = Path(tempdir)
+            smb_conf_path = samba_dir / "smb.conf"
+            globals_path = samba_dir / "simple_safer_server_globals.conf"
+            shares_path = samba_dir / "simple_safer_server_shares.conf"
+            globals_path.write_text("map to guest = never\n")
+            shares_path.write_text("# managed shares\n")
             original = textwrap.dedent(
                 """\
                 [global]
                    workgroup = WORKGROUP
 
-                  # BEGIN SimpleSaferServer share: backup
-                [backup]
-                   path = /media/backup
-                  # END SimpleSaferServer share: media
+                  # BEGIN SimpleSaferServer global include
+                   include = /etc/samba/simple_safer_server_globals.conf
+
+                [media]
+                   path = /srv/media
                 """
             )
             smb_conf_path.write_text(original)
@@ -400,16 +535,241 @@ class UninstallScriptTests(unittest.TestCase):
                     f"""\
                     source "{UNINSTALL_SCRIPT}"
                     SMB_CONF="{smb_conf_path}"
+                    SSS_SAMBA_GLOBALS_FILE="{globals_path}"
+                    SSS_SAMBA_SHARES_FILE="{shares_path}"
                     cleanup_managed_smb_shares
                     """
                 )
             )
 
             content = smb_conf_path.read_text()
+            globals_exists = globals_path.exists()
+            shares_exists = shares_path.exists()
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("markers are malformed", result.stdout)
         self.assertEqual(content, original)
+        self.assertFalse(globals_exists)
+        self.assertFalse(shares_exists)
+
+    def test_cleanup_managed_smb_shares_restarts_smbd_after_successful_cleanup(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            samba_dir = root / "samba"
+            fake_bin = root / "bin"
+            calls_path = root / "systemctl-calls"
+            samba_dir.mkdir()
+            fake_bin.mkdir()
+            smb_conf_path = samba_dir / "smb.conf"
+            globals_path = samba_dir / "simple_safer_server_globals.conf"
+            shares_path = samba_dir / "simple_safer_server_shares.conf"
+            globals_path.write_text("map to guest = never\n")
+            shares_path.write_text("# managed shares\n")
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    """\
+                    [global]
+                       workgroup = WORKGROUP
+                    # BEGIN SimpleSaferServer global include
+                       include = /etc/samba/simple_safer_server_globals.conf
+                    # END SimpleSaferServer global include
+
+                    # BEGIN SimpleSaferServer shares include
+                    include = /etc/samba/simple_safer_server_shares.conf
+                    # END SimpleSaferServer shares include
+                    """
+                )
+            )
+            systemctl = fake_bin / "systemctl"
+            systemctl.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    printf '%s\\n' "$*" >> "{calls_path}"
+                    exit 0
+                    """
+                )
+            )
+            systemctl.chmod(0o755)
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    export PATH="{fake_bin}:$PATH"
+                    SMB_CONF="{smb_conf_path}"
+                    SSS_SAMBA_GLOBALS_FILE="{globals_path}"
+                    SSS_SAMBA_SHARES_FILE="{shares_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            calls = calls_path.read_text()
+
+        self.assertIn("restart smbd", calls)
+        self.assertNotIn("restart nmbd", calls)
+        self.assertNotIn("restart wsdd2", calls)
+
+    def test_cleanup_managed_smb_shares_warns_on_smbd_restart_failure(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            samba_dir = root / "samba"
+            fake_bin = root / "bin"
+            samba_dir.mkdir()
+            fake_bin.mkdir()
+            smb_conf_path = samba_dir / "smb.conf"
+            globals_path = samba_dir / "simple_safer_server_globals.conf"
+            shares_path = samba_dir / "simple_safer_server_shares.conf"
+            globals_path.write_text("map to guest = never\n")
+            shares_path.write_text("# managed shares\n")
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    """\
+                    [global]
+                       workgroup = WORKGROUP
+                    # BEGIN SimpleSaferServer shares include
+                    include = /etc/samba/simple_safer_server_shares.conf
+                    # END SimpleSaferServer shares include
+                    """
+                )
+            )
+            systemctl = fake_bin / "systemctl"
+            systemctl.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    exit 1
+                    """
+                )
+            )
+            systemctl.chmod(0o755)
+
+            # Should NOT fail even though smbd restart fails
+            result = self.run_bash_raw(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    export PATH="{fake_bin}:$PATH"
+                    SMB_CONF="{smb_conf_path}"
+                    SSS_SAMBA_GLOBALS_FILE="{globals_path}"
+                    SSS_SAMBA_SHARES_FILE="{shares_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("WARNING", result.stdout)
+        self.assertIn("smbd", result.stdout)
+
+    def test_cleanup_managed_smb_shares_malformed_markers_warns_about_broken_includes(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            samba_dir = Path(tempdir)
+            smb_conf_path = samba_dir / "smb.conf"
+            globals_path = samba_dir / "simple_safer_server_globals.conf"
+            shares_path = samba_dir / "simple_safer_server_shares.conf"
+            globals_path.write_text("map to guest = never\n")
+            shares_path.write_text("# managed shares\n")
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    """\
+                    [global]
+                       workgroup = WORKGROUP
+
+                      # BEGIN SimpleSaferServer global include
+                       include = /etc/samba/simple_safer_server_globals.conf
+
+                    [media]
+                       path = /srv/media
+                    """
+                )
+            )
+
+            result = self.run_bash_raw(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    SMB_CONF="{smb_conf_path}"
+                    SSS_SAMBA_GLOBALS_FILE="{globals_path}"
+                    SSS_SAMBA_SHARES_FILE="{shares_path}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("simple_safer_server_globals.conf", result.stdout)
+        self.assertIn("simple_safer_server_shares.conf", result.stdout)
+        self.assertIn("systemctl restart smbd", result.stdout)
+
+    def test_cleanup_managed_smb_shares_removes_empty_legacy_backup_directory(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            samba_dir = root / "samba"
+            samba_dir.mkdir()
+            backup_dir = samba_dir / "backups"
+            backup_dir.mkdir()
+            smb_conf_path = samba_dir / "smb.conf"
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    """\
+                    [global]
+                       workgroup = WORKGROUP
+                    # BEGIN SimpleSaferServer shares include
+                    include = /etc/samba/simple_safer_server_shares.conf
+                    # END SimpleSaferServer shares include
+                    """
+                )
+            )
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    SMB_CONF="{smb_conf_path}"
+                    SSS_SAMBA_BACKUP_DIR="{backup_dir}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            self.assertFalse(backup_dir.exists())
+
+    def test_cleanup_managed_smb_shares_leaves_nonempty_legacy_backup_directory(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            samba_dir = root / "samba"
+            samba_dir.mkdir()
+            backup_dir = samba_dir / "backups"
+            backup_dir.mkdir()
+            (backup_dir / "smb.conf.backup.20250101_120000").write_text("[global]\n")
+            smb_conf_path = samba_dir / "smb.conf"
+            smb_conf_path.write_text(
+                textwrap.dedent(
+                    """\
+                    [global]
+                       workgroup = WORKGROUP
+                    # BEGIN SimpleSaferServer shares include
+                    include = /etc/samba/simple_safer_server_shares.conf
+                    # END SimpleSaferServer shares include
+                    """
+                )
+            )
+
+            self.run_bash(
+                textwrap.dedent(
+                    f"""\
+                    source "{UNINSTALL_SCRIPT}"
+                    SMB_CONF="{smb_conf_path}"
+                    SSS_SAMBA_BACKUP_DIR="{backup_dir}"
+                    cleanup_managed_smb_shares
+                    """
+                )
+            )
+
+            self.assertTrue(backup_dir.exists())
+            self.assertTrue((backup_dir / "smb.conf.backup.20250101_120000").exists())
 
     def test_remove_git_safe_directory_removes_only_matching_entries(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -841,6 +841,7 @@ class UninstallScriptTests(unittest.TestCase):
             input=script_content,
             capture_output=True,
             text=True,
+            env={"SSS_FORCE_NON_ROOT_CHECK": "true"},
         )
         self.assertEqual(result.returncode, 1)
         self.assertIn("Please run as root", result.stderr or result.stdout)

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -830,6 +830,22 @@ class UninstallScriptTests(unittest.TestCase):
 
         self.assertEqual(remaining.stdout.strip().splitlines(), ["/srv/other"])
 
+    def test_uninstall_piped_to_bash_does_not_raise_unbound_variable(self):
+        # Piping the script to bash (simulating curl ... | bash) should not crash
+        # with 'BASH_SOURCE[0]: unbound variable' error under 'set -u'.
+        # Since it is run as non-root in tests, it should fail at the root check
+        # in main(), returning exit code 1 and the expected error message.
+        script_content = UNINSTALL_SCRIPT.read_text(encoding="utf-8")
+        result = subprocess.run(
+            ["bash"],
+            input=script_content,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Please run as root", result.stderr or result.stdout)
+        self.assertNotIn("unbound variable", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -18,11 +18,16 @@ VOLATILE_DIR="/run/SimpleSaferServer"
 LOG_DIR="/var/log/SimpleSaferServer"
 SYSTEMD_DIR="/etc/systemd/system"
 SMB_CONF="/etc/samba/smb.conf"
+SSS_SAMBA_GLOBALS_FILE="/etc/samba/simple_safer_server_globals.conf"
+SSS_SAMBA_SHARES_FILE="/etc/samba/simple_safer_server_shares.conf"
+SSS_SAMBA_BACKUP_DIR="/etc/samba/backups"
 APT_AUTO_UPGRADES_CONF="/etc/apt/apt.conf.d/20auto-upgrades"
 FSTAB_MARKER="SimpleSaferServer managed backup drive"
 LEGACY_FSTAB_MARKER="SimpleSaferServer"
-MANAGED_SHARE_BEGIN_PREFIX="# BEGIN SimpleSaferServer share: "
-MANAGED_SHARE_END_PREFIX="# END SimpleSaferServer share: "
+SSS_GLOBALS_INCLUDE_BEGIN="# BEGIN SimpleSaferServer global include"
+SSS_GLOBALS_INCLUDE_END="# END SimpleSaferServer global include"
+SSS_SHARES_INCLUDE_BEGIN="# BEGIN SimpleSaferServer shares include"
+SSS_SHARES_INCLUDE_END="# END SimpleSaferServer shares include"
 SCRIPT_FILES=(
   check_mount.sh
   check_health.sh
@@ -246,60 +251,85 @@ PY
     fi
 }
 
+remove_owned_samba_include_files() {
+    # These files are app-owned by path, so they are safe to remove even when
+    # smb.conf is absent or too malformed for an automated rewrite.
+    rm -f "$SSS_SAMBA_GLOBALS_FILE" "$SSS_SAMBA_SHARES_FILE"
+    # Legacy installs created a backup directory for smb.conf snapshots.
+    # Remove it only if empty; preserve old backups the admin might want.
+    rmdir "$SSS_SAMBA_BACKUP_DIR" 2>/dev/null || true
+}
+
 cleanup_managed_smb_shares() {
     local cleaned=""
 
+    echo "Removing SimpleSaferServer-owned Samba include files..."
+
     if [ ! -f "$SMB_CONF" ]; then
+        remove_owned_samba_include_files
         return 0
     fi
 
     cleaned="$(make_atomic_temp_file "$SMB_CONF")"
 
-    echo "Removing SimpleSaferServer-managed Samba shares..."
     backup_file_if_present "$SMB_CONF" "uninstall_backup"
-    require_python3 "remove managed Samba shares" || return 1
+    require_python3 "remove SimpleSaferServer Samba include blocks" || return 1
 
-    if ! python3 - "$SMB_CONF" "$cleaned" "$MANAGED_SHARE_BEGIN_PREFIX" "$MANAGED_SHARE_END_PREFIX" <<'PY'
+    if ! python3 - "$SMB_CONF" "$cleaned" "$SSS_GLOBALS_INCLUDE_BEGIN" "$SSS_GLOBALS_INCLUDE_END" "$SSS_SHARES_INCLUDE_BEGIN" "$SSS_SHARES_INCLUDE_END" <<'PY'
 import sys
 
-source, cleaned, begin_prefix, end_prefix = sys.argv[1:]
+(
+    source,
+    cleaned,
+    globals_begin,
+    globals_end,
+    shares_begin,
+    shares_end,
+) = sys.argv[1:]
 with open(source, "r", encoding="utf-8") as handle:
     lines = handle.readlines()
 
+plain_blocks = {
+    globals_begin: globals_end,
+    shares_begin: shares_end,
+}
+
 output = []
-in_managed_share = False
-current_share_name = ""
+index = 0
 
-for line in lines:
-    stripped = line.lstrip()
-    if stripped.startswith(begin_prefix):
-        share_name = stripped[len(begin_prefix):].strip()
-        if in_managed_share or not share_name:
+while index < len(lines):
+    stripped = lines[index].strip()
+
+    if stripped in plain_blocks.values():
+        raise SystemExit(1)
+
+    if stripped in plain_blocks:
+        end_marker = plain_blocks[stripped]
+        index += 1
+        while index < len(lines):
+            inner_stripped = lines[index].strip()
+            if inner_stripped == stripped:
+                raise SystemExit(1)
+            if inner_stripped == end_marker:
+                index += 1
+                break
+            index += 1
+        else:
             raise SystemExit(1)
-        in_managed_share = True
-        current_share_name = share_name
         continue
 
-    if stripped.startswith(end_prefix):
-        share_name = stripped[len(end_prefix):].strip()
-        if not in_managed_share or not share_name or share_name != current_share_name:
-            raise SystemExit(1)
-        in_managed_share = False
-        current_share_name = ""
-        continue
-
-    if not in_managed_share:
-        output.append(line)
-
-if in_managed_share:
-    raise SystemExit(1)
+    output.append(lines[index])
+    index += 1
 
 with open(cleaned, "w", encoding="utf-8") as handle:
     handle.writelines(output)
 PY
     then
         rm -f "$cleaned"
-        echo "ERROR: Refusing to rewrite $SMB_CONF because the SimpleSaferServer share markers are malformed."
+        remove_owned_samba_include_files
+        echo "ERROR: Refusing to rewrite $SMB_CONF because the SimpleSaferServer include markers are malformed."
+        echo "WARNING: The owned include files were deleted, but $SMB_CONF may still contain include lines referencing them."
+        echo "To fix Samba manually, remove lines referencing simple_safer_server_globals.conf and simple_safer_server_shares.conf from $SMB_CONF, then run: systemctl restart smbd"
         return 1
     fi
 
@@ -322,8 +352,13 @@ PY
         return 1
     fi
 
-    systemctl restart smbd 2>/dev/null || true
-    systemctl restart nmbd 2>/dev/null || true
+    remove_owned_samba_include_files
+
+    # Restart smbd so the running service matches the rewritten smb.conf.
+    # Best-effort: warn and continue if it fails.
+    if ! systemctl restart smbd 2>/dev/null; then
+        echo "WARNING: Could not restart smbd. The running Samba service may still reference removed configuration until the next reboot or manual restart."
+    fi
 }
 
 remove_git_safe_directory() {
@@ -350,6 +385,7 @@ main() {
     fi
 
     echo "Starting SimpleSaferServer uninstallation..."
+    echo -e "${YELLOW}Active Samba file transfers will be interrupted.${NC}"
 
     # Read this before CONFIG_DIR is removed so the final report can tell the
     # admin about OS-level apt settings that intentionally survive uninstall.
@@ -437,10 +473,10 @@ main() {
 
     echo -e "${GREEN}Uninstallation complete!${NC}"
     echo "SimpleSaferServer application files, services, timers, data, and managed mount entries have been removed."
-    echo "Shared system packages such as Samba, Python, and rclone were left installed."
+    echo "Shared system packages and services such as Samba, wsdd2, Python, and rclone were left installed."
     echo "Samba user accounts created from SimpleSaferServer users were removed."
-    echo "Marker-wrapped SimpleSaferServer-managed Samba share blocks were removed from $SMB_CONF."
-    echo "Unmanaged or legacy untagged Samba share blocks were left untouched."
+    echo "SimpleSaferServer-owned Samba include files and include blocks were removed."
+    echo "Unmanaged Samba share blocks in $SMB_CONF were left untouched."
     if [ "$apt_updates_managed" = "true" ]; then
         echo "SimpleSaferServer had managed apt periodic settings in $APT_AUTO_UPGRADES_CONF."
         echo "That file was left in place. Review it manually if you want to disable automatic apt updates."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -379,7 +379,7 @@ main() {
     echo -e "${BLUE}   SimpleSaferServer Uninstaller${NC}"
     echo -e "${BLUE}===============================================${NC}\n"
 
-    if [ "$EUID" -ne 0 ]; then
+    if [ "${SSS_FORCE_NON_ROOT_CHECK:-}" = "true" ] || [ "$EUID" -ne 0 ]; then
         echo -e "${RED}ERROR:${NC} Please run as root (sudo)"
         exit 1
     fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -510,6 +510,10 @@ main() {
     fi
 }
 
-if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+# Execute main if the script is run directly or piped into bash (e.g. via curl).
+# We use "${BASH_SOURCE[0]:-}" to avoid "unbound variable" errors under "set -u"
+# when BASH_SOURCE is empty (which happens when reading from standard input).
+if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]:-}" = "$0" ]; then
     main "$@"
 fi
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer optionally adds Windows discovery support and now reports per-service SMB discovery status (smbd/nmbd/wsdd2) with clearer success/warning behavior.

* **Documentation**
  * Expanded and clarified install/manual/uninstall/drive-health/network-file-sharing/docs and landing notes: managed-share location, recovery/checklist steps, installer/uninstaller behavior, and setup wizard guidance.

* **Bug Fixes / UI**
  * Dashboard and Network File Sharing adopt three-tier service status and refined discovery badges; unmanaged-share verification exposes a distinct “verification failed” state and clearer operation errors.

* **Tests**
  * Added/updated tests covering installer, UI, SMB share verification, layout/uninstall, and service-status scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrismin13/SimpleSaferServer/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->