### PR TITLE
NTFS Driver Selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@ Follow `docs/development.md` as the canonical coding standard for this repositor
 
 Always sprinkle comments about things we might forget in a few months, or that might not immediately seem obvious on a first read.
 
-Double check about documentation that might be related to whatever you are implementing, along with the related links to the index.html file. You are encouraged to rewrite and refactor the documentation whenever it does not make sense to match the behavior seen in code.
+Double check about documentation that might be related to whatever you are implementing, along with the related links to the index.html file. You are encouraged to rewrite and refactor the documentation whenever it is outdated or does not make sense to match the behavior seen in code.
 
 When writing comments and documentation, don't write it assuming the person reading it has seen the previous version of the code or comments. For example don't do something like
 
@@ -16,10 +16,10 @@ instead just do
 
 Prefer refactoring code if the end result will mean that the code will be simpler, more effective, and easier to maintain, rather than sticking to existing conventions, even if it means more work in the short term
 
-When designing any UI elements, always use the frontend-design and uncodixfy skills. Try to reuse existing UI elements and UI patterns from elsewhere in the system or, if creating new ones, follow the same "Bunker" style. Make better use of the vertical space. Consider how this would be viewed both on desktop and mobile.
+When designing any UI elements, always use the uncodixfy skill. Try to reuse existing UI elements and UI patterns from elsewhere in the system or, if as a last resort creating new ones, follow the same "Bunker" style. Make good use of vertical space, so more things can be visible at once with your design. Consider how the page will be viewed both on desktop and mobile.
 
 Consider if anything that you add needs to be removed during the uninstallation by the uninstall.sh script.
 
-Security model: SimpleSaferServer is a root-run, admin-only local management tool. Admin users are trusted operators with server-level access, so do not hide useful managed secrets or config from them just for appearance; still avoid accidental leaks into logs, broad status responses, process argv, or unrelated UI.
+SimpleSaferServer is a root-run, admin-only local management tool. Admin users are trusted operators with server-level access, so do not hide useful managed secrets or config from them just for appearance; still avoid accidental leaks into logs, broad status responses, process argv, or unrelated UI.
 
 Do not edit the README.md, any edits to it will be done by the user.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -43,7 +43,7 @@ Four cards display real-time status:
 - Before unmounting, the app best-effort closes SMB sessions and stops the related background tasks so Samba does not keep the backup share busy.
 - If the backup drive stays connected, SimpleSaferServer may remount it automatically during the next scheduled `Check Mount` run.
 - When the next `Check Mount` run is available, the confirmation dialog explains the remount timing as a relative countdown so the user knows how long they have to remove or swap the drive.
-- **Mount Storage**: Opens a modal to mount the storage drive.
+- **Mount Storage**: Opens a modal to mount the storage drive. When a SimpleSaferServer-managed `/etc/fstab` entry exists for the mount point, the app verifies that the entry's `UUID=` still matches the configured backup drive before using it for the remount.
 - **Restart System**: Opens a modal to confirm and restart the system.
 - **Shutdown System**: Opens a modal to confirm and shut down the system.
 - Restart and shutdown are blocked while apt or dpkg is active so package operations are not interrupted.

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -115,6 +115,7 @@ This flow is partition-oriented.
 - The app intentionally does not escalate to that broader SMB-safe path based on UUID alone, because cloned replacement disks can legitimately share a filesystem UUID and would make the selected physical device ambiguous.
 - The configure action mounts only the exact selected partition.
 - The NTFS driver selector controls the filesystem type written to the managed `/etc/fstab` entry. `ntfs-3g` remains the default; `ntfs3` uses the kernel NTFS driver on kernels that support it.
+- Managed `ntfs3` entries use explicit `dmask=000,fmask=000` permissions so existing NTFS folders remain writable through the authenticated Samba share.
 
 This is different from setup wizard step 2, which is disk-oriented for formatting.
 
@@ -192,9 +193,9 @@ Important file locations:
 Example managed `/etc/fstab` entry:
 
 ```fstab
-UUID=2CD49023D48FED80    /media/backup    ntfs-3g    defaults,nofail    0    0 # SimpleSaferServer managed backup drive
+UUID=2CD49023D48FED80    /media/backup    ntfs-3g    defaults,nofail                                 0    0 # SimpleSaferServer managed backup drive
 # or, when the kernel NTFS driver is deliberately selected:
-UUID=2CD49023D48FED80    /media/backup    ntfs3       defaults,nofail    0    0 # SimpleSaferServer managed backup drive
+UUID=2CD49023D48FED80    /media/backup    ntfs3       rw,uid=0,gid=0,dmask=000,fmask=000,nofail    0    0 # SimpleSaferServer managed backup drive
 ```
 
 After manual changes, verify the result:

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -114,6 +114,7 @@ This flow is partition-oriented.
 - If the selected partition is still the configured backup drive and it is currently mounted at the managed backup mount point, the app first disconnects SMB access and stops the related background tasks so the unmount is not blocked by busy share handles.
 - The app intentionally does not escalate to that broader SMB-safe path based on UUID alone, because cloned replacement disks can legitimately share a filesystem UUID and would make the selected physical device ambiguous.
 - The configure action mounts only the exact selected partition.
+- The NTFS driver selector controls the filesystem type written to the managed `/etc/fstab` entry. `ntfs-3g` remains the default; `ntfs3` uses the kernel NTFS driver on kernels that support it.
 
 This is different from setup wizard step 2, which is disk-oriented for formatting.
 
@@ -130,10 +131,10 @@ It is also different from the main Dashboard `Unmount Drive` action.
 - the stored backup `mount_point`
 - the stored backup `uuid`
 - the stored backup `usb_id`
-- the SimpleSaferServer-managed `/etc/fstab` entry for the backup drive
+- the SimpleSaferServer-managed `/etc/fstab` entry for the backup drive, including the selected NTFS driver
 - the Samba backup share path if the mount point changed
 
-The rerun flow always refreshes the managed `/etc/fstab` entry with `defaults,nofail`.
+The rerun flow always refreshes the managed `/etc/fstab` entry with the selected NTFS driver and `defaults,nofail`.
 After rewriting the managed `/etc/fstab` entry, the app also runs `systemctl daemon-reload` so the next `Check Mount` run sees the updated systemd-generated mount units immediately.
 
 Persistent backup-drive state changes happen only when the rerun configure step succeeds.
@@ -153,6 +154,7 @@ The app does not treat unrelated `/etc/fstab` lines as its own unless they use t
 
 - The rerun flow does not edit unrelated `/etc/fstab` entries.
 - If the app finds multiple managed entries, it stops and asks for manual cleanup.
+- If `ntfs3` is selected on a kernel that cannot mount `ntfs3`, the configure step fails and restores the previous managed `/etc/fstab` entry.
 - If a non-SimpleSaferServer entry already uses the same UUID or mount point, it stops and asks for manual cleanup.
 - If the selected partition is already mounted, it stops and asks the user to unmount it first.
 
@@ -174,6 +176,7 @@ Manual recovery rules:
 
 - Update `/etc/SimpleSaferServer/config.conf` only if you know the correct `mount_point`, `uuid`, and `usb_id`.
 - Update only the SimpleSaferServer-managed `/etc/fstab` entry.
