### PR TITLE
Add ntfs driver switcher

### DIFF
--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -109,6 +109,8 @@ This flow is partition-oriented.
 - The selector uses the same NTFS-partition scan as setup wizard step 3.
 - If `lsblk` reports a mounted `ntfs-3g` partition as `fuseblk`, the app double-checks the on-disk type with `blkid` before showing it.
 - Partitions reported as `ntfs3`, `ntfs-3g`, or confirmed-NTFS `fuseblk` are treated as NTFS backup targets by the picker.
+- The NTFS driver selector controls the driver written to the managed `/etc/fstab` line and used by later manual mounts. `ntfs-3g` remains the compatibility default; `ntfs3` is available for newer kernels.
+- A driver-only save is intentionally non-disruptive. The current live mount keeps its existing driver until the drive is unmounted and mounted again.
 - The unmount action unmounts only the exact selected partition.
 - That unmount action only clears the live mount so the selected partition can be validated and configured again.
 - If the selected partition is still the configured backup drive and it is currently mounted at the managed backup mount point, the app first disconnects SMB access and stops the related background tasks so the unmount is not blocked by busy share handles.
@@ -189,7 +191,7 @@ Important file locations:
 Example managed `/etc/fstab` entry:
 
 ```fstab
-UUID=2CD49023D48FED80    /media/backup    ntfs-3g    defaults,nofail    0    0 # SimpleSaferServer managed backup drive
+UUID=2CD49023D48FED80    /media/backup    ntfs3    defaults,nofail    0    0 # SimpleSaferServer managed backup drive
 ```
 
 After manual changes, verify the result:

--- a/docs/manual_install.md
+++ b/docs/manual_install.md
@@ -8,6 +8,7 @@ This guide explains how to manually install SimpleSaferServer on a clean Debian 
 
 - Run `sudo apt-get update`.
 - Run `sudo apt-get install -y git python3 python3-pip python3-venv smartmontools samba msmtp rsync curl unzip fdisk ntfs-3g unattended-upgrades`.
+- `ntfs-3g` is still installed because it is the default backup-drive driver. The `ntfs3` driver is kernel-provided on newer systems and can be selected later from the Drive Health backup-drive setup panel when the running kernel supports it.
 - Optionally run `sudo apt-get install -y wsdd2` for modern Windows Network discovery. Continue
   without it if your distro release does not provide the package; `smbd` is the required
   file-serving daemon, while `nmbd` and `wsdd2` are discovery helpers.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -58,6 +58,7 @@ This step is partition-oriented.
 - The wizard intentionally does not offer that broader retry based on UUID alone, because cloned replacement disks can legitimately share a filesystem UUID and would make the safety check ambiguous.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
 - Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.
+- The app stores the NTFS mount driver as `backup.ntfs_driver`. `ntfs-3g` is the default because it works across older Debian installs; `ntfs3` can be selected later on systems with kernel support.
 
 Persistent backup-drive state changes only when the mount/configure step succeeds:
 
@@ -74,6 +75,7 @@ agree about which partitions are selectable, especially for already-mounted
 Boot behavior:
 
 - The managed `/etc/fstab` entry uses `defaults,nofail`.
+- The managed `/etc/fstab` filesystem type is the configured NTFS driver, either `ntfs-3g` or `ntfs3`.
 - That means the system should still boot if the backup drive is disconnected.
 
 ## Step 4: Backup Configuration
@@ -122,6 +124,8 @@ If the backup drive changes after setup:
 - use the advanced backup-drive section on the Drive Health page
 - select the correct NTFS partition there
 - rerun only the backup-drive configuration portion
+- change the NTFS driver there when you want future mounts to use `ntfs-3g` or `ntfs3`
 
 That rerun flow is intentionally partition-oriented and does not behave like the whole-disk format step.
 If the selected partition is still the live configured backup share, the rerun flow can temporarily disconnect SMB access before unmounting it.
+Driver-only changes update the app config and the managed `/etc/fstab` entry, then take effect after the backup drive is unmounted and mounted again.

--- a/simple_safer_server/adapters/backup_drive_commands.py
+++ b/simple_safer_server/adapters/backup_drive_commands.py
@@ -56,11 +56,18 @@ class BackupDriveCommandAdapter:
             timeout=BACKUP_DRIVE_MOUNT_TIMEOUT_SECONDS,
         )
 
-    def mount_ntfs(self, partition: str, mount_point: str):
+    def mount_ntfs(self, partition: str, mount_point: str, ntfs_driver: str = "ntfs-3g"):
         uid = os.getuid()
         gid = os.getgid()
+        options = f"rw,uid={uid},gid={gid}"
+        if ntfs_driver == "ntfs-3g":
+            command = ["ntfs-3g", partition, mount_point, "-o", options]
+        else:
+            # ntfs3 is a kernel filesystem type, so it goes through mount(8)
+            # instead of the ntfs-3g helper binary.
+            command = ["mount", "-t", ntfs_driver, "-o", options, partition, mount_point]
         return self._command_runner.run(
-            ["ntfs-3g", partition, mount_point, "-o", f"rw,uid={uid},gid={gid}"],
+            command,
             capture_output=True,
             text=True,
             timeout=BACKUP_DRIVE_MOUNT_TIMEOUT_SECONDS,

--- a/simple_safer_server/adapters/storage_commands.py
+++ b/simple_safer_server/adapters/storage_commands.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 from simple_safer_server.adapters.command_runner import CommandRunner
@@ -29,9 +30,19 @@ class StorageCommandAdapter:
         )
         return result.stdout.strip()
 