+- Use `ntfs-3g` or `ntfs3` as the filesystem type for the managed backup-drive line.
 - Run `sudo systemctl daemon-reload` after manually changing `/etc/fstab` so systemd forgets the old generated mount unit state.
 - If the mount point changes, also check `/etc/samba/simple_safer_server_shares.conf` (see [Network File Sharing](network_file_sharing.md)).
 - Do not modify unrelated `/etc/fstab` entries.
@@ -190,6 +193,8 @@ Example managed `/etc/fstab` entry:
 
 ```fstab
 UUID=2CD49023D48FED80    /media/backup    ntfs-3g    defaults,nofail    0    0 # SimpleSaferServer managed backup drive
+# or, when the kernel NTFS driver is deliberately selected:
+UUID=2CD49023D48FED80    /media/backup    ntfs3       defaults,nofail    0    0 # SimpleSaferServer managed backup drive
 ```
 
 After manual changes, verify the result:

--- a/docs/drive_health.md
+++ b/docs/drive_health.md
@@ -135,7 +135,7 @@ It is also different from the main Dashboard `Unmount Drive` action.
 - the SimpleSaferServer-managed `/etc/fstab` entry for the backup drive, including the selected NTFS driver
 - the Samba backup share path if the mount point changed
 
-The rerun flow always refreshes the managed `/etc/fstab` entry with the selected NTFS driver and `defaults,nofail`.
+The rerun flow always refreshes the managed `/etc/fstab` entry with driver-specific mount options. `ntfs-3g` entries use `defaults,nofail`; `ntfs3` entries use `rw,uid=0,gid=0,dmask=000,fmask=000,nofail` so existing NTFS folders stay writable through Samba.
 After rewriting the managed `/etc/fstab` entry, the app also runs `systemctl daemon-reload` so the next `Check Mount` run sees the updated systemd-generated mount units immediately.
 
 Persistent backup-drive state changes happen only when the rerun configure step succeeds.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -57,7 +57,8 @@ This step is partition-oriented.
 - If the exact unmount fails and the selected partition is still the live configured backup drive mounted at the managed backup mount point, the wizard offers a second explicit SMB-safe retry that may temporarily stop SMB access and the related background backup tasks before retrying the unmount.
 - The wizard intentionally does not offer that broader retry based on UUID alone, because cloned replacement disks can legitimately share a filesystem UUID and would make the safety check ambiguous.
 - The mount button mounts that selected NTFS partition at the chosen mount point.
-- Advanced options allow changing the mount point and whether the managed `/etc/fstab` entry should be present.
+- Advanced options allow changing the mount point.
+- A successful mount step always writes the managed `/etc/fstab` entry so the backup drive can be remounted at boot and by scheduled mount checks.
 
 Persistent backup-drive state changes only when the mount/configure step succeeds:
 
@@ -73,7 +74,7 @@ agree about which partitions are selectable, especially for already-mounted
 
 Boot behavior:
 
-- The managed `/etc/fstab` entry uses `defaults,nofail`.
+- The managed `/etc/fstab` entry uses `ntfs-3g` with `defaults,nofail`.
 - That means the system should still boot if the backup drive is disconnected.
 
 ## Step 4: Backup Configuration

--- a/simple_safer_server/adapters/backup_drive_commands.py
+++ b/simple_safer_server/adapters/backup_drive_commands.py
@@ -59,10 +59,13 @@ class BackupDriveCommandAdapter:
     def mount_ntfs(self, partition: str, mount_point: str, ntfs_driver: str = "ntfs-3g"):
         uid = os.getuid()
         gid = os.getgid()
-        mount_options = f"rw,uid={uid},gid={gid}"
         if ntfs_driver == "ntfs3":
+            # Match the managed fstab entry so the immediate validation mount
+            # has the same Samba-friendly permission view as later remounts.
+            mount_options = "rw,uid=0,gid=0,dmask=000,fmask=000"
             command = ["mount", "-t", "ntfs3", partition, mount_point, "-o", mount_options]
         else:
+            mount_options = f"rw,uid={uid},gid={gid}"
             # ntfs-3g stays the default because it has the longest compatibility
             # history across the Debian/Ubuntu releases SimpleSaferServer supports.
             command = ["ntfs-3g", partition, mount_point, "-o", mount_options]

--- a/simple_safer_server/adapters/backup_drive_commands.py
+++ b/simple_safer_server/adapters/backup_drive_commands.py
@@ -56,11 +56,18 @@ class BackupDriveCommandAdapter:
             timeout=BACKUP_DRIVE_MOUNT_TIMEOUT_SECONDS,
         )
 
-    def mount_ntfs(self, partition: str, mount_point: str):
+    def mount_ntfs(self, partition: str, mount_point: str, ntfs_driver: str = "ntfs-3g"):
         uid = os.getuid()
         gid = os.getgid()
+        mount_options = f"rw,uid={uid},gid={gid}"
+        if ntfs_driver == "ntfs3":
+            command = ["mount", "-t", "ntfs3", partition, mount_point, "-o", mount_options]
+        else:
+            # ntfs-3g stays the default because it has the longest compatibility
+            # history across the Debian/Ubuntu releases SimpleSaferServer supports.
+            command = ["ntfs-3g", partition, mount_point, "-o", mount_options]
         return self._command_runner.run(
-            ["ntfs-3g", partition, mount_point, "-o", f"rw,uid={uid},gid={gid}"],
+            command,
             capture_output=True,
             text=True,
             timeout=BACKUP_DRIVE_MOUNT_TIMEOUT_SECONDS,

--- a/simple_safer_server/adapters/storage_commands.py
+++ b/simple_safer_server/adapters/storage_commands.py
@@ -36,6 +36,13 @@ class StorageCommandAdapter:
             timeout=STORAGE_MOUNT_TIMEOUT_SECONDS,
         )
 
+    def mount_managed(self, mount_point: str) -> None:
+        self._command_runner.run(
+            ["mount", mount_point],
+            check=True,
+            timeout=STORAGE_MOUNT_TIMEOUT_SECONDS,
+        )
+
     def start_unit(self, unit_name: str) -> None:
         # These service restarts are best-effort after a successful mount so
         # one unavailable helper does not hide the drive from the dashboard.

--- a/simple_safer_server/routes/drive_health.py
+++ b/simple_safer_server/routes/drive_health.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from flask import Blueprint, abort, current_app, render_template, request, send_file
 
+from simple_safer_server.services.backup_drive_setup import get_managed_ntfs_driver
 from simple_safer_server.services.drive_health import (
     SMART_FIELDS,
     SMARTCTL_JSON_UPGRADE_MESSAGE,
@@ -57,6 +58,7 @@ def drives():
         ),
         "uuid": services.config_manager.get_value("backup", "uuid", ""),
         "usb_id": services.config_manager.get_value("backup", "usb_id", ""),
+        "ntfs_driver": get_managed_ntfs_driver(runtime=services.runtime),
     }
 
     smart_support_warning = None

--- a/simple_safer_server/routes/setup_wizard.py
+++ b/simple_safer_server/routes/setup_wizard.py
@@ -575,7 +575,9 @@ def mount_drive():
         if not partition:
             return _validation_problem('partition is required')
         mount_point = data.get('mount_point') or runtime.default_mount_point
-        auto_mount = data.get('auto_mount', True)
+        # SimpleSaferServer-managed backup drives are always registered for boot
+        # remounts; the UI no longer exposes a non-persistent mount mode.
+        auto_mount = True
         result = apply_backup_drive_configuration(
             partition,
             mount_point,

--- a/simple_safer_server/routes/storage.py
+++ b/simple_safer_server/routes/storage.py
@@ -270,6 +270,7 @@ def api_backup_drive_configure():
             config_manager=services.config_manager,
             smb_manager=services.smb_manager,
             runtime=services.runtime,
+            ntfs_driver=data.get("ntfs_driver", "ntfs-3g"),
         )
         return json_data({"result": result})
     except BackupDriveSetupError as exc:

--- a/simple_safer_server/services/backup_drive_setup.py
+++ b/simple_safer_server/services/backup_drive_setup.py
@@ -350,9 +350,20 @@ def _validate_fstab_file(path):
     return True, None, None
 
 
+def _managed_ntfs_mount_options(ntfs_driver):
+    ntfs_driver = normalize_ntfs_driver(ntfs_driver)
+    if ntfs_driver == 'ntfs3':
+        # ntfs3 otherwise exposes existing NTFS directories as root-owned 0755
+        # on common kernels, which makes authenticated Samba users hit Linux
+        # permission denials even though the share itself is writable.
+        return 'rw,uid=0,gid=0,dmask=000,fmask=000,nofail'
+    return 'defaults,nofail'
+
+
 def _render_managed_fstab_entry(uuid, mount_point, ntfs_driver=DEFAULT_NTFS_DRIVER):
     ntfs_driver = normalize_ntfs_driver(ntfs_driver)
-    return f'UUID={uuid}\t\t{mount_point}\t{ntfs_driver}\tdefaults,nofail\t0\t0 {FSTAB_MARKER}\n'
+    mount_options = _managed_ntfs_mount_options(ntfs_driver)
+    return f'UUID={uuid}\t\t{mount_point}\t{ntfs_driver}\t{mount_options}\t0\t0 {FSTAB_MARKER}\n'
 
 
 def get_managed_ntfs_driver(runtime=None, fstab_path=None):

--- a/simple_safer_server/services/backup_drive_setup.py
+++ b/simple_safer_server/services/backup_drive_setup.py
@@ -15,6 +15,8 @@ from simple_safer_server.services.runtime import get_fake_state, get_runtime
 LOGGER = logging.getLogger(__name__)
 FSTAB_MARKER = "# SimpleSaferServer managed backup drive"
 LEGACY_FSTAB_MARKER = "SimpleSaferServer"
+DEFAULT_NTFS_DRIVER = 'ntfs-3g'
+SUPPORTED_NTFS_DRIVERS = {DEFAULT_NTFS_DRIVER, 'ntfs3'}
 NTFS_FILESYSTEM_TYPES = {'ntfs', 'ntfs3', 'ntfs-3g'}
 
 
@@ -96,6 +98,7 @@ def _parse_fstab_entry(line):
     return {
         'spec': parts[0],
         'mount_point': parts[1],
+        'fstype': parts[2] if len(parts) >= 3 else '',
     }
 
 
@@ -106,6 +109,13 @@ def _backup_file(path, runtime, prefix):
     backup_path = backup_dir / f'{prefix}.{timestamp}'
     shutil.copy2(path, backup_path)
     return backup_path
+
+
+def normalize_ntfs_driver(ntfs_driver):
+    normalized_driver = (ntfs_driver or DEFAULT_NTFS_DRIVER).strip().lower()
+    if normalized_driver not in SUPPORTED_NTFS_DRIVERS:
+        raise BackupDriveSetupError('Unsupported NTFS driver. Choose ntfs-3g or ntfs3.')
+    return normalized_driver
 
 
 def _is_ntfs_filesystem(filesystem_type):
@@ -328,7 +338,7 @@ def _validate_fstab_file(path):
                 )
             if not spec.startswith('UUID='):
                 issues.append(f'line {line_number} has an invalid managed UUID spec: {spec}')
-            if fstype != 'ntfs-3g':
+            if fstype not in SUPPORTED_NTFS_DRIVERS:
                 issues.append(
                     f'line {line_number} has unexpected managed filesystem type: {fstype}'
                 )
@@ -340,11 +350,60 @@ def _validate_fstab_file(path):
     return True, None, None
 
 
-def _render_managed_fstab_entry(uuid, mount_point):
-    return f'UUID={uuid}\t\t{mount_point}\tntfs-3g\tdefaults,nofail\t0\t0 {FSTAB_MARKER}\n'
+def _render_managed_fstab_entry(uuid, mount_point, ntfs_driver=DEFAULT_NTFS_DRIVER):
+    ntfs_driver = normalize_ntfs_driver(ntfs_driver)
+    return f'UUID={uuid}\t\t{mount_point}\t{ntfs_driver}\tdefaults,nofail\t0\t0 {FSTAB_MARKER}\n'
 
 
-def update_managed_fstab(uuid, mount_point, auto_mount, runtime=None, fstab_path=None):
+def get_managed_ntfs_driver(runtime=None, fstab_path=None):
+    runtime = runtime or get_runtime()
+    path = _get_fstab_path(runtime, fstab_path=fstab_path)
+    if not path.exists():
+        return DEFAULT_NTFS_DRIVER
+
+    for line in path.read_text().splitlines():
+        if not _is_managed_fstab_line(line):
+            continue
+        entry = _parse_fstab_entry(line)
+        if not entry:
+            continue
+        # The managed fstab line is the durable source of truth for the driver;
+        # config.conf intentionally does not duplicate this filesystem detail.
+        fstype = (entry.get('fstype') or '').strip().lower()
+        if fstype in SUPPORTED_NTFS_DRIVERS:
+            return fstype
+    return DEFAULT_NTFS_DRIVER
+
+
+def has_managed_fstab_entry_for_mount_point(mount_point, runtime=None, fstab_path=None):
+    mount_point = (mount_point or '').strip()
+    if not mount_point:
+        return False
+
+    runtime = runtime or get_runtime()
+    path = _get_fstab_path(runtime, fstab_path=fstab_path)
+    if not path.exists():
+        return False
+
+    normalized_mount_point = os.path.realpath(mount_point)
+    for line in path.read_text().splitlines():
+        if not _is_managed_fstab_line(line):
+            continue
+        entry = _parse_fstab_entry(line)
+        if entry and os.path.realpath(entry['mount_point']) == normalized_mount_point:
+            return True
+    return False
+
+
+def update_managed_fstab(
+    uuid,
+    mount_point,
+    auto_mount,
+    runtime=None,
+    fstab_path=None,
+    ntfs_driver=DEFAULT_NTFS_DRIVER,
+):
+    ntfs_driver = normalize_ntfs_driver(ntfs_driver)
     runtime = runtime or get_runtime()
     path = _get_fstab_path(runtime, fstab_path=fstab_path)
 