-    def mount(self, device: str, mount_point: str) -> None:
+    def mount(self, device: str, mount_point: str, ntfs_driver: str = "ntfs-3g") -> None:
+        uid = os.getuid()
+        gid = os.getgid()
         self._command_runner.run(
-            ["mount", device, mount_point],
+            [
+                "mount",
+                "-t",
+                ntfs_driver,
+                "-o",
+                f"rw,uid={uid},gid={gid}",
+                device,
+                mount_point,
+            ],
             check=True,
             timeout=STORAGE_MOUNT_TIMEOUT_SECONDS,
         )

--- a/simple_safer_server/routes/drive_health.py
+++ b/simple_safer_server/routes/drive_health.py
@@ -4,6 +4,10 @@ from typing import Any
 
 from flask import Blueprint, abort, current_app, render_template, request, send_file
 
+from simple_safer_server.services.backup_drive_setup import (
+    get_configured_ntfs_mount_driver,
+    list_ntfs_mount_driver_options,
+)
 from simple_safer_server.services.drive_health import (
     SMART_FIELDS,
     SMARTCTL_JSON_UPGRADE_MESSAGE,
@@ -57,6 +61,7 @@ def drives():
         ),
         "uuid": services.config_manager.get_value("backup", "uuid", ""),
         "usb_id": services.config_manager.get_value("backup", "usb_id", ""),
+        "ntfs_driver": get_configured_ntfs_mount_driver(services.config_manager),
     }
 
     smart_support_warning = None
@@ -152,6 +157,7 @@ def drives():
         hdsentinel_settings=hdsentinel_settings,
         hdsentinel_snapshot=hdsentinel_snapshot,
         drive_config=drive_config,
+        ntfs_driver_options=list_ntfs_mount_driver_options(),
         smart_support_warning=smart_support_warning,
         prediction_warning=prediction_warning,
         settings_message=settings_message,

--- a/simple_safer_server/routes/storage.py
+++ b/simple_safer_server/routes/storage.py
@@ -1,12 +1,15 @@
 from typing import Any
 
 import psutil
-from flask import Blueprint, current_app
+from flask import Blueprint, current_app, request
 
 from simple_safer_server.services.backup_drive_setup import (
     BackupDriveSetupError,
     apply_backup_drive_configuration,
+    get_configured_ntfs_mount_driver,
+    list_ntfs_mount_driver_options,
     list_available_drives,
+    update_backup_drive_ntfs_driver,
     unmount_selected_partition,
 )
 from simple_safer_server.services.backup_drive_unmount import (
@@ -270,6 +273,7 @@ def api_backup_drive_configure():
             config_manager=services.config_manager,
             smb_manager=services.smb_manager,
             runtime=services.runtime,
+            ntfs_driver=data.get("ntfs_driver"),
         )
         return json_data({"result": result})
     except BackupDriveSetupError as exc:
@@ -283,3 +287,35 @@ def api_backup_drive_configure():
     except Exception as exc:
         current_app.logger.error("Error configuring backup drive: %s", exc)
         return json_problem(OperationProblem("Could not configure the backup drive."))
+
+
+@storage.route("/api/backup_drive/ntfs-driver", methods=["GET", "POST"])
+@api_admin_required
+def api_backup_drive_ntfs_driver():
+    services = _get_services()
+    try:
+        if request.method == "POST":
+            data = json_request_data()
+            result = update_backup_drive_ntfs_driver(
+                data.get("ntfs_driver"),
+                services.config_manager,
+                runtime=services.runtime,
+            )
+            return json_data({"result": result}, message=result["message"])
+        return json_data(
+            {
+                "ntfs_driver": get_configured_ntfs_mount_driver(services.config_manager),
+                "options": list_ntfs_mount_driver_options(),
+            }
+        )
+    except BackupDriveSetupError as exc:
+        return json_problem(
+            ValidationProblem(
+                str(exc),
+                slug="backup-drive-validation-error",
+                extra={"details": exc.details},
+            )
+        )
+    except Exception as exc:
+        current_app.logger.error("Error updating backup drive NTFS driver: %s", exc)
+        return json_problem(OperationProblem("Could not update the NTFS driver."))

--- a/simple_safer_server/services/backup_drive_setup.py
+++ b/simple_safer_server/services/backup_drive_setup.py
@@ -16,6 +16,22 @@ LOGGER = logging.getLogger(__name__)
 FSTAB_MARKER = "# SimpleSaferServer managed backup drive"
 LEGACY_FSTAB_MARKER = "SimpleSaferServer"
 NTFS_FILESYSTEM_TYPES = {'ntfs', 'ntfs3', 'ntfs-3g'}