@@ -386,7 +445,7 @@ def update_managed_fstab(uuid, mount_point, auto_mount, runtime=None, fstab_path
     for line in existing:
         if _is_managed_fstab_line(line):
             if auto_mount:
-                new_lines.append(_render_managed_fstab_entry(uuid, mount_point))
+                new_lines.append(_render_managed_fstab_entry(uuid, mount_point, ntfs_driver))
                 managed_written = True
             continue
         new_lines.append(line)
@@ -394,7 +453,7 @@ def update_managed_fstab(uuid, mount_point, auto_mount, runtime=None, fstab_path
     if auto_mount and not managed_written:
         if new_lines and not new_lines[-1].endswith('\n'):
             new_lines[-1] = new_lines[-1] + '\n'
-        new_lines.append(_render_managed_fstab_entry(uuid, mount_point))
+        new_lines.append(_render_managed_fstab_entry(uuid, mount_point, ntfs_driver))
 
     path.parent.mkdir(parents=True, exist_ok=True)
     with NamedTemporaryFile(
@@ -663,9 +722,11 @@ def apply_backup_drive_configuration(
     smb_manager,
     runtime=None,
     command_adapter=None,
+    ntfs_driver=DEFAULT_NTFS_DRIVER,
 ):
     runtime = runtime or get_runtime()
     command_adapter = _command_adapter(command_adapter)
+    ntfs_driver = normalize_ntfs_driver(ntfs_driver)
     fake_state = get_fake_state(runtime) if runtime.is_fake else None
 
     mount_point = (mount_point or '').strip()
@@ -702,7 +763,11 @@ def apply_backup_drive_configuration(
 
         try:
             fstab_backup = update_managed_fstab(
-                uuid, selected_path_str, bool(auto_mount), runtime=runtime
+                uuid,
+                selected_path_str,
+                bool(auto_mount),
+                runtime=runtime,
+                ntfs_driver=ntfs_driver,
             )
             _reload_systemd_mount_units(runtime=runtime, command_adapter=command_adapter)
 
@@ -722,6 +787,7 @@ def apply_backup_drive_configuration(
                 'uuid': uuid,
                 'usb_id': usb_id,
                 'mount_point': selected_path_str,
+                'ntfs_driver': ntfs_driver,
             }
         except Exception:
             if fstab_backup:
@@ -767,10 +833,16 @@ def apply_backup_drive_configuration(
     config_updated = False
 
     try:
-        fstab_backup = update_managed_fstab(uuid, mount_point, bool(auto_mount), runtime=runtime)
+        fstab_backup = update_managed_fstab(
+            uuid,
+            mount_point,
+            bool(auto_mount),
+            runtime=runtime,
+            ntfs_driver=ntfs_driver,
+        )
         _reload_systemd_mount_units(runtime=runtime, command_adapter=command_adapter)
 
-        mount_result = command_adapter.mount_ntfs(partition, mount_point)
+        mount_result = command_adapter.mount_ntfs(partition, mount_point, ntfs_driver=ntfs_driver)
         if mount_result.returncode != 0:
             error_msg = (
                 mount_result.stderr.strip() if mount_result.stderr else 'Unknown error occurred'
@@ -790,6 +862,7 @@ def apply_backup_drive_configuration(
             'uuid': uuid,
             'usb_id': usb_id,
             'mount_point': mount_point,
+            'ntfs_driver': ntfs_driver,
         }
     except Exception:
         if mounted:

--- a/simple_safer_server/services/backup_drive_setup.py
+++ b/simple_safer_server/services/backup_drive_setup.py
@@ -375,24 +375,36 @@ def get_managed_ntfs_driver(runtime=None, fstab_path=None):
     return DEFAULT_NTFS_DRIVER
 
 
-def has_managed_fstab_entry_for_mount_point(mount_point, runtime=None, fstab_path=None):
+def get_managed_fstab_entry_for_mount_point(mount_point, runtime=None, fstab_path=None):
     mount_point = (mount_point or '').strip()
     if not mount_point:
-        return False
+        return None
 
     runtime = runtime or get_runtime()
     path = _get_fstab_path(runtime, fstab_path=fstab_path)
     if not path.exists():
-        return False
+        return None
 
     normalized_mount_point = os.path.realpath(mount_point)
     for line in path.read_text().splitlines():
         if not _is_managed_fstab_line(line):
             continue
         entry = _parse_fstab_entry(line)
-        if entry and os.path.realpath(entry['mount_point']) == normalized_mount_point:
-            return True
-    return False
+        if not entry or os.path.realpath(entry['mount_point']) != normalized_mount_point:
+            continue
+        spec = entry.get('spec', '')
+        # Dashboard remounts may delegate to `mount <mount_point>`, so expose the
+        # UUID from fstab and let callers verify it still matches config.conf.
+        entry['uuid'] = spec.split('=', 1)[1] if spec.startswith('UUID=') else ''
+        return entry
+    return None
+
+
+def has_managed_fstab_entry_for_mount_point(mount_point, runtime=None, fstab_path=None):
+    return (
+        get_managed_fstab_entry_for_mount_point(mount_point, runtime=runtime, fstab_path=fstab_path)
+        is not None
+    )
 
 
 def update_managed_fstab(

--- a/simple_safer_server/services/backup_drive_setup.py
+++ b/simple_safer_server/services/backup_drive_setup.py
@@ -167,6 +167,30 @@ def _normalize_device_path(device_path):
     return os.path.realpath(device_path)
 
 
+def split_uuid_device_lookup(device_lookup_output):
+    return [line.strip() for line in (device_lookup_output or '').splitlines() if line.strip()]
+
+
+def _validate_uuid_maps_to_selected_device(uuid, selected_partition, command_adapter=None):
+    matching_devices = split_uuid_device_lookup(
+        _command_adapter(command_adapter).find_device_by_uuid(uuid)
+    )
+    if len(matching_devices) != 1:
+        if matching_devices:
+            raise BackupDriveSetupError(
+                'Multiple connected devices have the selected backup drive UUID. Disconnect cloned drives or assign a unique filesystem UUID before configuring the backup drive.'
+            )
+        raise BackupDriveSetupError('Could not verify the selected backup drive UUID.')
+
+    if _normalize_device_path(matching_devices[0]) != _normalize_device_path(selected_partition):
+        # The immediate mount uses the selected partition path, but fstab uses
+        # UUID=. Stop if those disagree so future boot/dashboard remounts do not
+        # target a different block device than the one the admin selected.
+        raise BackupDriveSetupError(
+            'The selected partition does not match the device found for its filesystem UUID.'
+        )
+
+
 def _lsblk_flag_is_true(value):
     if isinstance(value, bool):
         return value
@@ -843,6 +867,7 @@ def apply_backup_drive_configuration(
         )
 
     uuid = get_drive_uuid(partition, command_adapter=command_adapter)
+    _validate_uuid_maps_to_selected_device(uuid, partition, command_adapter=command_adapter)
     usb_id = get_drive_usb_id(partition)
     filesystem_type = _get_partition_filesystem_type(partition, command_adapter=command_adapter)
     if not _is_ntfs_filesystem(filesystem_type):

--- a/simple_safer_server/services/storage_service.py
+++ b/simple_safer_server/services/storage_service.py
@@ -2,7 +2,10 @@ import os
 from typing import Any
 
 from simple_safer_server.adapters.command_runner import CalledProcessError
-from simple_safer_server.services.backup_drive_setup import get_managed_fstab_entry_for_mount_point
+from simple_safer_server.services.backup_drive_setup import (
+    get_managed_fstab_entry_for_mount_point,
+    split_uuid_device_lookup,
+)
 from simple_safer_server.web.problems import OperationProblem, ValidationProblem
 
 
@@ -61,12 +64,21 @@ class StorageService:
             raise ValidationProblem("No drive UUID configured.", slug="storage-validation-error")
 
         try:
-            partition_device = self._command_adapter.find_device_by_uuid(uuid)
-            if not partition_device:
+            matching_devices = split_uuid_device_lookup(
+                self._command_adapter.find_device_by_uuid(uuid)
+            )
+            if not matching_devices:
                 raise ValidationProblem(
                     "Drive not found. Please check the connection.",
                     slug="storage-validation-error",
                 )
+            if len(matching_devices) > 1:
+                raise ValidationProblem(
+                    "Multiple connected drives have the configured backup drive UUID. "
+                    "Disconnect cloned drives or re-run backup drive setup before mounting.",
+                    slug="storage-validation-error",
+                )
+            partition_device = matching_devices[0]
             os.makedirs(mount_point, exist_ok=True)
             managed_fstab_entry = get_managed_fstab_entry_for_mount_point(
                 mount_point, runtime=self._runtime

--- a/simple_safer_server/services/storage_service.py
+++ b/simple_safer_server/services/storage_service.py
@@ -2,6 +2,7 @@ import os
 from typing import Any
 
 from simple_safer_server.adapters.command_runner import CalledProcessError
+from simple_safer_server.services.backup_drive_setup import has_managed_fstab_entry_for_mount_point
 from simple_safer_server.web.problems import OperationProblem, ValidationProblem
 
 
@@ -67,7 +68,12 @@ class StorageService:
                     slug="storage-validation-error",
                 )
             os.makedirs(mount_point, exist_ok=True)
-            self._command_adapter.mount(partition_device, mount_point)
+            if has_managed_fstab_entry_for_mount_point(mount_point, runtime=self._runtime):
+                # Prefer the managed fstab entry when it exists so dashboard
+                # remounts keep the admin-selected NTFS driver and mount options.
+                self._command_adapter.mount_managed(mount_point)
+            else:
+                self._command_adapter.mount(partition_device, mount_point)
             # Start mount-dependent checks/backups only after the volume exists;
             # smbd/nmbd expose Samba shares after the mounted paths are available.
             for unit_name in [

--- a/simple_safer_server/services/storage_service.py
+++ b/simple_safer_server/services/storage_service.py
@@ -2,7 +2,7 @@ import os
 from typing import Any
 
 from simple_safer_server.adapters.command_runner import CalledProcessError
-from simple_safer_server.services.backup_drive_setup import has_managed_fstab_entry_for_mount_point
+from simple_safer_server.services.backup_drive_setup import get_managed_fstab_entry_for_mount_point
 from simple_safer_server.web.problems import OperationProblem, ValidationProblem
 
 
@@ -68,9 +68,19 @@ class StorageService:
                     slug="storage-validation-error",
                 )
             os.makedirs(mount_point, exist_ok=True)
-            if has_managed_fstab_entry_for_mount_point(mount_point, runtime=self._runtime):
-                # Prefer the managed fstab entry when it exists so dashboard
-                # remounts keep the admin-selected NTFS driver and mount options.
+            managed_fstab_entry = get_managed_fstab_entry_for_mount_point(
+                mount_point, runtime=self._runtime
+            )
+            if managed_fstab_entry:
+                if managed_fstab_entry.get("uuid") != uuid:
+                    raise ValidationProblem(
+                        "Managed fstab entry does not match the configured backup drive UUID. "
+                        "Re-run backup drive setup from Drive Health before mounting.",
+                        slug="storage-validation-error",
+                    )
+                # Prefer the managed fstab entry only after the UUID matches so
+                # remounts keep the admin-selected NTFS driver without letting a
+                # stale fstab line mount a different backup disk.
                 self._command_adapter.mount_managed(mount_point)
             else:
                 self._command_adapter.mount(partition_device, mount_point)

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -265,7 +265,7 @@
             <option value="ntfs-3g" {% if drive_config.ntfs_driver == 'ntfs-3g' %}selected{% endif %}>ntfs-3g (default)</option>
             <option value="ntfs3" {% if drive_config.ntfs_driver == 'ntfs3' %}selected{% endif %}>ntfs3 (kernel driver)</option>
           </select>
-          <div class="form-hint">Use ntfs3 only when this kernel supports it.</div>
+          <div class="form-hint">Use ntfs3 only when this kernel supports it. The app gives ntfs3 mounts broad backup-share permissions.</div>
         </div>
       </div>
 

--- a/templates/drive_health.html
+++ b/templates/drive_health.html
@@ -227,6 +227,10 @@
               <th>Configured USB ID</th>
               <td><code id="configuredUsbIdValue">{{ drive_config.usb_id or '—' }}</code></td>
             </tr>
+            <tr>
+              <th>Configured NTFS Driver</th>
+              <td><code id="configuredNtfsDriverValue">{{ drive_config.ntfs_driver }}</code></td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -255,10 +259,18 @@
           <label class="form-label" for="backupDriveMountPoint">Mount Point</label>
           <input type="text" class="form-control text-mono" id="backupDriveMountPoint" value="{{ drive_config.mount_point }}" placeholder="/media/backup">
         </div>
+        <div class="form-group">
+          <label class="form-label" for="backupDriveNtfsDriver">NTFS Driver</label>
+          <select class="form-control" id="backupDriveNtfsDriver">
+            <option value="ntfs-3g" {% if drive_config.ntfs_driver == 'ntfs-3g' %}selected{% endif %}>ntfs-3g (default)</option>
+            <option value="ntfs3" {% if drive_config.ntfs_driver == 'ntfs3' %}selected{% endif %}>ntfs3 (kernel driver)</option>
+          </select>
+          <div class="form-hint">Use ntfs3 only when this kernel supports it.</div>
+        </div>
       </div>
 
       <div class="text-muted mb-4" style="font-size: var(--text-sm); line-height: 1.6;">
-        Scan drives, select the correct backup partition, unmount it first if needed, then apply the updated backup drive setup. This always refreshes the SimpleSaferServer-managed <code>/etc/fstab</code> entry using the boot-safe <code>nofail</code> configuration. Do not use this for unrelated system storage changes.
+        Scan drives, select the correct backup partition, unmount it first if needed, then apply the updated backup drive setup. This always refreshes the SimpleSaferServer-managed <code>/etc/fstab</code> entry using the selected NTFS driver and boot-safe <code>nofail</code> configuration. Do not use this for unrelated system storage changes.
       </div>
 
       <div class="d-flex gap-2 justify-end flex-wrap">
@@ -299,7 +311,7 @@
         <ul style="list-style: disc; padding-left: var(--sp-5); margin: var(--sp-2) 0 0 0;">
           <li>the backup drive mount point in <code>/etc/SimpleSaferServer/config.conf</code></li>
           <li>the stored backup drive UUID and USB ID</li>
-          <li>the SimpleSaferServer-managed line in <code>/etc/fstab</code> for the backup drive</li>
+          <li>the SimpleSaferServer-managed line in <code>/etc/fstab</code> for the backup drive, including the selected NTFS driver</li>
           <li>the Samba backup share path in <code>/etc/samba/smb.conf</code> if the mount point changed</li>
         </ul>
       </div>
@@ -466,9 +478,11 @@
     const applyBtn = document.getElementById('applyBackupDriveBtn');
     const driveSelect = document.getElementById('backupDriveSelect');
     const mountPointInput = document.getElementById('backupDriveMountPoint');
+    const ntfsDriverSelect = document.getElementById('backupDriveNtfsDriver');
     const configuredMountPointValue = document.getElementById('configuredMountPointValue');
     const configuredUuidValue = document.getElementById('configuredUuidValue');
     const configuredUsbIdValue = document.getElementById('configuredUsbIdValue');
+    const configuredNtfsDriverValue = document.getElementById('configuredNtfsDriverValue');
     let currentDriveSetupErrorDetails = '';
 
     function setDriveSetupStatus(message, type) {
@@ -600,7 +614,8 @@ Note: SMB access will briefly disconnect while unmounting.`;
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             partition: driveSelect.value,
-            mount_point: mountPointInput.value.trim()
+            mount_point: mountPointInput.value.trim(),
+            ntfs_driver: ntfsDriverSelect.value
           })
         });
         const result = data.result || {};
@@ -608,6 +623,7 @@ Note: SMB access will briefly disconnect while unmounting.`;
         if (configuredMountPointValue) configuredMountPointValue.textContent = result.mount_point || mountPointInput.value.trim();
         if (configuredUuidValue) configuredUuidValue.textContent = result.uuid || '—';
         if (configuredUsbIdValue) configuredUsbIdValue.textContent = result.usb_id || '—';
+        if (configuredNtfsDriverValue) configuredNtfsDriverValue.textContent = result.ntfs_driver || ntfsDriverSelect.value;
         if (window.showAlert) {
           window.showAlert(result.message || 'Backup drive setup updated successfully.', 'success');
         }

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -167,10 +167,7 @@ This removes all files on the selected drive and prepares it as one backup drive
                                         <label class="form-label">Mount Point</label>
                                         <input type="text" id="mountPoint" value="{{ default_mount_point }}" class="form-control">
                                     </div>
-                                    <div class="form-check">
-                                        <input type="checkbox" id="autoMount" class="form-check-input" checked>
-                                        <label class="form-check-label" for="autoMount">Mount automatically at boot</label>
-                                    </div>
+                                    <div class="form-hint">The backup drive is registered for automatic remounts during boot and scheduled mount checks.</div>
                                 </div>
                             </div>
                             <div class="d-flex gap-2 justify-end mb-4">
@@ -651,12 +648,11 @@ unmount the share, then restart SMB automatically."
             const mountBtn = document.getElementById('mountDriveBtn');
             const partition = document.getElementById('mountDriveSelect').value;
             const mountPoint = document.getElementById('mountPoint').value;
-            const autoMount = document.getElementById('autoMount').checked;
             if (!partition) { showMountError('Please select a drive to mount'); setMountStatus('Please select a drive.', 'warning'); return; }
             window.AsyncButtonState.start(mountBtn);
             setMountStatus('Mounting drive…', 'info');
             try {
-                await window.ApiClient.fetchJson('/api/setup/mount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ partition, mount_point: mountPoint, auto_mount: autoMount }) });
+                await window.ApiClient.fetchJson('/api/setup/mount', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ partition, mount_point: mountPoint }) });
                 window.AsyncButtonState.success(mountBtn); localStorage.setItem('mountSuccess', '1'); nextStep(); hideMountError(); setMountStatus('Drive mounted successfully.', 'success'); await loadDrives();
             } catch (error) { window.AsyncButtonState.error(mountBtn); setMountStatus('Failed to mount drive.', 'error'); showMountError(error.message || 'An error occurred while mounting the drive', error.details); }
         }

--- a/tests/test_backup_drive_command_adapter.py
+++ b/tests/test_backup_drive_command_adapter.py
@@ -51,6 +51,28 @@ class BackupDriveCommandAdapterTests(unittest.TestCase):
         self.assertFalse(runner.calls[0][1]["check"])
         self.assertTrue(runner.calls[0][1]["capture_output"])
 
+    def test_mount_ntfs_defaults_to_ntfs_3g_binary(self):
+        runner = FakeCommandRunner()
+        adapter = BackupDriveCommandAdapter(command_runner=cast(Any, runner))
+
+        adapter.mount_ntfs("/dev/sdb1", "/media/backup")
+
+        self.assertEqual(runner.calls[0][0][0:3], ["ntfs-3g", "/dev/sdb1", "/media/backup"])
+        self.assertEqual(runner.calls[0][0][3], "-o")
+        self.assertIn("rw,uid=", runner.calls[0][0][4])
+
+    def test_mount_ntfs3_uses_kernel_mount_type(self):
+        runner = FakeCommandRunner()
+        adapter = BackupDriveCommandAdapter(command_runner=cast(Any, runner))
+
+        adapter.mount_ntfs("/dev/sdb1", "/media/backup", ntfs_driver="ntfs3")
+
+        self.assertEqual(
+            runner.calls[0][0][0:5], ["mount", "-t", "ntfs3", "/dev/sdb1", "/media/backup"]
+        )
+        self.assertEqual(runner.calls[0][0][5], "-o")
+        self.assertIn("rw,uid=", runner.calls[0][0][6])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_backup_drive_command_adapter.py
+++ b/tests/test_backup_drive_command_adapter.py
@@ -71,7 +71,7 @@ class BackupDriveCommandAdapterTests(unittest.TestCase):
             runner.calls[0][0][0:5], ["mount", "-t", "ntfs3", "/dev/sdb1", "/media/backup"]
         )
         self.assertEqual(runner.calls[0][0][5], "-o")
-        self.assertIn("rw,uid=", runner.calls[0][0][6])
+        self.assertEqual(runner.calls[0][0][6], "rw,uid=0,gid=0,dmask=000,fmask=000")
 
 
 if __name__ == "__main__":

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -25,6 +25,7 @@ class FakeBackupDriveCommandAdapter:
         )
         self.current_mounts_result = SimpleNamespace(returncode=0, stderr='', stdout='')
         self.system_drive_result = SimpleNamespace(returncode=0, stderr='', stdout='/dev/sda\n')
+        self.find_device_by_uuid_result = '/dev/sdb1\n'
 
     def lsblk_devices_json(self):
         return self.lsblk_devices_json_result
@@ -38,6 +39,10 @@ class FakeBackupDriveCommandAdapter:
 
     def system_drive(self):
         return self.system_drive_result
+
+    def find_device_by_uuid(self, uuid):
+        del uuid
+        return self.find_device_by_uuid_result
 
     def unmount_partition(self, device):
         self.unmounted_partitions.append(device)
@@ -573,6 +578,48 @@ class BackupDriveSetupTests(unittest.TestCase):
             ntfs_driver='ntfs3',
         )
         self.assertEqual(command_adapter.mounted_ntfs, [('/dev/sdb1', '/media/backup', 'ntfs3')])
+
+    @patch('simple_safer_server.services.backup_drive_setup.os.makedirs')
+    @patch('simple_safer_server.services.backup_drive_setup.update_managed_fstab')
+    @patch('simple_safer_server.services.backup_drive_setup._get_partition_filesystem_type')
+    @patch('simple_safer_server.services.backup_drive_setup.get_drive_uuid')
+    @patch('simple_safer_server.services.backup_drive_setup._get_mount_for_partition')
+    def test_apply_backup_drive_configuration_rejects_duplicate_uuid_devices(
+        self,
+        mock_get_mount,
+        mock_get_uuid,
+        mock_get_fstype,
+        mock_update_fstab,
+        mock_makedirs,
+    ):
+        del mock_get_fstype
+        del mock_makedirs
+        runtime = SimpleNamespace(is_fake=False, default_mount_point='/media/backup')
+        command_adapter = FakeBackupDriveCommandAdapter()
+        command_adapter.find_device_by_uuid_result = '/dev/sdb1\n/dev/sdc1\n'
+        config_manager = MagicMock()
+        config_manager.get_value.side_effect = ['/media/backup', '', '']
+        smb_manager = MagicMock()
+
+        mock_get_mount.return_value = None
+        mock_get_uuid.return_value = 'UUID-1'
+
+        with self.assertRaisesRegex(
+            backup_drive_setup.BackupDriveSetupError,
+            'Multiple connected devices have the selected backup drive UUID',
+        ):
+            backup_drive_setup.apply_backup_drive_configuration(
+                '/dev/sdb1',
+                '/media/backup',
+                True,
+                config_manager,
+                smb_manager,
+                runtime=runtime,
+                command_adapter=command_adapter,
+            )
+
+        mock_update_fstab.assert_not_called()
+        self.assertEqual(command_adapter.mounted_ntfs, [])
 
     @patch('simple_safer_server.services.backup_drive_setup.restore_fstab_backup')
     @patch('simple_safer_server.services.backup_drive_setup.os.makedirs')

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -412,6 +412,12 @@ class BackupDriveSetupTests(unittest.TestCase):
                     '/media/backup', runtime=runtime
                 )
             )