+DEFAULT_NTFS_MOUNT_DRIVER = 'ntfs-3g'
+NTFS_MOUNT_DRIVER_OPTIONS = (
+    {
+        'value': 'ntfs-3g',
+        'label': 'ntfs-3g',
+        'description': 'FUSE driver with broad Debian compatibility.',
+    },
+    {
+        'value': 'ntfs3',
+        'label': 'ntfs3',
+        'description': 'In-kernel driver available on newer Linux kernels.',
+    },
+)
+VALID_NTFS_MOUNT_DRIVERS = {
+    option['value'] for option in NTFS_MOUNT_DRIVER_OPTIONS
+}
 
 
 @dataclass(frozen=True)
@@ -110,6 +126,27 @@ def _backup_file(path, runtime, prefix):
 
 def _is_ntfs_filesystem(filesystem_type):
     return (filesystem_type or '').strip().lower() in NTFS_FILESYSTEM_TYPES
+
+
+def list_ntfs_mount_driver_options():
+    return [dict(option) for option in NTFS_MOUNT_DRIVER_OPTIONS]
+
+
+def normalize_ntfs_mount_driver(ntfs_driver):
+    driver = (ntfs_driver or DEFAULT_NTFS_MOUNT_DRIVER).strip().lower()
+    if driver not in VALID_NTFS_MOUNT_DRIVERS:
+        raise BackupDriveSetupError(
+            'NTFS driver must be one of: {}'.format(
+                ', '.join(sorted(VALID_NTFS_MOUNT_DRIVERS))
+            )
+        )
+    return driver
+
+
+def get_configured_ntfs_mount_driver(config_manager):
+    return normalize_ntfs_mount_driver(
+        config_manager.get_value('backup', 'ntfs_driver', DEFAULT_NTFS_MOUNT_DRIVER)
+    )
 
 
 def _get_blkid_filesystem_type(device_path, command_adapter=None):
@@ -328,7 +365,7 @@ def _validate_fstab_file(path):
                 )
             if not spec.startswith('UUID='):
                 issues.append(f'line {line_number} has an invalid managed UUID spec: {spec}')
-            if fstype != 'ntfs-3g':
+            if fstype not in VALID_NTFS_MOUNT_DRIVERS:
                 issues.append(
                     f'line {line_number} has unexpected managed filesystem type: {fstype}'
                 )
@@ -340,12 +377,21 @@ def _validate_fstab_file(path):
     return True, None, None
 
 
-def _render_managed_fstab_entry(uuid, mount_point):
-    return f'UUID={uuid}\t\t{mount_point}\tntfs-3g\tdefaults,nofail\t0\t0 {FSTAB_MARKER}\n'
+def _render_managed_fstab_entry(uuid, mount_point, ntfs_driver=DEFAULT_NTFS_MOUNT_DRIVER):
+    ntfs_driver = normalize_ntfs_mount_driver(ntfs_driver)
+    return f'UUID={uuid}\t\t{mount_point}\t{ntfs_driver}\tdefaults,nofail\t0\t0 {FSTAB_MARKER}\n'
 
 
-def update_managed_fstab(uuid, mount_point, auto_mount, runtime=None, fstab_path=None):
+def update_managed_fstab(
+    uuid,
+    mount_point,
+    auto_mount,
+    runtime=None,
+    fstab_path=None,
+    ntfs_driver=DEFAULT_NTFS_MOUNT_DRIVER,
+):
     runtime = runtime or get_runtime()
+    ntfs_driver = normalize_ntfs_mount_driver(ntfs_driver)
     path = _get_fstab_path(runtime, fstab_path=fstab_path)
 
     if runtime.is_fake:
@@ -386,7 +432,7 @@ def update_managed_fstab(uuid, mount_point, auto_mount, runtime=None, fstab_path
     for line in existing:
         if _is_managed_fstab_line(line):
             if auto_mount:
-                new_lines.append(_render_managed_fstab_entry(uuid, mount_point))
+                new_lines.append(_render_managed_fstab_entry(uuid, mount_point, ntfs_driver))
                 managed_written = True
             continue
         new_lines.append(line)
@@ -394,7 +440,7 @@ def update_managed_fstab(uuid, mount_point, auto_mount, runtime=None, fstab_path
     if auto_mount and not managed_written:
         if new_lines and not new_lines[-1].endswith('\n'):
             new_lines[-1] = new_lines[-1] + '\n'
-        new_lines.append(_render_managed_fstab_entry(uuid, mount_point))
+        new_lines.append(_render_managed_fstab_entry(uuid, mount_point, ntfs_driver))
 
     path.parent.mkdir(parents=True, exist_ok=True)
     with NamedTemporaryFile(
@@ -431,6 +477,70 @@ def restore_fstab_backup(backup_path, runtime=None, fstab_path=None):
         return
     path = _get_fstab_path(runtime, fstab_path=fstab_path)
     shutil.copy2(backup_path, path)
+
+
+def _managed_fstab_entry_exists(runtime=None):
+    runtime = runtime or get_runtime()
+    path = _get_fstab_path(runtime)
+    if not path.exists():
+        return False
+    return any(_is_managed_fstab_line(line) for line in path.read_text().splitlines())
+
+
+def update_backup_drive_ntfs_driver(
+    ntfs_driver,
+    config_manager,
+    runtime=None,
+    command_adapter=None,
+):
+    runtime = runtime or get_runtime()
+    ntfs_driver = normalize_ntfs_mount_driver(ntfs_driver)
+    previous_driver = get_configured_ntfs_mount_driver(config_manager)
+    mount_point = config_manager.get_value(
+        'backup', 'mount_point', runtime.default_mount_point
+    )
+    uuid = config_manager.get_value('backup', 'uuid', '')
+    if not mount_point or not uuid:
+        raise BackupDriveSetupError('Backup drive must be configured before changing drivers.')
+
+    fstab_backup = None
+    config_updated = False
+    auto_mount = _managed_fstab_entry_exists(runtime=runtime)
+
+    try:
+        # Store the preference even when auto-mount is disabled; later manual
+        # mounts and backup-drive reruns should not fall back to the old driver.
+        config_manager.set_value('backup', 'ntfs_driver', ntfs_driver)
+        config_updated = True
+        if auto_mount:
+            fstab_backup = update_managed_fstab(
+                uuid,
+                mount_point,
+                True,
+                runtime=runtime,
+                ntfs_driver=ntfs_driver,
+            )
+            _reload_systemd_mount_units(runtime=runtime, command_adapter=command_adapter)
+    except Exception:
+        if fstab_backup:
+            restore_fstab_backup(fstab_backup, runtime=runtime)
+            _reload_systemd_mount_units(runtime=runtime, command_adapter=command_adapter)
+        if config_updated:
+            try:
+                config_manager.set_value('backup', 'ntfs_driver', previous_driver)
+            except Exception as config_exc:
+                LOGGER.error(
+                    'Failed to restore NTFS driver setting after update error: %s',
+                    config_exc,
+                )
+        raise
+
+    message = 'NTFS driver saved as {}.'.format(ntfs_driver)
+    if auto_mount:
+        message += ' The managed /etc/fstab entry now uses that driver.'
+    else:
+        message += ' Auto-mount is disabled, so no managed /etc/fstab entry was created.'
+    return {'ntfs_driver': ntfs_driver, 'message': message}
 
 
 def _reload_systemd_mount_units(runtime=None, command_adapter=None):
@@ -663,6 +773,7 @@ def apply_backup_drive_configuration(
     smb_manager,
     runtime=None,
     command_adapter=None,
+    ntfs_driver=None,
 ):
     runtime = runtime or get_runtime()
     command_adapter = _command_adapter(command_adapter)
@@ -677,6 +788,8 @@ def apply_backup_drive_configuration(
     )
     previous_uuid = config_manager.get_value('backup', 'uuid', '')
     previous_usb_id = config_manager.get_value('backup', 'usb_id', '')
+    previous_ntfs_driver = get_configured_ntfs_mount_driver(config_manager)
+    ntfs_driver = normalize_ntfs_mount_driver(ntfs_driver or previous_ntfs_driver)
 
     if runtime.is_fake:
         if fake_state is None:
@@ -702,7 +815,11 @@ def apply_backup_drive_configuration(
 
         try:
             fstab_backup = update_managed_fstab(
-                uuid, selected_path_str, bool(auto_mount), runtime=runtime
+                uuid,
+                selected_path_str,
+                bool(auto_mount),
+                runtime=runtime,
+                ntfs_driver=ntfs_driver,
             )
             _reload_systemd_mount_units(runtime=runtime, command_adapter=command_adapter)
 
@@ -714,6 +831,7 @@ def apply_backup_drive_configuration(
             config_manager.set_value('backup', 'mount_point', selected_path_str)
             config_manager.set_value('backup', 'uuid', uuid)
             config_manager.set_value('backup', 'usb_id', usb_id)
+            config_manager.set_value('backup', 'ntfs_driver', ntfs_driver)
             fake_state.set_mount(
                 True, mount_point=selected_path_str, drive=partition or '/dev/fakebackup1'
             )
@@ -722,6 +840,7 @@ def apply_backup_drive_configuration(
                 'uuid': uuid,
                 'usb_id': usb_id,
                 'mount_point': selected_path_str,
+                'ntfs_driver': ntfs_driver,
             }
         except Exception:
             if fstab_backup:
@@ -733,6 +852,7 @@ def apply_backup_drive_configuration(
                     config_manager.set_value('backup', 'mount_point', previous_mount_point)
                     config_manager.set_value('backup', 'uuid', previous_uuid)
                     config_manager.set_value('backup', 'usb_id', previous_usb_id)
+                    config_manager.set_value('backup', 'ntfs_driver', previous_ntfs_driver)
                 except Exception as config_exc:
                     LOGGER.error(
                         'Failed to restore fake backup config after drive setup error: %s',
@@ -767,10 +887,16 @@ def apply_backup_drive_configuration(
     config_updated = False
 
     try:
-        fstab_backup = update_managed_fstab(uuid, mount_point, bool(auto_mount), runtime=runtime)
+        fstab_backup = update_managed_fstab(
+            uuid,
+            mount_point,
+            bool(auto_mount),
+            runtime=runtime,
+            ntfs_driver=ntfs_driver,
+        )
         _reload_systemd_mount_units(runtime=runtime, command_adapter=command_adapter)
 
-        mount_result = command_adapter.mount_ntfs(partition, mount_point)
+        mount_result = command_adapter.mount_ntfs(partition, mount_point, ntfs_driver)
         if mount_result.returncode != 0:
             error_msg = (
                 mount_result.stderr.strip() if mount_result.stderr else 'Unknown error occurred'
@@ -784,12 +910,14 @@ def apply_backup_drive_configuration(
         config_manager.set_value('backup', 'mount_point', mount_point)
         config_manager.set_value('backup', 'uuid', uuid)
         config_manager.set_value('backup', 'usb_id', usb_id)
+        config_manager.set_value('backup', 'ntfs_driver', ntfs_driver)
 
         return {
             'message': f'Successfully configured {partition} at {mount_point}',
             'uuid': uuid,
             'usb_id': usb_id,
             'mount_point': mount_point,
+            'ntfs_driver': ntfs_driver,
         }
     except Exception:
         if mounted:
@@ -803,6 +931,7 @@ def apply_backup_drive_configuration(
                 config_manager.set_value('backup', 'mount_point', previous_mount_point)
                 config_manager.set_value('backup', 'uuid', previous_uuid)
                 config_manager.set_value('backup', 'usb_id', previous_usb_id)
+                config_manager.set_value('backup', 'ntfs_driver', previous_ntfs_driver)
             except Exception as config_exc:
                 LOGGER.error(
                     'Failed to restore backup config after drive setup error: %s', config_exc

--- a/simple_safer_server/services/config_manager.py
+++ b/simple_safer_server/services/config_manager.py
@@ -99,6 +99,7 @@ class ConfigManager:
             'uuid': '',
             'usb_id': '',
             'mount_point': self.runtime.default_mount_point,
+            'ntfs_driver': 'ntfs-3g',
             'rclone_dir': '',
             'bandwidth_limit': '',
         }

--- a/simple_safer_server/services/storage_service.py
+++ b/simple_safer_server/services/storage_service.py
@@ -2,6 +2,7 @@ import os
 from typing import Any
 
 from simple_safer_server.adapters.command_runner import CalledProcessError
+from simple_safer_server.services.backup_drive_setup import get_configured_ntfs_mount_driver
 from simple_safer_server.web.problems import OperationProblem, ValidationProblem
 
 
@@ -67,7 +68,8 @@ class StorageService:
                     slug="storage-validation-error",
                 )
             os.makedirs(mount_point, exist_ok=True)
-            self._command_adapter.mount(partition_device, mount_point)
+            ntfs_driver = get_configured_ntfs_mount_driver(self._config_manager)
+            self._command_adapter.mount(partition_device, mount_point, ntfs_driver=ntfs_driver)
             # Start mount-dependent checks/backups only after the volume exists;
             # smbd/nmbd expose Samba shares after the mounted paths are available.
             for unit_name in [

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -227,6 +227,10 @@
               <th>Configured USB ID</th>
               <td><code id="configuredUsbIdValue">{{ drive_config.usb_id or '—' }}</code></td>
             </tr>
+            <tr>
+              <th>NTFS Driver</th>
+              <td><code id="configuredNtfsDriverValue">{{ drive_config.ntfs_driver }}</code></td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -255,14 +259,24 @@
           <label class="form-label" for="backupDriveMountPoint">Mount Point</label>
           <input type="text" class="form-control text-mono" id="backupDriveMountPoint" value="{{ drive_config.mount_point }}" placeholder="/media/backup">
         </div>
+        <div class="form-group">
+          <label class="form-label" for="backupDriveNtfsDriver">NTFS Driver</label>
+          <select class="form-control" id="backupDriveNtfsDriver">
+            {% for option in ntfs_driver_options %}
+              <option value="{{ option.value }}" {% if option.value == drive_config.ntfs_driver %}selected{% endif %}>{{ option.label }}</option>
+            {% endfor %}
+          </select>
+          <div class="form-hint">Use ntfs3 on newer kernels; keep ntfs-3g for widest compatibility.</div>
+        </div>
       </div>
 
       <div class="text-muted mb-4" style="font-size: var(--text-sm); line-height: 1.6;">
-        Scan drives, select the correct backup partition, unmount it first if needed, then apply the updated backup drive setup. This always refreshes the SimpleSaferServer-managed <code>/etc/fstab</code> entry using the boot-safe <code>nofail</code> configuration. Do not use this for unrelated system storage changes.
+        Scan drives, select the correct backup partition, unmount it first if needed, then apply the updated backup drive setup. This always refreshes the SimpleSaferServer-managed <code>/etc/fstab</code> entry using the boot-safe <code>nofail</code> configuration and the selected NTFS driver. Driver-only changes take effect after the next mount or remount. Do not use this for unrelated system storage changes.
       </div>
 
       <div class="d-flex gap-2 justify-end flex-wrap">
         <button type="button" id="unmountBackupDriveBtn" class="btn btn-secondary btn-sm">Unmount Selected Drive</button>
+        <button type="button" id="saveNtfsDriverBtn" class="btn btn-secondary btn-sm">Save NTFS Driver</button>
         <button type="button" id="applyBackupDriveBtn" class="btn btn-primary btn-sm">Apply Backup Drive Setup</button>
       </div>
     </div>
@@ -299,7 +313,7 @@
         <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
           <li>the backup drive mount point in <code>/etc/SimpleSaferServer/config.conf</code></li>
           <li>the stored backup drive UUID and USB ID</li>
-          <li>the SimpleSaferServer-managed line in <code>/etc/fstab</code> for the backup drive</li>
+          <li>the NTFS driver used by the SimpleSaferServer-managed line in <code>/etc/fstab</code></li>
           <li>the Samba backup share path in <code>/etc/samba/smb.conf</code> if the mount point changed</li>
         </ul>
       </div>
@@ -320,7 +334,7 @@
         </p>
         <div class="mt-2">
           <strong>Example:</strong>
-          <div class="mt-2"><code>UUID=2CD49023D48FED80 /media/backup ntfs-3g defaults,nofail 0 0 # SimpleSaferServer managed backup drive</code></div>
+          <div class="mt-2"><code>UUID=2CD49023D48FED80 /media/backup ntfs3 defaults,nofail 0 0 # SimpleSaferServer managed backup drive</code></div>
         </div>
       </div>
     </div>
@@ -463,12 +477,15 @@
     const errorDetailsTextEl = document.getElementById('backupDriveSetupErrorDetailsText');
     const scanBtn = document.getElementById('scanBackupDrivesBtn');
     const unmountBtn = document.getElementById('unmountBackupDriveBtn');
+    const saveNtfsDriverBtn = document.getElementById('saveNtfsDriverBtn');
     const applyBtn = document.getElementById('applyBackupDriveBtn');
     const driveSelect = document.getElementById('backupDriveSelect');
     const mountPointInput = document.getElementById('backupDriveMountPoint');
+    const ntfsDriverSelect = document.getElementById('backupDriveNtfsDriver');
     const configuredMountPointValue = document.getElementById('configuredMountPointValue');
     const configuredUuidValue = document.getElementById('configuredUuidValue');
     const configuredUsbIdValue = document.getElementById('configuredUsbIdValue');
+    const configuredNtfsDriverValue = document.getElementById('configuredNtfsDriverValue');
     let currentDriveSetupErrorDetails = '';
 
     function setDriveSetupStatus(message, type) {
@@ -600,7 +617,8 @@ Note: SMB access will briefly disconnect while unmounting.`;
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             partition: driveSelect.value,
-            mount_point: mountPointInput.value.trim()
+            mount_point: mountPointInput.value.trim(),
+            ntfs_driver: ntfsDriverSelect ? ntfsDriverSelect.value : undefined
           })
         });
         const result = data.result || {};
@@ -608,6 +626,7 @@ Note: SMB access will briefly disconnect while unmounting.`;
         if (configuredMountPointValue) configuredMountPointValue.textContent = result.mount_point || mountPointInput.value.trim();
         if (configuredUuidValue) configuredUuidValue.textContent = result.uuid || '—';
         if (configuredUsbIdValue) configuredUsbIdValue.textContent = result.usb_id || '—';
+        if (configuredNtfsDriverValue && ntfsDriverSelect) configuredNtfsDriverValue.textContent = ntfsDriverSelect.value;
         if (window.showAlert) {
           window.showAlert(result.message || 'Backup drive setup updated successfully.', 'success');
         }
@@ -615,6 +634,47 @@ Note: SMB access will briefly disconnect while unmounting.`;
       } catch (error) {
         showDriveSetupError(error.message || 'Failed to apply backup drive setup.', error.details);
         if (window.AsyncButtonState && applyBtn) window.AsyncButtonState.error(applyBtn);
+      }
+    }
+
+    async function saveNtfsDriver() {
+      hideDriveSetupError();
+      if (!ntfsDriverSelect || !ntfsDriverSelect.value) {
+        showDriveSetupError('Select an NTFS driver first.');
+        return;
+      }
+
+      const confirmed = await window.showConfirmationDialog({
+        title: 'Save NTFS Driver',
+        message: `This updates the SimpleSaferServer-managed backup drive driver to ${ntfsDriverSelect.value}.
+
+The current live mount keeps using its existing driver until the drive is unmounted and mounted again.`,
+        confirmLabel: 'Save Driver',
+        confirmClass: 'btn-primary'
+      });
+      if (!confirmed) {
+        return;
+      }
+
+      setDriveSetupStatus('Saving NTFS driver…', 'info');
+      if (window.AsyncButtonState && saveNtfsDriverBtn) window.AsyncButtonState.start(saveNtfsDriverBtn);
+      try {
+        const { data, message } = await window.ApiClient.fetchJson('/api/backup_drive/ntfs-driver', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ntfs_driver: ntfsDriverSelect.value })
+        });
+        const result = data.result || {};
+        const driver = result.ntfs_driver || ntfsDriverSelect.value;
+        if (configuredNtfsDriverValue) configuredNtfsDriverValue.textContent = driver;
+        setDriveSetupStatus(result.message || message || 'NTFS driver saved.', 'success');
+        if (window.showAlert) {
+          window.showAlert(result.message || message || 'NTFS driver saved.', 'success');
+        }
+        if (window.AsyncButtonState && saveNtfsDriverBtn) window.AsyncButtonState.success(saveNtfsDriverBtn);
+      } catch (error) {
+        showDriveSetupError(error.message || 'Failed to save the NTFS driver.', error.details);
+        if (window.AsyncButtonState && saveNtfsDriverBtn) window.AsyncButtonState.error(saveNtfsDriverBtn);
       }
     }
 
@@ -629,6 +689,7 @@ Note: SMB access will briefly disconnect while unmounting.`;
 
     if (scanBtn) scanBtn.addEventListener('click', scanDrives);
     if (unmountBtn) unmountBtn.addEventListener('click', unmountSelectedDrive);
+    if (saveNtfsDriverBtn) saveNtfsDriverBtn.addEventListener('click', saveNtfsDriver);
     if (applyBtn) applyBtn.addEventListener('click', applyDriveSetup);
   })();
 </script>

--- a/tests/test_backup_drive_command_adapter.py
+++ b/tests/test_backup_drive_command_adapter.py
@@ -51,6 +51,16 @@ class BackupDriveCommandAdapterTests(unittest.TestCase):
         self.assertFalse(runner.calls[0][1]["check"])
         self.assertTrue(runner.calls[0][1]["capture_output"])
 
+    def test_mount_ntfs3_uses_kernel_mount_type(self):
+        runner = FakeCommandRunner(default_response=SimpleNamespace(returncode=0, stdout="", stderr=""))
+        adapter = BackupDriveCommandAdapter(command_runner=cast(Any, runner))
+
+        adapter.mount_ntfs("/dev/sdb1", "/media/backup", "ntfs3")
+
+        command = runner.calls[0][0]
+        self.assertEqual(command[:4], ["mount", "-t", "ntfs3", "-o"])
+        self.assertEqual(command[-2:], ["/dev/sdb1", "/media/backup"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -45,8 +45,8 @@ class FakeBackupDriveCommandAdapter:
             return self.unmount_results.pop(0)
         return SimpleNamespace(returncode=0, stderr='', stdout='')
 
-    def mount_ntfs(self, partition, mount_point):
-        self.mounted_ntfs.append((partition, mount_point))
+    def mount_ntfs(self, partition, mount_point, ntfs_driver='ntfs-3g'):
+        self.mounted_ntfs.append((partition, mount_point, ntfs_driver))
         return self.mount_ntfs_result
 
     def cleanup_unmount(self, device):
@@ -375,6 +375,64 @@ class BackupDriveSetupTests(unittest.TestCase):
 
         self.assertEqual(mount, {'device': '/dev/sdb1', 'mount_point': '/media/one'})
 
+    def test_update_managed_fstab_can_render_ntfs3_driver(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            runtime = SimpleNamespace(
+                is_fake=True,
+                config_dir=Path(tempdir) / 'config',
+            )
+            fstab_path = Path(tempdir) / 'fstab'
+
+            backup_drive_setup.update_managed_fstab(
+                'UUID-1',
+                '/media/backup',
+                True,
+                runtime=runtime,
+                fstab_path=fstab_path,
+                ntfs_driver='ntfs3',
+            )
+
+            self.assertIn(
+                'UUID=UUID-1\t\t/media/backup\tntfs3\tdefaults,nofail\t0\t0',
+                fstab_path.read_text(),
+            )
+
+    def test_update_backup_drive_ntfs_driver_rewrites_existing_managed_fstab(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            runtime = SimpleNamespace(
+                is_fake=True,
+                default_mount_point='/media/backup',
+                config_dir=Path(tempdir) / 'config',
+            )
+            fstab_path = Path(tempdir) / 'fstab'
+            fstab_path.write_text(
+                'UUID=UUID-1 /media/backup ntfs-3g defaults,nofail 0 0 '
+                '# SimpleSaferServer managed backup drive\n'
+            )
+
+            config_manager = MagicMock()
+            config_manager.get_value.side_effect = [
+                'ntfs-3g',
+                '/media/backup',
+                'UUID-1',
+            ]
+
+            with patch(
+                'simple_safer_server.services.backup_drive_setup._get_fstab_path',
+                return_value=fstab_path,
+            ):
+                result = backup_drive_setup.update_backup_drive_ntfs_driver(
+                    'ntfs3',
+                    config_manager,
+                    runtime=runtime,
+                )
+
+            self.assertEqual(result['ntfs_driver'], 'ntfs3')
+            self.assertIn('/media/backup\tntfs3\t', fstab_path.read_text())
+            config_manager.set_value.assert_called_once_with(
+                'backup', 'ntfs_driver', 'ntfs3'
+            )
+
     @patch('simple_safer_server.services.backup_drive_setup._get_mounted_partitions_for_disk')
     def test_unmount_disk_partitions_unmounts_all_members(self, mock_get_mounted):
         runtime = SimpleNamespace(is_fake=False)
@@ -426,7 +484,7 @@ class BackupDriveSetupTests(unittest.TestCase):
         runtime = SimpleNamespace(is_fake=False, default_mount_point='/media/backup')
         command_adapter = FakeBackupDriveCommandAdapter()
         config_manager = MagicMock()
-        config_manager.get_value.side_effect = ['/media/backup', '', '']
+        config_manager.get_value.side_effect = ['/media/backup', '', '', 'ntfs-3g']
         smb_manager = MagicMock()
         smb_manager.get_managed_share.return_value = None
 
@@ -451,7 +509,10 @@ class BackupDriveSetupTests(unittest.TestCase):
         mock_reload_mount_units.assert_called_once_with(
             runtime=runtime, command_adapter=command_adapter
         )
-        self.assertEqual(command_adapter.mounted_ntfs, [('/dev/sdb1', '/media/backup')])
+        self.assertEqual(
+            command_adapter.mounted_ntfs,
+            [('/dev/sdb1', '/media/backup', 'ntfs-3g')],
+        )
 
     @patch('simple_safer_server.services.backup_drive_setup.restore_fstab_backup')
     @patch('simple_safer_server.services.backup_drive_setup.os.makedirs')
@@ -475,7 +536,12 @@ class BackupDriveSetupTests(unittest.TestCase):
         runtime = SimpleNamespace(is_fake=False, default_mount_point='/media/backup')
         command_adapter = FakeBackupDriveCommandAdapter()
         config_manager = MagicMock()
-        config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', '1234:5678']
+        config_manager.get_value.side_effect = [
+            '/media/backup',
+            'OLD-UUID',
+            '1234:5678',
+            'ntfs-3g',
+        ]
         smb_manager = MagicMock()
         smb_manager.get_managed_share.return_value = None
 
@@ -524,7 +590,12 @@ class BackupDriveSetupTests(unittest.TestCase):
         runtime = SimpleNamespace(is_fake=False, default_mount_point='/media/backup')
         command_adapter = FakeBackupDriveCommandAdapter()
         config_manager = MagicMock()
-        config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', '1234:5678']
+        config_manager.get_value.side_effect = [
+            '/media/backup',
+            'OLD-UUID',
+            '1234:5678',
+            'ntfs-3g',
+        ]
         smb_manager = MagicMock()
         smb_manager.get_managed_share.return_value = None
 
@@ -584,7 +655,12 @@ class BackupDriveSetupTests(unittest.TestCase):
             mock_update_fstab.return_value = '/tmp/fstab.backup'
 
             config_manager = MagicMock()
-            config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', 'OLD-USB']
+            config_manager.get_value.side_effect = [
+                '/media/backup',
+                'OLD-UUID',
+                'OLD-USB',
+                'ntfs-3g',
+            ]
             config_manager.set_value.side_effect = [None, None, RuntimeError('boom')]
 
             smb_manager = MagicMock()
@@ -648,7 +724,12 @@ class BackupDriveSetupTests(unittest.TestCase):
             mock_update_fstab.return_value = '/tmp/fstab.backup'
 
             config_manager = MagicMock()
-            config_manager.get_value.side_effect = ['/media/backup', 'OLD-UUID', 'OLD-USB']
+            config_manager.get_value.side_effect = [
+                '/media/backup',
+                'OLD-UUID',
+                'OLD-USB',
+                'ntfs-3g',
+            ]
             config_manager.set_value.side_effect = [None, None, RuntimeError('boom')]
 
             managed_share = {

--- a/tests/test_runtime_command_adapters.py
+++ b/tests/test_runtime_command_adapters.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -33,7 +34,15 @@ class RuntimeCommandAdapterTests(unittest.TestCase):
             [
                 ["systemctl", "reboot"],
                 ["systemctl", "poweroff"],
-                ["mount", "/dev/sdb1", "/media/backup"],
+                [
+                    "mount",
+                    "-t",
+                    "ntfs-3g",
+                    "-o",
+                    "rw,uid={},gid={}".format(os.getuid(), os.getgid()),
+                    "/dev/sdb1",
+                    "/media/backup",
+                ],
                 ["systemctl", "start", "smbd"],
             ],
         )

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -10,14 +10,21 @@ from simple_safer_server.web.problems import OperationProblem, ValidationProblem
 
 
 class FakeConfigManager:
-    def __init__(self, mount_point, uuid: Optional[str] = "drive-uuid"):
+    def __init__(
+        self,
+        mount_point,
+        uuid: Optional[str] = "drive-uuid",
+        ntfs_driver: str = "ntfs-3g",
+    ):
         self.mount_point = mount_point
         self.uuid = uuid
+        self.ntfs_driver = ntfs_driver
 
     def get_value(self, section, key, default=None):
         values = {
             ("backup", "mount_point"): self.mount_point,
             ("backup", "uuid"): self.uuid,
+            ("backup", "ntfs_driver"): self.ntfs_driver,
         }
         return values.get((section, key), default)
 
@@ -52,10 +59,10 @@ class FakeStorageCommandAdapter:
     def find_device_by_uuid(self, uuid):
         return self.device
 
-    def mount(self, device, mount_point):
+    def mount(self, device, mount_point, ntfs_driver="ntfs-3g"):
         if self.raise_on_mount:
             raise self.raise_on_mount
-        self.mounted.append((device, mount_point))
+        self.mounted.append((device, mount_point, ntfs_driver))
 
     def start_unit(self, unit_name):
         self.started.append(unit_name)
@@ -107,7 +114,7 @@ class StorageServiceTests(unittest.TestCase):
             self.assertEqual(
                 service.mount_dashboard_drive(), "Drive mounted and available for use."
             )
-            self.assertEqual(adapter.mounted, [("/dev/sdb1", mount_point)])
+            self.assertEqual(adapter.mounted, [("/dev/sdb1", mount_point, "ntfs-3g")])
         self.assertEqual(
             adapter.started,
             [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable NTFS mount driver selection in the Drive Health backup-drive setup panel. Users can now choose between `ntfs-3g` (default) or `ntfs3` (for newer kernel support) and persist their selection.

* **Documentation**
  * Updated setup and Drive Health guides to clarify NTFS driver configuration and managed filesystem mount point handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->