+            self.assertEqual(
+                backup_drive_setup.get_managed_fstab_entry_for_mount_point(
+                    '/media/backup', runtime=runtime
+                )['uuid'],
+                'UUID-1',
+            )
 
     def test_update_managed_fstab_rejects_unknown_ntfs_driver(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -45,8 +45,8 @@ class FakeBackupDriveCommandAdapter:
             return self.unmount_results.pop(0)
         return SimpleNamespace(returncode=0, stderr='', stdout='')
 
-    def mount_ntfs(self, partition, mount_point):
-        self.mounted_ntfs.append((partition, mount_point))
+    def mount_ntfs(self, partition, mount_point, ntfs_driver='ntfs-3g'):
+        self.mounted_ntfs.append((partition, mount_point, ntfs_driver))
         return self.mount_ntfs_result
 
     def cleanup_unmount(self, device):
@@ -375,6 +375,65 @@ class BackupDriveSetupTests(unittest.TestCase):
 
         self.assertEqual(mount, {'device': '/dev/sdb1', 'mount_point': '/media/one'})
 
+    def test_managed_fstab_driver_defaults_to_ntfs_3g(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            fstab_path = Path(tempdir) / 'fstab'
+
+            self.assertEqual(
+                backup_drive_setup.get_managed_ntfs_driver(fstab_path=fstab_path),
+                'ntfs-3g',
+            )
+
+    def test_update_managed_fstab_can_write_ntfs3_driver(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            data_dir = Path(tempdir)
+            runtime = SimpleNamespace(
+                is_fake=True,
+                data_dir=data_dir,
+                config_dir=data_dir / 'config',
+            )
+
+            backup_drive_setup.update_managed_fstab(
+                'UUID-1',
+                '/media/backup',
+                True,
+                runtime=runtime,
+                ntfs_driver='ntfs3',
+            )
+
+            content = (data_dir / 'fstab').read_text()
+            self.assertIn('/media/backup\tntfs3\tdefaults,nofail', content)
+            self.assertEqual(
+                backup_drive_setup.get_managed_ntfs_driver(runtime=runtime),
+                'ntfs3',
+            )
+            self.assertTrue(
+                backup_drive_setup.has_managed_fstab_entry_for_mount_point(
+                    '/media/backup', runtime=runtime
+                )
+            )
+
+    def test_update_managed_fstab_rejects_unknown_ntfs_driver(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            data_dir = Path(tempdir)
+            runtime = SimpleNamespace(
+                is_fake=True,
+                data_dir=data_dir,
+                config_dir=data_dir / 'config',
+            )
+
+            with self.assertRaisesRegex(
+                backup_drive_setup.BackupDriveSetupError,
+                'Unsupported NTFS driver',
+            ):
+                backup_drive_setup.update_managed_fstab(
+                    'UUID-1',
+                    '/media/backup',
+                    True,
+                    runtime=runtime,
+                    ntfs_driver='ntfs4',
+                )
+
     @patch('simple_safer_server.services.backup_drive_setup._get_mounted_partitions_for_disk')
     def test_unmount_disk_partitions_unmounts_all_members(self, mock_get_mounted):
         runtime = SimpleNamespace(is_fake=False)
@@ -451,7 +510,60 @@ class BackupDriveSetupTests(unittest.TestCase):
         mock_reload_mount_units.assert_called_once_with(
             runtime=runtime, command_adapter=command_adapter
         )
-        self.assertEqual(command_adapter.mounted_ntfs, [('/dev/sdb1', '/media/backup')])
+        self.assertEqual(command_adapter.mounted_ntfs, [('/dev/sdb1', '/media/backup', 'ntfs-3g')])
+
+    @patch('simple_safer_server.services.backup_drive_setup.os.makedirs')
+    @patch('simple_safer_server.services.backup_drive_setup._reload_systemd_mount_units')
+    @patch('simple_safer_server.services.backup_drive_setup.update_managed_fstab')
+    @patch('simple_safer_server.services.backup_drive_setup._get_partition_filesystem_type')
+    @patch('simple_safer_server.services.backup_drive_setup.get_drive_usb_id')
+    @patch('simple_safer_server.services.backup_drive_setup.get_drive_uuid')
+    @patch('simple_safer_server.services.backup_drive_setup._get_mount_for_partition')
+    def test_apply_backup_drive_configuration_uses_selected_ntfs_driver(
+        self,
+        mock_get_mount,
+        mock_get_uuid,
+        mock_get_usb_id,
+        mock_get_fstype,
+        mock_update_fstab,
+        mock_reload_mount_units,
+        mock_makedirs,
+    ):
+        del mock_makedirs
+        del mock_reload_mount_units
+        runtime = SimpleNamespace(is_fake=False, default_mount_point='/media/backup')
+        command_adapter = FakeBackupDriveCommandAdapter()
+        config_manager = MagicMock()
+        config_manager.get_value.side_effect = ['/media/backup', '', '']
+        smb_manager = MagicMock()
+        smb_manager.get_managed_share.return_value = None
+
+        mock_get_mount.return_value = None
+        mock_get_uuid.return_value = 'UUID-1'
+        mock_get_usb_id.return_value = '1234:5678'
+        mock_get_fstype.return_value = 'ntfs'
+        mock_update_fstab.return_value = None
+
+        result = backup_drive_setup.apply_backup_drive_configuration(
+            '/dev/sdb1',
+            '/media/backup',
+            True,
+            config_manager,
+            smb_manager,
+            runtime=runtime,
+            command_adapter=command_adapter,
+            ntfs_driver='ntfs3',
+        )
+
+        self.assertEqual(result['ntfs_driver'], 'ntfs3')
+        mock_update_fstab.assert_called_once_with(
+            'UUID-1',
+            '/media/backup',
+            True,
+            runtime=runtime,
+            ntfs_driver='ntfs3',
+        )
+        self.assertEqual(command_adapter.mounted_ntfs, [('/dev/sdb1', '/media/backup', 'ntfs3')])
 
     @patch('simple_safer_server.services.backup_drive_setup.restore_fstab_backup')
     @patch('simple_safer_server.services.backup_drive_setup.os.makedirs')

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -402,7 +402,10 @@ class BackupDriveSetupTests(unittest.TestCase):
             )
 
             content = (data_dir / 'fstab').read_text()
-            self.assertIn('/media/backup\tntfs3\tdefaults,nofail', content)
+            self.assertIn(
+                '/media/backup\tntfs3\trw,uid=0,gid=0,dmask=000,fmask=000,nofail',
+                content,
+            )
             self.assertEqual(
                 backup_drive_setup.get_managed_ntfs_driver(runtime=runtime),
                 'ntfs3',

--- a/tests/test_backup_drive_setup.py
+++ b/tests/test_backup_drive_setup.py
@@ -420,12 +420,12 @@ class BackupDriveSetupTests(unittest.TestCase):
                     '/media/backup', runtime=runtime
                 )
             )
-            self.assertEqual(
-                backup_drive_setup.get_managed_fstab_entry_for_mount_point(
-                    '/media/backup', runtime=runtime
-                )['uuid'],
-                'UUID-1',
+            managed_entry = backup_drive_setup.get_managed_fstab_entry_for_mount_point(
+                '/media/backup', runtime=runtime
             )
+            if managed_entry is None:
+                self.fail('Expected a managed fstab entry for /media/backup.')
+            self.assertEqual(managed_entry['uuid'], 'UUID-1')
 
     def test_update_managed_fstab_rejects_unknown_ntfs_driver(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_runtime_command_adapters.py
+++ b/tests/test_runtime_command_adapters.py
@@ -26,6 +26,7 @@ class RuntimeCommandAdapterTests(unittest.TestCase):
         adapter.reboot()
         adapter.poweroff()
         adapter.mount("/dev/sdb1", "/media/backup")
+        adapter.mount_managed("/media/backup")
         adapter.start_unit("smbd")
 
         self.assertEqual(
@@ -34,6 +35,7 @@ class RuntimeCommandAdapterTests(unittest.TestCase):
                 ["systemctl", "reboot"],
                 ["systemctl", "poweroff"],
                 ["mount", "/dev/sdb1", "/media/backup"],
+                ["mount", "/media/backup"],
                 ["systemctl", "start", "smbd"],
             ],
         )

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -4,6 +4,7 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
+from unittest.mock import patch
 
 from simple_safer_server.services.storage_service import StorageService
 from simple_safer_server.web.problems import OperationProblem, ValidationProblem
@@ -40,6 +41,7 @@ class FakeStorageCommandAdapter:
         self.powered_off = False
         self.device = "/dev/sdb1"
         self.mounted = []
+        self.managed_mounted = []
         self.started = []
         self.raise_on_mount = None  # type: Optional[Exception]
 
@@ -56,6 +58,11 @@ class FakeStorageCommandAdapter:
         if self.raise_on_mount:
             raise self.raise_on_mount
         self.mounted.append((device, mount_point))
+
+    def mount_managed(self, mount_point):
+        if self.raise_on_mount:
+            raise self.raise_on_mount
+        self.managed_mounted.append(mount_point)
 
     def start_unit(self, unit_name):
         self.started.append(unit_name)
@@ -118,6 +125,21 @@ class StorageServiceTests(unittest.TestCase):
                 "nmbd",
             ],
         )
+
+    def test_real_mount_prefers_managed_fstab_entry(self):
+        with tempfile.TemporaryDirectory() as mount_point:
+            service, _fake_state, adapter = self.build_service(mount_point=mount_point)
+
+            with patch(
+                "simple_safer_server.services.storage_service.has_managed_fstab_entry_for_mount_point",
+                return_value=True,
+            ):
+                self.assertEqual(
+                    service.mount_dashboard_drive(), "Drive mounted and available for use."
+                )
+
+            self.assertEqual(adapter.managed_mounted, [mount_point])
+            self.assertEqual(adapter.mounted, [])
 
     def test_real_mount_reports_missing_uuid_without_system_commands(self):
         service, _fake_state, adapter = self.build_service(uuid=None)

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -131,14 +131,28 @@ class StorageServiceTests(unittest.TestCase):
             service, _fake_state, adapter = self.build_service(mount_point=mount_point)
 
             with patch(
-                "simple_safer_server.services.storage_service.has_managed_fstab_entry_for_mount_point",
-                return_value=True,
+                "simple_safer_server.services.storage_service.get_managed_fstab_entry_for_mount_point",
+                return_value={"uuid": "drive-uuid"},
             ):
                 self.assertEqual(
                     service.mount_dashboard_drive(), "Drive mounted and available for use."
                 )
 
             self.assertEqual(adapter.managed_mounted, [mount_point])
+            self.assertEqual(adapter.mounted, [])
+
+    def test_real_mount_rejects_stale_managed_fstab_uuid(self):
+        with tempfile.TemporaryDirectory() as mount_point:
+            service, _fake_state, adapter = self.build_service(mount_point=mount_point)
+
+            with patch(
+                "simple_safer_server.services.storage_service.get_managed_fstab_entry_for_mount_point",
+                return_value={"uuid": "stale-uuid"},
+            ):
+                with self.assertRaisesRegex(ValidationProblem, "fstab entry does not match"):
+                    service.mount_dashboard_drive()
+
+            self.assertEqual(adapter.managed_mounted, [])
             self.assertEqual(adapter.mounted, [])
 
     def test_real_mount_reports_missing_uuid_without_system_commands(self):

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -155,6 +155,17 @@ class StorageServiceTests(unittest.TestCase):
             self.assertEqual(adapter.managed_mounted, [])
             self.assertEqual(adapter.mounted, [])
 
+    def test_real_mount_rejects_ambiguous_uuid_matches(self):
+        with tempfile.TemporaryDirectory() as mount_point:
+            service, _fake_state, adapter = self.build_service(mount_point=mount_point)
+            adapter.device = "/dev/sdb1\n/dev/sdc1\n"
+
+            with self.assertRaisesRegex(ValidationProblem, "Multiple connected drives"):
+                service.mount_dashboard_drive()
+
+            self.assertEqual(adapter.mounted, [])
+            self.assertEqual(adapter.managed_mounted, [])
+
     def test_real_mount_reports_missing_uuid_without_system_commands(self):
         service, _fake_state, adapter = self.build_service(uuid=None)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NTFS filesystem driver selection (`ntfs-3g` vs `ntfs3`) in Drive Health re-run flow for backup drive configuration.
  * Backup drives now always registered for automatic boot-time remounting.

* **Documentation**
  * Updated setup and health documentation with NTFS driver options, managed mount-point verification, and fstab entry details.

* **Bug Fixes**
  * Added UUID consistency validation before remounting managed backup drives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->